### PR TITLE
Digital Spy forum false positive

### DIFF
--- a/easylist/easylist_whitelist_general_hide.txt
+++ b/easylist/easylist_whitelist_general_hide.txt
@@ -469,7 +469,7 @@ time.com#@#.google-sponsored
 gumtree.co.za#@#.googleAdSense
 nicovideo.jp#@#.googleAds
 davidsilverspares.co.uk#@#.greyAd
-waer.org#@#.has-ad
+forums.digitalspy.com,waer.org#@#.has-ad
 minecraftforge.net#@#.hasads
 adexchanger.com,assetbar.com,burningangel.com,donthatethegeek.com,drunkenstepfather.com,intomobile.com,poderpda.com,politicususa.com,seattlepi.com,sfgate.com,startingstrongman.com,thenationonlineng.net,thinkcomputers.org,wccftech.com,wholelifestylenutrition.com#@#.header-ad
 greenbayphoenix.com,photobucket.com#@#.headerAd


### PR DESCRIPTION
https://forums.digitalspy.com/discussion/2207363/recent-fixes-to-ds-forums-current-tasks/p2

Specifically, the first post on any page of any thread, excluding page 1, was hidden by the `##.has-ad` rule.