### PR TITLE
Remove traffic.omny.fm first-party tracking

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1927,7 +1927,6 @@
 ||trade-it.co.uk/counter/
 ||tradetrucks.com.au/ga.
 ||traffic.buyservices.com^
-||traffic.omny.fm^
 ||traffic.tuberip.com^
 ||trainup.com/inc/TUPTracking.js
 ||traktr.news.com.au^


### PR DESCRIPTION
Disclosure: I am a developer from omny.fm

I propose removing traffic.omny.fm from the privacy list because it is a first-party tracking solution for the purpose of only tracking audio play/pause events.

The data is anonymized and is only presented as an aggregated statistic (e.g. 50% of listeners played at 2:11). No personal data is available.