### PR TITLE
M: exclude matomo.org from blocking /piwik/

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2191,11 +2191,11 @@
 /pingServerAction?
 /pippio.
 /pistats/cgi-bin/*
-/piwik-$domain=~github.com|~piwik.org
-/piwik.$script,domain=~piwik.org
+/piwik-$domain=~github.com|~piwik.org|~matomo.org
+/piwik.$script,domain=~piwik.org|~matomo.org
 /piwik.*/ping?
 /piwik.php
-/piwik/*$domain=~github.com|~piwik.org
+/piwik/*$domain=~github.com|~piwik.org|~matomo.org
 /piwik1.
 /piwik2.js
 /piwik_


### PR DESCRIPTION
Hi,

The open source Google Analytics alternative Piwik has been renamed to Matomo, which causes the exceptions to not work anymore.