### PR TITLE
Update easylist_general_block.txt

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1417,7 +1417,7 @@
 /adbanner2.
 /adbanner_
 /adbanners/*
-/adbar.
+/adbar.$domain=~adbar.fi|~adbar.io
 /adbar/*
 /adbar2_
 /adbar_


### PR DESCRIPTION
We have quite stupidly named our company to Adbar and there's a rule blocking access to our websites:
```
/adbar.
```
We have added a www prefix to our main domain [http://www.adbar.fi](http://www.adbar.fi) and that seems to fix the issue, but we would like to get that prefix out of there. We're also building an international version of our site to [http://adbar.io](http://adbar.io) and that is blocked as well by the same rule, when not using the www prefix.

<img width="738" alt="screen shot 2017-07-03 at 16 46 36" src="https://user-images.githubusercontent.com/22136575/27799963-435a0528-600f-11e7-8bd8-305c012e922b.png">

We're a web and graphic design company and we don't serve any ads on our websites.

Could you please update this rule to make our domains better available, thanks!