### PR TITLE
Block popup on Openload's alternative domain

### DIFF
--- a/easylist/easylist_specific_block_popup.txt
+++ b/easylist/easylist_specific_block_popup.txt
@@ -88,6 +88,7 @@
 ||oddschecker.com/clickout.htm?type=takeover-$popup
 ||oogh8ot0el.com/*.html$popup
 ||openload.co^*/_$popup
+||oload.tv^*/_$popup
 ||pamaradio.com^$popup,domain=secureupload.eu
 ||park.above.com^$popup
 ||pasted.co/*.php$popup


### PR DESCRIPTION
This has better effect however: `about:blank$popup,domain=oload.tv`