### PR TITLE
M: allow tagtray.com gallery, block tracking requests

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1806,7 +1806,7 @@
 ||tagcommander.com^$third-party
 ||tagifydiageo.com^$third-party
 ||tagsrvcs.com^$third-party
-||tagtray.com^$third-party
+||tagtray.com/api^$third-party
 ||tamgrt.com^$third-party
 ||tapfiliate.com^$third-party
 ||taps.io^$third-party


### PR DESCRIPTION
[TagTray](https://www.tagtray.com/) provides a way for people to embed a javascript image gallery that shows images of their brand being used on social media.  Blocking 3rd party from the entire domain prevents the gallery from rendering.  If we permit the domain itself but block the /api calls, we get to still show the gallery but block any kind of tracking of viewing the gallery.

I've created a [simple sample gallery example](http://eastcodes.com/test.html) for testing