### PR TITLE
Deletion of filter in easylist_whitelist.txt

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -2600,7 +2600,6 @@
 @@||lag10.net^$generichide
 @@||lapurno.info/ads.php
 @@||lasexta.com/adsxml/$object-subrequest
-@@||lasprovincias.es^*/adframe.js
 @@||last.fm^$generichide
 @@||latinomegahd.net^$generichide
 @@||layer13.net^$generichide,script


### PR DESCRIPTION
This is to delete anti adb filter from whitelist, for a spanish newspaper website. The anti adb filter already exists in EasyList Spanish. See https://github.com/easylist/easylistspanish/commit/b3e08018ffd43d88c962b8e0fd32cff1ed9ae0c9