### PR TITLE
Additions to easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -1370,6 +1370,7 @@
 ||cpxadroit.com^$third-party
 ||cpxinteractive.com^$third-party
 ||crakmedia.com^$third-party
+||crazyhell.com^$third-party
 ||crazylead.com^$third-party
 ||crazyvideosempire.com^$third-party
 ||creative-serving.com^$third-party
@@ -2411,6 +2412,7 @@
 ||letysheeps.ru^$third-party
 ||lfstmedia.com^$third-party
 ||lgse.com^$third-party
+||licantrum.com^$third-party
 ||liftdna.com^$third-party
 ||ligadx.com^$third-party
 ||ligational.com^$third-party
@@ -3491,6 +3493,7 @@
 ||smilered.com^$third-party
 ||smileycentral.com^$third-party
 ||smilyes4u.com^$third-party
+||smintmouse.com^$third-party
 ||smowtion.com^$third-party
 ||smpgfx.com^$third-party
 ||smrt-view.com^$third-party


### PR DESCRIPTION
||crazyhell.com^$third-party
||licantrum.com^$third-party
||smintmouse.com^$third-party

All of them appear to be adservers, tried surfing those URLs, nothing displays. They are used to launch ads from, in website pajarracos.es (NSFW).