### PR TITLE
Add Google Analytics by MonsterInsights to whitelist

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -12,6 +12,8 @@
 @@/cdn-cgi/pe/bag2?*skimlinks.js$domain=droid-life.com
 @@/cdn-cgi/pe/bag2?*static.getclicky.com%2Fjs$domain=amazingpics.net
 @@/cdn-cgi/pe/bag2?*yieldbot.intent.js$domain=droid-life.com
+@@/wp-content/mu-plugins/google-analytics-for-wordpress/*
+@@/wp-content/plugins/google-analytics-for-wordpress/*
 @@/wp-content/plugins/google-analytics-dashboard-for-wp/*$~third-party
 @@||1dmp.io/pixel.gif$image,domain=overclockers.co.uk
 @@||247sports.com/site/minify.js?*/scripts/stats/$script
@@ -488,6 +490,8 @@
 @@||productads.hlserve.com^$script,domain=argos.co.uk
 @@||propelmedia.com/resources/images/load.gif
 @@||ps.w.org/google-analytics-dashboard-for-wp/assets/
+@@||ps.w.org/google-analytics-analytics-for-wordpress/assets/
+@@||i2.wp.com/plugins.svn.wordpress.org/!svn/bc/*/google-analytics-for-wordpress/assets/
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.StreamSense.js
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.Viewability.js
 @@||push2check.com/stats.php

--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -13,7 +13,9 @@
 @@/cdn-cgi/pe/bag2?*static.getclicky.com%2Fjs$domain=amazingpics.net
 @@/cdn-cgi/pe/bag2?*yieldbot.intent.js$domain=droid-life.com
 @@/wp-content/mu-plugins/google-analytics-for-wordpress/*
+@@/wp-content/mu-plugins/google-analytics-premium/*
 @@/wp-content/plugins/google-analytics-for-wordpress/*
+@@/wp-content/plugins/google-analytics-premium/*
 @@/wp-content/plugins/google-analytics-dashboard-for-wp/*$~third-party
 @@||1dmp.io/pixel.gif$image,domain=overclockers.co.uk
 @@||247sports.com/site/minify.js?*/scripts/stats/$script


### PR DESCRIPTION
Google Analytics For MonsterInsights is the most popular Google Analytics integration for WordPress, allowing website owners to view their Google Analytics statistics without having to log into Google Analytics (backend dashboard)

Right now, EasyList's EasyPrivacy is blocking the CSS, JS, and images we load to make our WordPress backend panel when uBlock Origin (which uses this whitelist) is used by our users. It's basically the same issue as the Google Analytics Dashboard for WP plugin had which was whitelisted into EasyList EasyPrivacy.

Without uBlock:
http://screencloud.net/v/90o8

With uBlock Origin (which includes EasyList EasyPrivacy on by default):
http://screencloud.net/v/oe30 (it blocks all JS/CSS/Images)

Disabling the EasyPrivacy filterset in uBlock solves the issue.

It also breaks images in unrelated sites, for example, sites like WordPress.org where it blocks our logo, banner, and screenshots: https://wordpress.org/plugins-wp/google-analytics-for-wordpress/
as well as on any site that takes screenshots of our plugin and names the images using our slug, such as on plugin review websites.

This commit adds whitelist for our plugin's asset files based on the way the whitelist rules the other WP plugins are whitelisted in the filterset.