### PR TITLE
Allow all rsrc.php for Facebook domains

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -799,7 +799,8 @@
 @@||facebook.com/ajax/feed/filter_action/dialog_direct_action_ads?$xmlhttprequest,domain=facebook.com
 @@||faceinhole.com/adsense.swf$object-subrequest
 @@||farecompare.com^*/farecomp/
-@@||fbcdn.net/rsrc.php/*-aD2.js$script
+@@||fbcdn.net/rsrc.php/
+@@||facebook.com/rsrc.php/
 @@||fbexternal-a.akamaihd.net/safe_image.php?$image,domain=facebook.com
 @@||feedroom.speedera.net/static.feedroom.com/affiliate/
 @@||feeds.videogamer.com^*/videoad.xml?$object-subrequest


### PR DESCRIPTION
rsrc.php is a system that Facebook uses to serve static resources such as Javascript, CSS and images to users. rsrc.php only serves resources that our engineers check into our codebase -- for example, the Facebook logo, the like icon, etc. It does not serve any user generated content such as photos or advertisements.

rsrc.php includes a random base64 component in the URL For example:

https://www.facebook.com/rsrc.php/v3ijkh4/ye/l/en_US/r7yXJx0J6oX.js

We have found that there are various rules in the easy list of the form:

"block any URL that ends with ads7.js"

Sometimes, we generate URLs where the base64 URL happens to meet this condition. The URLs that get blocked have nothing to do with ads and often break Facebook for a subset of users who happen to get these URLs. We believe this has caused frustration for users who use easylist.

Because the URLs used by this script are random and have no meaning, we believe the best solution is to whitelist them -- there is no safe way to tell if content under these URLs needs to be blocked.

I'm not an expert on the format of this file, but I believe this change will allow all requests that start with /rsrc.php on any subdomain of fbcdn.net or facebook.com.