### PR TITLE
Additions to easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -719,6 +719,7 @@
 ||affplanet.com^$third-party
 ||afftrack.com^$third-party
 ||aflrm.com^$third-party
+||afovelsa.com^$third-party
 ||africawin.com^$third-party
 ||afterdownload.com^$third-party
 ||afterdownloads.com^$third-party
@@ -926,6 +927,7 @@
 ||befade.com^$third-party
 ||beforescence.com^$third-party
 ||begun.ru^$third-party
+||bekoted.work^$third-party
 ||belointeractive.com^$third-party
 ||belvertising.be^$third-party
 ||benchmarkingstuff.com^$third-party
@@ -946,6 +948,7 @@
 ||bet3000partners.com^$third-party
 ||bet365affiliates.com^$third-party
 ||betaffs.com^$third-party
+||betigo.work^$third-party
 ||betoga.com^$third-party
 ||betpartners.it^$third-party
 ||betrad.com^$third-party
@@ -1021,6 +1024,7 @@
 ||bororas.com^$third-party
 ||bostonparadise.com^$third-party
 ||bostonwall.com^$third-party
+||boteko.work^$third-party
 ||bounce.bar^$third-party
 ||boydadvertising.co.uk^$third-party
 ||boylesportsreklame.com^$third-party
@@ -1745,6 +1749,7 @@
 ||feed-ads.com^$third-party
 ||feljack.com^$third-party
 ||fenixm.com^$third-party
+||feybu.work^$third-party
 ||fiberpairjo.link^$third-party
 ||ficusoid.xyz^$third-party
 ||fidel.to^$third-party
@@ -1785,6 +1790,7 @@
 ||fluidads.co^$third-party
 ||flurryconakrychamfer.info^$third-party
 ||fluxads.com^$third-party
+||fluxybe.work^$third-party
 ||flyertown.ca^$third-party
 ||flymyads.com^$third-party
 ||flytomars.online^$third-party
@@ -2288,9 +2294,11 @@
 ||knorex.asia^$third-party
 ||knowd.com^$third-party
 ||kolition.com^$third-party
+||komego.work^$third-party
 ||komoona.com^$third-party
 ||kontextua.com^$third-party
 ||koocash.com^$third-party
+||korexo.com^$third-party
 ||korrelate.net^$third-party
 ||kovla.com^$third-party
 ||kqzyfj.com/image-$third-party
@@ -2310,6 +2318,7 @@
 ||larentisol.com^$third-party
 ||large-format.net^$third-party
 ||largestable.com^$third-party
+||larkbe.com^$third-party
 ||laserhairremovalstore.com^$third-party
 ||launchbit.com^$third-party
 ||layer-ad.org^$third-party
@@ -2847,8 +2856,10 @@
 ||oxsng.com^$third-party
 ||oxtracking.com^$third-party
 ||oxybe.com^$third-party
+||oxyes.work^$third-party
 ||ozertesa.com^$third-party
 ||ozonemedia.com^$third-party
+||ozora.work^$third-party
 ||p-advg.com^$third-party
 ||p-comme-performance.com^$third-party
 ||p-digital-server.com^$third-party
@@ -2885,6 +2896,7 @@
 ||pay-click.ru^$third-party
 ||paydotcom.com^$third-party
 ||payperpost.com^$third-party
+||pbyet.com^$third-party
 ||pc-ads.com^$third-party
 ||pdn-2.com^$third-party
 ||pe2k2dty.com^$third-party
@@ -2920,6 +2932,7 @@
 ||pianobuyerdeals.com^$third-party
 ||picadmedia.com^$third-party
 ||picbucks.com^$third-party
+||pickoga.work^$third-party
 ||picsti.com^$third-party
 ||pictela.net^$third-party
 ||piercial.com^$third-party
@@ -3069,6 +3082,9 @@
 ||publir.com^$third-party
 ||publisher.to^$third-party
 ||publisheradnetwork.com^$third-party
+||publited.com^$third-party
+||publited.net^$third-party
+||publited.org^$third-party
 ||pubmatic.com^$third-party
 ||pubmine.com^$third-party
 ||pubnation.com^$third-party
@@ -3295,6 +3311,7 @@
 ||sedoparking.com^$third-party
 ||seductionprofits.com^$third-party
 ||seekads.net^$third-party
+||seiya.work^$third-party
 ||sekindo.com^$third-party
 ||selectablemedia.com^$third-party
 ||sellhealth.com^$third-party
@@ -3802,6 +3819,7 @@
 ||valueclickmedia.com^$third-party
 ||valuecommerce.com^$third-party
 ||valuecontent.net^$third-party
+||vamartin.work^$third-party
 ||vapedia.com^$third-party
 ||vashoot.com^$third-party
 ||vastopped.com^$third-party
@@ -4021,6 +4039,7 @@
 ||yes-messenger.com^$third-party
 ||yesadsrv.com^$third-party
 ||yesnexus.com^$third-party
+||yesobe.work^$third-party
 ||yieldads.com^$third-party
 ||yieldadvert.com^$third-party
 ||yieldbuild.com^$third-party
@@ -4070,6 +4089,7 @@
 ||zaparena.com^$third-party
 ||zappy.co.za^$third-party
 ||zapunited.com^$third-party
+||zavu.work^$third-party
 ||zde-engage.com^$third-party
 ||zeads.com^$third-party
 ||zedo.com^$third-party


### PR DESCRIPTION
This should be continuation of #252. In the past few days, I have been encountering several ads coming from several domains ending in .work, which was suspicious to me. Today, I looked at URL www.mejortorrent.com and I found another one (fluxybe.work). I decided I would do a whois on that one, and so I found Registrant Name, then I looked at a reverse whois for that Registrant Name (see this link: http://www.viewdns.info/reversewhois/?q=AFOVEL+SA). I then checked all domains in the list, and found several domains (most of them ending in .work) that are not included into easylist_adservers.txt. All of them redirect to publited.com. Using mejortorrent.com as a example, they have used zerozo.work in the past to launch ads (https://forums.lanik.us/viewtopic.php?f=103&t=27560), then rolinda.work (see #252), and now today they are using fluxybe.work. Looks like a pool of domains, and they rotate between them. Other websites probably do the same. I believe all of these should be included into EasyList. Thanks.