### PR TITLE
Whitelisting VMware Clarity libraries

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -1,3 +1,7 @@
+@@/clarity-angular.js$script,~third-party
+@@/clarity-angular.min.js$script,~third-party
+@@/clarity-icons.js$script,~third-party
+@@/clarity-icons.min.js$script,~third-party
 @@/cdn-cgi/pe/bag2?*geoiplookup$xmlhttprequest,domain=orain.org
 @@/cdn-cgi/pe/bag2?*google-analytics.com%2Fanalytics.js$domain=amypink.de|biznews.com|cryptospot.me|dailycaller.com|droid-life.com|forwardprogressives.com|fpif.org|fullpotentialma.com|geekzone.co.nz|goldsday.com|hoyentec.com|imageupload.co.uk|is-arquitectura.es|lazygamer.net|lingholic.com|mmanews.com|nehandaradio.com|nmac.to|orain.org|tvunblock.com|unilad.co.uk|xrussianteens.com|youngcons.com
 @@/cdn-cgi/pe/bag2?*googleadservices.com$domain=droid-life.com


### PR DESCRIPTION
I tried to be as explicit as possible and placed this next to the other whitelisted entry using the blocked “clarity-*” string.

Please see:

https://forums.lanik.us/viewtopic.php?f=64&t=35937&p=117983&hilit=clarity#p117983

…and…

https://github.com/vmware/clarity/issues/850

…for reference.

I avoided using RegExp because it appeared that the library in general avoided them (likely for performance reasons as listed in the AdBlock dox).

Signed-off-by: Scott Mathis <smathis@vmware.com>