### PR TITLE
Additions to easylist_general_block.txt - CDN-based filters section

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7091,6 +7091,8 @@ takeover_banner_
 /cdn-cgi/pe/bag2?r*.adroll.com
 /cdn-cgi/pe/bag2?r*.codeonclick.com
 /cdn-cgi/pe/bag2?r*.qualitypublishers.com
+/cdn-cgi/pe/bag2?r*.srcsmrtgs.com
+/cdn-cgi/pe/bag2?r*.tradeadexchange.com
 /cdn-cgi/pe/bag2?r*.worldoffersdaily.com
 /cdn-cgi/pe/bag2?r*.zergnet.com
 /cdn-cgi/pe/bag2?r*adblade.com


### PR DESCRIPTION
Popups in seriesflv.net website as per one issue report I was checking. Took me a bit to figure out. I noticed a filter already existing into EasyList: /cdn-cgi/pe/bag2?r*.codeonclick.com - So then I looked at Blockable Items screen, and found similar calls for XML requests. Hence these filters. Then when I tried to test this filter, the call was gone, no more. I believe this filter would only work if website is experiencing difficulties and it is under Cloudflare, where the call would then take place. Website is offline right now, but these filters are worth to add to EasyList, in my opinion, there are plenty of similar filters under the CDN-based filters sections, in easylist_general_block.txt.

**seriesflv.net**
/cdn-cgi/pe/bag2?r*.srcsmrtgs.com
/cdn-cgi/pe/bag2?r*.tradeadexchange.com