### PR TITLE
remove zalando/api

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -2223,7 +2223,6 @@
 ||yuku.com/stats?
 ||yupptv.com/yupptvreports/stats.php^
 ||yyv.co/track/
-||zalando.*/api/
 ||zap.dw-world.de^$image
 ||zap2it.com^*/editorial-partner/
 ||zappos.com/onload.cgi?


### PR DESCRIPTION
zalando/api routes are used for client-side calls needed by the website for normal usage.
Tracking do not use api paths and blacklisting this path will make zalando unusable.