### PR TITLE
Addition to easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -15430,6 +15430,7 @@
 ##.rightAdContainer
 ##.rightAd_bottom_fmt
 ##.rightAd_top_fmt
+##.rightAds
 ##.rightAds_ie_fix
 ##.rightAdvert
 ##.rightAdverts


### PR DESCRIPTION
Found div class=rightAds in http://www.tandildiario.com/ that suits EasyList. Adding general rule to hide this class.