### PR TITLE
Additions to easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -950,6 +950,7 @@
 ||betpartners.it^$third-party
 ||betrad.com^$third-party
 ||bettingpartners.com^$third-party
+||bezoya.work^$third-party
 ||bf-ad.net^$third-party
 ||bfast.com^$third-party
 ||bh3.net^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3219,6 +3219,7 @@
 ||rogueaffiliatesystem.com^$third-party
 ||roicharger.com^$third-party
 ||roirocket.com^$third-party
+||rolinda.work^$third-party
 ||romance-net.com^$third-party
 ||rometroit.com^$third-party
 ||rotaban.ru^$third-party
@@ -4071,6 +4072,7 @@
 ||zercstas.com^$third-party
 ||zerezas.com^$third-party
 ||zeropark.com^$third-party
+||zerozo.work^$third-party
 ||zferral.com^$third-party
 ||zidae.com^$third-party
 ||ziffdavis.com^$third-party


### PR DESCRIPTION
Both zerozo.work and rolinda.work redirect to publited.com, which shows to be ad network business.

If you go to http://www.mejortorrent.com/ and click on any movie, for example see this one http://www.mejortorrent.com/peli-descargar-torrent-14552-Stereo.html , then click "Descargar" (spanish for "Download") and then finally click where it says "Pincha aquí para descargar el torrent." (spanish for "Click here to download torrent."). Popups will appear. I got one from URL rolinda.work. If you go to rolinda.work, it redirects to publited.com.

The other URL in the commit is zerozo.work, but I was not able to reproduce this one (this was originally reported in EasyList Spanish Forum a couple months ago, that's why it may have changed). But if you go to zerozo.work, it redirects to publited.com.