### PR TITLE
Addition to easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -9380,6 +9380,7 @@
 ##.adLabels
 ##.adLargeRec
 ##.adLargeRect
+##.adLat
 ##.adLeader
 ##.adLeaderForum
 ##.adLeaderboard


### PR DESCRIPTION
##.adLat - Reported by user over e-mail to EasyList Spanish. I believe it refers to "ad lateral", which applies in English as well, and so I thought it should be added to EasyList.