### PR TITLE
bbelements.com false whitelist

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -3594,7 +3594,6 @@
 @@||banki.ru/bitrix/*/advertising.block/$stylesheet
 @@||bbelements.com/bb/$script,domain=iprima.cz
 @@||bbelements.com/bb/bb_one2n.js$domain=moviezone.cz
-@@||bbelements.com/please/showit/*/?typkodu=$script,domain=idnes.cz|moviezone.cz
 @@||benchmarkhardware.com^$generichide
 @@||bhaskar.com/revenue/$script
 @@||biancolavoro.euspert.com/js/ad.js


### PR DESCRIPTION
This exception is no longer doing any good – only allows ads to be shown.