### PR TITLE
Additions to easylist_adservers.txt and easylist_adservers_popup.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2888,6 +2888,7 @@
 ||onrampadvertising.com^$third-party
 ||onscroll.com^$third-party
 ||onsitemarketplace.net^$third-party
+||onti.rocks^$third-party
 ||onvertise.com^$third-party
 ||onwsys.net^$third-party
 ||oodode.com^$third-party

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2282,6 +2282,7 @@
 ||jdproject.net^$third-party
 ||jeetyetmedia.com^$third-party
 ||jemmgroup.com^$third-party
+||jettags.rocks^$third-party
 ||jewishcontentnetwork.com^$third-party
 ||jf2mn2ms.club^$third-party
 ||jfduv7.com^$third-party
@@ -4200,6 +4201,7 @@
 ||zangocash.com^$third-party
 ||zanox-affiliate.de/ppv/$third-party
 ||zanox.com/ppv/$third-party
+||zanyx.club^$third-party
 ||zaparena.com^$third-party
 ||zappy.co.za^$third-party
 ||zapunited.com^$third-party

--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -354,6 +354,7 @@
 ||onlinecareerpackage.com^$popup,third-party
 ||onlinecashmethod.com^$popup,third-party
 ||onpato.ru^$popup,third-party
+||onti.rocks^$popup,third-party
 ||open-downloads.net^$popup,third-party
 ||openadserving.com^$popup,third-party
 ||oratosaeron.com^$popup,third-party

--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -285,6 +285,7 @@
 ||interner-magaziin.ru^$popup,third-party
 ||iwanttodeliver.com^$popup,third-party
 ||jdtracker.com^$popup,third-party
+||jettags.rocks^$popup,third-party
 ||juiceads.net^$popup,third-party
 ||jujzh9va.com^$popup,third-party
 ||junbi-tracker.com^$popup,third-party
@@ -560,6 +561,7 @@
 ||youradexchange.com^$popup,third-party
 ||yupiromo.ru^$popup,third-party
 ||z5x.net^$popup,third-party
+||zanyx.club^$popup,third-party
 ||zavu.work^$popup,third-party
 ||zedo.com^$popup,third-party
 ||zeroredirect1.com^$popup,third-party


### PR DESCRIPTION
Continuation of #289 - More domains that redirect to publited.com, and are used to load advertising from and launch popup windows from.

||jettags.rocks^$third-party
||zanyx.club^$third-party

||jettags.rocks^$popup,third-party
||zanyx.club^$popup,third-party

