### PR TITLE
A: http://www.forospyware.com/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -4381,6 +4381,7 @@
 /images/ads.
 /images/ads/*
 /images/ads_
+/images/adsMB/*
 /images/adv-
 /images/adv.
 /images/adv/*


### PR DESCRIPTION
There's an ad in http://www.forospyware.com/, top-right of the page. If you Inspect Element in Firefox, you will see img src="https://max-infospyware.netdna-ssl.com/images/adsMB/Spanish_MB_468X60v2.jpg"

"adsMB" apparently refers to "ads **M**alware**b**ytes"