### PR TITLE
[WHITELIST] images.twee-app.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -1624,6 +1624,7 @@
 @@||theplatform.com/current/pdk/js/plugins/doubleclick.js$domain=cbc.ca
 @@||thestreet-static.com/video/js/companionAdFunc.js$domain=thestreet.com
 @@||thetvdb.com/banners/
+@@||images.twee-app.com/banners/
 @@||thewatchseries.to^$generichide
 @@||theweathernetwork.com/js/adrefresh.js
 @@||theweathernetwork.com/tpl/web/adtech/$xmlhttprequest


### PR DESCRIPTION
We are having problems when proxying/serving images. Cause thetvdb isn't
allowing hotlinking , so we need to have the images on our side. So
cause the tvdb using /banners , we get caught. So I have whitelisted our
domain exactly like thetvdb.com domain.

Here is the logs also
![log](https://cloud.githubusercontent.com/assets/132698/16361570/2bd99642-3b95-11e6-9850-7cf31a49061e.PNG)

if you want to visit the site it's https://web.twee-app.com , so you can verify it's not ads. An example image under the banners are: https://images.twee-app.com/banners/posters/80224-1.jpg