### PR TITLE
change stackadapt.com to srv.stackadapt.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3550,7 +3550,7 @@
 ||sta-ads.com^$third-party
 ||stabilityappointdaily.xyz^$third-party
 ||stabletrappeddevote.info^$third-party
-||stackadapt.com^$third-party
+||srv.stackadapt.com^$third-party
 ||stackattacka.com^$third-party
 ||stalesplit.com^$third-party
 ||standartads.com^$third-party


### PR DESCRIPTION
srv.stackadapt.com is the proper ad serving URL, stackadapt.com and www.stackadapt.com is the website, which is currently being unservable by adblock