### PR TITLE
Also whitelist adex.png, to avoid adex logo being blacklisted

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1605,7 +1605,7 @@
 /adError/*
 /adevent.$domain=~adevent.com
 /adevents.$domain=~adevents.com.au
-/adex.$domain=~adex.alphalab.com|~adex.az|~adex.cloud|~adex.link|~adex.network|~adex.tech|~adextechnologies.com
+/adex.$domain=~adex.alphalab.com|~adex.az|~adex.cloud|~adex.link|~adex.network|~adex.tech|~adex.png|~adextechnologies.com
 /adEx_$domain=~adex.link
 /adexample?
 /adexclude/*


### PR DESCRIPTION
I am from adex.network, the site that we whitelisted on easylist a few weeks ago

Now we have a different issue: our logo is getting blocked on this web page: https://coinmarketcap.com/assets/adex/

I think that adding such an exception makes sense and fixes the issue