### PR TITLE
Exclude adex.network from the blocklist

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1605,7 +1605,7 @@
 /adError/*
 /adevent.$domain=~adevent.com
 /adevents.$domain=~adevents.com.au
-/adex.$domain=~adex.alphalab.com|~adex.az|~adex.cloud|~adex.link|~adex.tech|~adextechnologies.com
+/adex.$domain=~adex.alphalab.com|~adex.az|~adex.cloud|~adex.link|~adex.tech|~adex.network|~adextechnologies.com
 /adEx_$domain=~adex.link
 /adexample?
 /adexclude/*


### PR DESCRIPTION
AdEx.network is a decentralized advertising network; FYI not serving any ads from adex.* domains (not even live at the moment)