### PR TITLE
Remove amp-error-reporting.appspot.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -139,7 +139,6 @@
 ||amazonaws.com^*.kissmetrics.com/
 ||amazonaws.com^*/pageviews
 ||amazonaws.com^*/track.js$domain=hitfix.com
-||amp-error-reporting.appspot.com^
 ||amplifypixel.outbrain.com^
 ||ams.addflow.ru^
 ||an.yandex.ru^


### PR DESCRIPTION
`amp-error-reporting.appspot.com` does not track any private user information. It's an error reporting server we use to log errors generated by the AMP HTML runtime (these are javascript error messages and stack traces). At most the url, user agent, and referrer are recorded (the least amount of information we need), but these are **only** used to reproduce the error and never to track the user.

/cc @cramforce