### PR TITLE
Remove Bugsnag rules

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -711,7 +711,6 @@
 /buffer.pgif?r=
 /buffermetrics/*
 /bugcounter.php?
-/bugsnag-
 /BuiltRegister.aspx?upt=
 /bundles/cm.js|
 /bundles/tracciamento?

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -326,7 +326,6 @@
 ||btttag.com^$third-party
 ||bubblestat.com^$third-party
 ||bugherd.com^$third-party
-||bugsnag.com^$third-party
 ||burstbeacon.com^$third-party
 ||burt.io^$third-party
 ||bux1le001.com^$third-party


### PR DESCRIPTION
Hi there, I have supplied a couple of changes that were causing issues for us. Please take a look when you get the chance 😃.

### `/bugsnag-` in  easyprivacy/easyprivacy_general.txt

This rule breaks commenting on issues and PRs on all of Bugsnag's open source repositories on GitHub (screenshot below). It causes confusion and frustration for us and our users, so this change removes the rule.

Additionally we have seen similar requests blocked on our support platform zendesk and our internal project tools such as JIRA/Confluence. I think ultimately this rule causes more harm than good because it is far too vague.

![screen shot 2017-11-21 at 11 59 21](https://user-images.githubusercontent.com/609579/33071564-f323fa64-ceb3-11e7-8204-470d623433a1.png)

### Bugsnag CDN links

As a result of a conversation in [this thread](https://forums.lanik.us/viewtopic.php?f=64&t=31754&p=99380&hilit=bugsnag#p99380), Sentry had their easyprivacy_trackingservers.txt rule [removed](48b28f3ad28bb38b0a17b39d44169774ea13e3c2). [bugsnag-js](https://github.com/bugsnag/bugsnag-js) is an equivalent open-source tool to Sentry's raven-js so it doesn't make sense to block one and not the other. Obviously, as an employee of Bugsnag and a steward of the JS notifiers I'm biased to say don't block Bugsnag or Sentry – but whatever the decision, please apply it consistently.

Cheers!