### PR TITLE
Additions to easylist_specific_hide.txt

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -286,11 +286,14 @@ btvguide.com,cuteoverload.com,edmunds.com,investorschronicle.co.uk,megafilmeshd.
 btvguide.com,internetradiouk.com,jamaicaradio.net,onlineradios.in,pimpandhost.com,radio.net.bd,radio.net.pk,radio.or.ke,radio.org.ng,radio.org.nz,radio.org.ph,radioonline.co.id,radioonline.my,radioonline.vn,radiosa.org,radioth.net,splitsider.com,theawl.com,thehairpin.com,trinidadradiostations.net,way2sms.com,weekendpost.co.zw,zerocast.tv###ad3
 splitsider.com,theawl.com,thehairpin.com###ad4
 about.com,allexperts.com###adB
+###adBannerHeader
 joblo.com###adBillboard
 fxnetworks.com,isearch.avg.com###adBlock
 experts-exchange.com###adComponent
 gamemazing.com###adContainer
 about.com,paidcontent.org###adL
+###adRectangleFooter
+###adRectangleHeader
 all-nettools.com,apnadesi-tv.net,britsabroad.com,candlepowerforums.com,droidforums.net,filesharingtalk.com,forum.opencarry.org,gsmindore.com,hongfire.com,justskins.com,kiwibiker.co.nz,lifeinvictoria.com,lotoftalks.com,m-hddl.com,moneymakerdiscussion.com,mpgh.net,nextgenupdate.com,partyvibe.com,perthpoms.com,pomsinadelaide.com,pomsinoz.com,printroot.com,thriveforums.org,watchdesitv.com,watchuseek.com,webmastertalkforums.com,win8heads.com###ad_global_below_navbar
 im9.eu###adb
 tweakguides.com###adbar > br + p[style="text-align: center"] + p[style="text-align: center"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -860,6 +860,7 @@ gizmochina.com###boxed_widget-4
 gizmochina.com###boxed_widget-7
 gizmochina.com###boxed_widget-8
 collive.com,ecnmag.com###boxes
+###boxes-box-ad_mpu
 thevideo.me###boxly-container
 filesoup.com###boxopus-btn
 activistpost.com###boxzilla-overlay
@@ -4604,6 +4605,8 @@ nowsci.com##.black_overlay
 kioskea.net##.bloc_09
 overwatchhentai.net##.block
 jobmail.co.za##.block-AdsByJobMail
+##.block-ad-masthead
+##.block-ad-mpu
 ap.org##.block-ap-google-adwords
 taxsutra.com##.block-banner
 mensfitness.com##.block-boxes + div > div[style]


### PR DESCRIPTION
These are generic hiding filters, and because they are in english, I believe they should be in EasyList. 

bandaancha.eu - User reported by e-mail to easylist.spanish@gmail.com. There's another one for this site, which I already covered in EasyList Spanish: bandaancha.eu###spBx  -- see https://github.com/easylist/easylistspanish/commit/02cb856be23b3aa45294ca6feb60e4761c6e7e35

boing.es - Found while looking at a list I got from Alexa top 500, for spanish speaking countries.