### PR TITLE
A: http://westeros.org/ (for #463 - Sovrn Anti-Adblock scripts)

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2498,6 +2498,7 @@
 ||ligational.com^$third-party
 ||lightad.co.kr^$third-party
 ||lightningcast.net^$~object-subrequest,third-party
+||lijit.com^$third-party
 ||linicom.co.il^$third-party
 ||linicom.co.uk^$third-party
 ||linkbuddies.com^$third-party
@@ -3654,6 +3655,7 @@
 ||soosooka.com^$third-party
 ||sophiasearch.com^$third-party
 ||sotuktraffic.com^$third-party
+||sovrnlabs.net^$third-party
 ||sparkstudios.com^$third-party
 ||speakol.com^$third-party
 ||specificclick.net^$third-party

--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -7090,6 +7090,8 @@
 ###source-ad-native-sticky-wrapper
 ###source_ad
 ###source_content_ad
+###sovrn_beacon
+###sovrn_container
 ###spec_offer_ad2
 ###special-deals-ad
 ###specialAd_one


### PR DESCRIPTION
Added Sovrn Anti-Adblock scripts ad-server block and general element hiding rules, as I had reported in issue #463 
Sovrn Sovrn.com provides commercial script Anti-adblock and ad scripts used on various sites, which they host at sovrnlabs.net and lijit.com