### PR TITLE
Neon lab fix

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1516,6 +1516,7 @@
 ||tracker.mtrax.net^
 ||tracker.myseofriend.net^$third-party
 ||tracker.neon-images.com^
+||tracker.neon-lab.com^
 ||tracker.roitesting.com^
 ||tracker.seoboost.net^$third-party
 ||tracker.timesgroup.com^

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1128,7 +1128,6 @@
 ||nedstatbasic.net^$third-party
 ||nedstatpro.net^$third-party
 ||neki.org^$third-party
-||neon-lab.com^$third-party
 ||nestedmedia.com^$third-party
 ||net-filter.com^$third-party
 ||netaffiliation.com^$script,third-party


### PR DESCRIPTION
Make the filters for Neon Labs accurate.

We are an image optimization company. For some of our customers, we do A/B testing on imagery and collect telemetry on how well images are doing. It makes sense for our tracking domain to be on the privacy list so that people can opt out, however, the existing filter is too broad and catches our entire domain (including corp site www.neon-lab.com, our app app.neon-lab.com etc).

These changes make sure that our tracking endpoints can be blocked, but that the rest of our business is not.

Mark Desnoyer,
VP Engineering, Neon Labs Inc.