### PR TITLE
analytics.maimail.co - piwik tracking installation

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -2391,3 +2391,4 @@
 ||wt-eu02.net^$domain=stern.de
 ||wt-safetag.com^$domain=stern.de
 ||xplosion.de^$domain=spiegel.de|stern.de
+||analytics.maimail.co/piwik.js


### PR DESCRIPTION
This pull request blocks the Piwik installation hosted at analytics.maimail.co used on maimail.co and their network of partner sites for personally identifiable tracking.