### PR TITLE
Fix google analytics dashboard (Privacy Filter)

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -771,3 +771,4 @@
 @@||heatmap.it^$domain=heatmap.me
 ! Google
 @@||google.*/analytics/js/$~third-party
+@@||ssl.gstatic.com/analytics/*/web/analytics.js


### PR DESCRIPTION
[Google Analytics Dashboard](https://analytics.google.com) doesn't load without disabling filters because of the static filter `/web/analytics.$script` found in EasyPrivacy as it prevents the script below resulting with white screen.

`/web/analytics.$script	--	script	https://ssl.gstatic.com/analytics/*/web/analytics.js` where asterisk is the latest version's timestamp (For instance: 20171205-00)