### PR TITLE
Fix whitelisting for advert.io

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -447,7 +447,7 @@
 .adtech_
 .adtooltip&
 .adv.cdn.
-.advert.$domain=~advert.ly
+.advert.$domain=~advert.ly|~advert.io
 .AdvertismentBottom.
 .advertmarket.
 .adwolf.


### PR DESCRIPTION
in referral to this commit: https://github.com/easylist/easylist/commit/11e0d587b016d74b54122f8491f996d69e1c1a30

Fixed the whitelisting to include subdomains such as www. and app.