### PR TITLE
Fix shinobi.jp to subdomain adm.shinobi.jp for ad server.

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3624,7 +3624,7 @@
 ||sharegods.com^$third-party
 ||shareresults.com^$third-party
 ||sharethrough.com^$third-party
-||shinobi.jp^$third-party
+||adm.shinobi.jp^$third-party
 ||shipthankrecognizing.info^$third-party
 ||shokala.com^$third-party
 ||shoogloonetwork.com^$third-party


### PR DESCRIPTION
shinobi.jp is not an ad server.
However, adm.shinobi.jp is an ad server.
Since several Internet services are operated using shinobi.jp domain, I really hope that you accept this request.

For more information, I hope that you can see this content, which my colleagues posted in the past in the past.
https://forums.lanik.us/viewtopic.php?f=64&t=37393&p=120492&hilit=shinobi.jp#p120492

I'm sorry, my English is not good.