### PR TITLE
No third-party cookie on a.mobify.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -46,7 +46,6 @@
 ||99widgets.com/counters/
 ||9fine.ru/js/counter.
 ||9msn.com.au^*/tracking/
-||a.mobify.com^$third-party
 ||a.unanimis.co.uk^
 ||a2a.lockerz.com^
 ||aaa.aj5.info^

--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -396,6 +396,7 @@
 @@||mlb.com/scripts/stats/app/$script
 @@||mlb.com/shared/scripts/bam.tracking.js
 @@||mmi.bemobile.ua/lib/lib.js$domain=uatoday.tv
+@@||a.mobify.com^$~third-party
 @@||monetate.net/img/$script,domain=newegg.com
 @@||monetate.net/js/$domain=nike.com
 @@||monetate.net/trk/$script,domain=newegg.com


### PR DESCRIPTION
Hi there,

(following on a thread of email with @monzta )

The promises of Mobify is to use our javascript to overlay the Mobile website.  It is party of the functionality of the website (which we require first party cookie) - but we do not use 3rd party cookie to track users.

Blocking the script breaks the customer experience on Mobile devices.  Would like to remove ourselves from the list and to be whitelisted. 

Example site: extrastores.com

List of cookies
![image](https://cloud.githubusercontent.com/assets/1215939/23186731/f6bde534-f83c-11e6-9209-8478b3ffe3e5.png)

Many thanks!

Our legal privacy policy: http://downloads.mobify.com/legal/mobify-privacy.pdf
