### PR TITLE
Additions to easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -4041,6 +4041,7 @@
 ###boxes-box-ad300x250set2block
 ###boxes-box-ad_300x250_1
 ###boxes-box-ad_728x90_1
+###boxes-box-ad_mpu
 ###boxtube-ad
 ###bpAd
 ###bps-header-ad-container
@@ -12294,7 +12295,9 @@
 ##.block-ad
 ##.block-ad-header
 ##.block-ad-leaderboard
+##.block-ad-masthead
 ##.block-ad-middle
+##.block-ad-mpu
 ##.block-ad-wrapper
 ##.block-ad300
 ##.block-ad_injector

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -1262,6 +1262,7 @@
 ###adBanner9
 ###adBannerBottom
 ###adBannerBreaking
+###adBannerHeader
 ###adBannerSpacer
 ###adBannerTable
 ###adBannerTop
@@ -1431,6 +1432,8 @@
 ###adPosition9
 ###adPush
 ###adRContain
+###adRectangleFooter
+###adRectangleHeader
 ###adRight
 ###adRight1
 ###adRight2


### PR DESCRIPTION
I got it right this time (see #295).

These are generic hiding filters, and because they are in English, I believe they should be in EasyList.

bandaancha.eu - User reported by e-mail to easylist.spanish@gmail.com. There's another one for this site, which I already covered in EasyList Spanish: bandaancha.eu###spBx -- see easylist/easylistspanish@02cb856

boing.es - Found while looking at a list I got from Alexa top 500, for Spanish speaking countries.