### PR TITLE
Additions to easylist_adservers.txt and easylist_adservers_popup.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3724,6 +3724,7 @@
 ||torads.xyz^$third-party
 ||torconpro.com^$third-party
 ||torerolumiere.net^$third-party
+||toro-tags.com^$third-party
 ||toroadvertising.com^$third-party
 ||toroadvertisingmedia.com^$third-party
 ||torrida.net^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3460,6 +3460,7 @@
 ||smart2.allocine.fr^$third-party
 ||smartad.ee^$third-party
 ||smartadserver.com^$third-party
+||smartadtags.com^$third-party
 ||smartdevicemedia.com^$third-party
 ||smarterdownloads.net^$third-party
 ||smartredirect.de^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -769,6 +769,7 @@
 ||alternads.info^$third-party
 ||alternativeadverts.com^$third-party
 ||altitude-arena.com^$third-party
+||altpubli.com^$third-party
 ||am-display.com^$third-party
 ||am10.ru^$third-party
 ||am11.ru^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2380,6 +2380,7 @@
 ||leadcola.com^$third-party
 ||leaderpub.fr^$third-party
 ||leadmediapartners.com^$third-party
+||leadzu.com^$third-party
 ||leaptrade.com^$third-party
 ||leetmedia.com^$third-party
 ||legisland.net^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -58,6 +58,7 @@
 ||32b4oilo.com^$third-party
 ||3393.com^$third-party
 ||33across.com^$third-party
+||35.184.98.90^$third-party
 ||350media.com^$third-party
 ||360ads.com^$third-party
 ||360adstrack.com^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -1077,6 +1077,11 @@
 ||brokeloy.com^$third-party
 ||browsersfeedback.com^$third-party
 ||brucelead.com^$third-party
+||bruceleadx.com^$third-party
+||bruceleadx1.com^$third-party
+||bruceleadx2.com^$third-party
+||bruceleadx3.com^$third-party
+||bruceleadx4.com^$third-party
 ||bstrtb.com^$third-party
 ||btnibbler.com^$third-party
 ||btrll.com^$third-party

--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -451,6 +451,7 @@
 ||slikslik.com^$popup,third-party
 ||slimspots.com^$popup,third-party
 ||slimtrade.com^$popup,third-party
+||smartadtags.com^$popup,third-party
 ||smartwebads.com^$popup,third-party
 ||sms-mmm.com^$popup,third-party
 ||smutty.com^$popup,third-party


### PR DESCRIPTION
URLs in commits.

**easylist_adservers.txt**
||toro-tags.com^$third-party -> It is already into EasyPrivacy, but not into EasyList.
||altpubli.com^$third-party -> Advertising Agency.
||leadzu.com^$third-party -> Advertising Agency. Note: disable ABP to see the ads. 
||35.184.98.90^$third-party -> Adserver.
||smartadtags.com^$third-party -> Advertising Agency
||bruceleadx1.com^$third-party -> Adserver.
||bruceleadx2.com^$third-party -> Adserver.
||bruceleadx3.com^$third-party -> Adserver.
||bruceleadx4.com^$third-party -> Adserver.
||bruceleadx.com^$third-party -> Adserver.

**easylist_adservers_popup.txt**
||smartadtags.com^$popup,third-party -> Popups launched from this one