### PR TITLE
Addition to easylist_adservers_popup.txt

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -470,6 +470,7 @@
 ||swadvertising.org^$popup,third-party
 ||symkashop.ru^$popup,third-party
 ||syncedvision.com^$popup,third-party
+||tagsd.com^$popup,third-party
 ||targetctracker.com^$popup,third-party
 ||tatami-solutions.com^$popup,third-party
 ||td563.com^$popup,third-party


### PR DESCRIPTION
I was able to see a popup from tagsd.com while looking at newpct.com, this happened a few days ago. Unfortunately, they appear to have changed the website source code, and I can not reproduce it any longer. But if you go to tags.com, you will see nothing; and also doing a [whois](https://whois.domaintools.com/tagsd.com) on the domain shows that it is owned by YESUP MEDIA INC. (advertising agency - website http://www.yesup.com/).