### PR TITLE
Additions to easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -13602,6 +13602,8 @@
 ##.fns_td_wrap
 ##.fold-ads
 ##.follower-ad-bottom
+##.following-ad
+##.following-ad-container
 ##.foot-ad
 ##.foot-ads
 ##.foot-advertisement

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -4660,6 +4660,8 @@
 ###dfp-ad-wallpaper-wrapper
 ###dfp-article-mpu
 ###dfp-article-related-mpu
+###dfp-global_top
+###dfp-home_after-headline_leaderboard
 ###dfp-middle
 ###dfp-middle1
 ###dfp-wallpaper-wrapper

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -17012,6 +17012,7 @@
 ##.tileAdWrap
 ##.tileAds
 ##.tile_AdBanner
+##.tile_ad
 ##.tile_ad_container
 ##.tips_advertisement
 ##.title-ad

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -1096,6 +1096,7 @@
 ###ad-springboard-300x250
 ###ad-squares
 ###ad-standard-wrap
+###ad-stickers
 ###ad-story-bottom-in
 ###ad-story-bottom-out
 ###ad-story-right

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -9003,6 +9003,9 @@
 ##.ad-signup
 ##.ad-sitewide
 ##.ad-sky
+##.ad-sky-left
+##.ad-sky-right
+##.ad-sky-wrap
 ##.ad-skyscr
 ##.ad-skyscraper
 ##.ad-skyscraper-label

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -15017,6 +15017,7 @@
 ##.misc-ad
 ##.misc-ad-label
 ##.miscAd
+##.mks_ads_widget
 ##.ml-advert
 ##.ml-adverts-sidebar-1
 ##.ml-adverts-sidebar-2

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -9123,6 +9123,7 @@
 ##.ad-update
 ##.ad-upper_rec
 ##.ad-us
+##.ad-v
 ##.ad-v2
 ##.ad-vendor-text-link
 ##.ad-vert


### PR DESCRIPTION
Found several DIV classes and IDs that are worth adding to EasyList.

**sport.es**
##.following-ad-container
##.following-ad

**diarioregistrado.com**
###dfp-home_after-headline_leaderboard
###dfp-global_top

**diariodesevilla.es**
##.ad-v

**timeout.es**
##.tile_ad

**eldiario.es** (example URL where they are seen: http://vertele.eldiario.es/noticias/Scream-Queens-gritar-temporadas-FOX_0_1903009695.html)
##.ad-sky-wrap
##.ad-sky-right
##.ad-sky-left

**elguasap.com**
##.mks_ads_widget

**diariodesevilla.es**
###ad-stickers