### PR TITLE
Remove : datadome.co

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -530,7 +530,6 @@
 ||data-analytics.jp^$third-party
 ||databrain.com^$third-party
 ||datacaciques.com^$third-party
-||datadome.co^$third-party
 ||datafeedfile.com^$third-party
 ||datam.com^$third-party
 ||datamind.ru^$third-party


### PR DESCRIPTION
As @Khrin  [said](https://forums.lanik.us/viewtopic.php?p=119756#p119756), we are not a tracking company. Our business is to protect websites from scraping bots. In order to do so, we have an Javascript tag that will get elements from the end-user browser not to have a global fingerprint of a device but to see if the elements returned by a device are coherent (and not an emulated browser like Selenium, Chrome Headless and so on). 