### PR TITLE
ISSUE-188: Update curalate.com domain wide EasyPrivacyList block.

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -504,6 +504,7 @@
 ||cts.channelintelligence.com^$third-party
 ||cts.vresp.com^
 ||cumulus-cloud.com/trackers/
+||curalate.com/*events*$third-party
 ||curate.nestedmedia.com^
 ||customerlobby.com/ctrack-
 ||cx.atdmt.com^

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -461,7 +461,6 @@
 ||csi-tracking.com^$third-party
 ||ctnsnet.com^$third-party
 ||cttracking02.com^$third-party
-||curalate.com^$third-party
 ||customer.io^$third-party
 ||customerconversio.com^$third-party
 ||customerdiscoverytrack.com^$third-party


### PR DESCRIPTION
Details in https://github.com/easylist/easylist/issues/188

Instead of blocking all traffic to curalate.com, it specifically blocks Curalate's tracking urls. An example can be seen on this page which uses Curalate as a third party: http://www.urbanoutfitters.com/urban/uo-community?cm_re=UOONYOU

![image](https://cloud.githubusercontent.com/assets/1526699/20183319/e3d50c96-a732-11e6-979b-50e026f46242.png)
