### PR TITLE
Addition to easylist_whitelist.txt

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -3148,6 +3148,7 @@
 @@||veedi.com/player/js/ads/advert.js
 @@||veedi.com^*/ADS.js
 @@||veekyforums.com^$generichide
+@@||veja.abril.com.br^$generichide
 @@||velocity.com^$generichide
 @@||vencko.net^$generichide
 @@||veohb.net/js/advertisement.js$domain=veohb.net


### PR DESCRIPTION
Anti adb filter for veja.abril.com.br. This one came from an Issue Report to EasyList Spanish, but the website is in portuguese, and not in spanish. Therefore this filter belongs to EasyList and not EasyList Spanish.