### PR TITLE
Addition to easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -899,6 +899,7 @@
 ||awstaticdn.net^$third-party
 ||awsurveys.com^$third-party
 ||axill.com^$third-party
+||axiomaticalley.com^$third-party
 ||ayboll.com^$third-party
 ||azads.com^$third-party
 ||azjmp.com^$third-party


### PR DESCRIPTION
**graffica.info**
||axiomaticalley.com^$third-party

Blocks Admiral anti adb script, but it really looks like an adserver to me, given that navigating to that URL displays nothing, and also given the weird/funny hostname, similar to others. I'd like to add this filter into EasyList if you agree. Thanks.