### PR TITLE
Replace https://siftscience.com with https://hexagon-analytics.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -806,6 +806,7 @@
 ||heatmap.it^$third-party
 ||hellosherpa.com^$third-party
 ||hentaicounter.com^$third-party
+||hexagon-analytics.com^$third-party
 ||heystaks.com^$third-party
 ||hiconversion.com^$third-party
 ||higherengine.com^$third-party
@@ -1536,7 +1537,6 @@
 ||shinystat.com^$third-party
 ||shippinginsights.com^$third-party
 ||showroomlogic.com^$third-party
-||siftscience.com^$third-party
 ||signup-way.com^$third-party
 ||silverpop.com^$third-party
 ||silverpush.co^$third-party


### PR DESCRIPTION
I work at Sift Science and we provide fraud prevention services for online businesses. Most of our clients use a JavaScript snippet that is hosted on our domain to more accurately predict fraud on their sites.

We have noticed that our domain [siftscience.com](https://siftscience.com) is on the blocked list, which breaks our website. Please unblock this domain, as we no longer send user information to this domain. We have changed the endpoint to be hosted on [hexagon-analytics.com](http://hexagon-analytics.com) so that we may get our main domain unblocked.