### PR TITLE
Add Google Analytics by MonsterInsights to whitelist

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -1,3 +1,5 @@
+@@/wp-content/mu-plugins/google-analytics-for-wordpress/*
+@@/wp-content/plugins/google-analytics-for-wordpress/*
 @@/cdn-cgi/pe/bag2?*geoiplookup$xmlhttprequest,domain=orain.org
 @@/cdn-cgi/pe/bag2?*google-analytics.com%2Fanalytics.js$domain=amypink.de|biznews.com|cryptospot.me|dailycaller.com|droid-life.com|forwardprogressives.com|fpif.org|fullpotentialma.com|geekzone.co.nz|goldsday.com|hoyentec.com|imageupload.co.uk|is-arquitectura.es|lazygamer.net|mmanews.com|nehandaradio.com|nmac.to|orain.org|tvunblock.com|unilad.co.uk|xrussianteens.com|youngcons.com
 @@/cdn-cgi/pe/bag2?*googleadservices.com$domain=droid-life.com


### PR DESCRIPTION
We've got a lot of uBlock users who when they try to view our plugin, the block of anything with `google-analytics` in the slug breaks the backend WordPress dashboard for the whole plugin