### PR TITLE
P: dopc.cz is needed

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -426,7 +426,6 @@
 ||xclaimwords.net^$third-party
 ! Czech
 ||analights.com^$third-party
-||dopc.cz^$third-party
 ||ibillboard.com^$third-party
 ||itop.cz^$third-party
 ||lookit.cz^$third-party


### PR DESCRIPTION
deleted ||dopc.cz^$third-party (broken novinky.cz, games.cz, aktualne.cz, zive.cz etc)
dopc proxing css and images for this websites.