### PR TITLE
P: https://www.loganair.co.uk/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -6555,7 +6555,7 @@
 ?adpage=
 ?adPageCd=
 ?adpartner=
-?ads=
+?ads=$domain=~booking.loganair.co.uk
 ?adsdata=
 ?adsite=
 ?adsize=

--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -444,6 +444,7 @@
 @@||bodybuilding.com/ad-ops/prebid.js$script
 @@||bonappetit.com/ams/page-ads.js?
 @@||bonappetit.com^*/cn.dart.js
+@@||booking.loganair.co.uk^*/images/ads-
 @@||boracay.mobi/boracay/imageAds/$image,domain=boracay.tel
 @@||boreburn.com^$generichide
 @@||boston.com/images/ads/yourtown_social_widget/$image

--- a/easylist/easylist_whitelist_general_hide.txt
+++ b/easylist/easylist_whitelist_general_hide.txt
@@ -94,6 +94,7 @@ videozed.net#@##adsdiv
 carryconcealed.net,haberler.com,instiz.net,promoce.cz,ps3scenefiles.com,sondakika.com#@##adsense
 remixshare.com#@##adsense_block
 jeeppatriot.com#@##adsense_inline
+loganair.co.uk#@##adsIframe
 autoweek.com,cooperhewitt.org,core77.com,metblogs.com,oreilly.com,thisisthehive.net#@##adspace
 e24.se#@##adspace_top
 smh.com.au,theage.com.au#@##adspot-300x250-pos-1


### PR DESCRIPTION
The iframe in the "Book an ADS flight" tab was blocked and hidden, making it impossible to book an ADS flight.

The image https://booking.loganair.co.uk/VARS/Public/CustomerFiles/LoganAir/images/ads-sm.png was also blocked.

(ADS = Air Discount Scheme)