### PR TITLE
A: notebookcheck.com and localizations

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11267,6 +11267,7 @@ nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
 notebookcheck.com##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
+notebookcheck.org##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsoredUB
 oregonlive.com,mlive.com,cnet.com#?#.trc_related_container div[data-item-syndicated="true"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11266,6 +11266,7 @@ nationalpost.com#?#.nativeadcontent
 nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
 notebookcheck.com##div[style="display: inherit !important;"]
+notebookcheck.net##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsoredUB
 oregonlive.com,mlive.com,cnet.com#?#.trc_related_container div[data-item-syndicated="true"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11265,6 +11265,7 @@ nationalpost.com#?#.l-top-content
 nationalpost.com#?#.nativeadcontent
 nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
+notebookcheck-ru.com##div[style="display: inherit !important;"]
 notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
 notebookcheck.info##div[style="display: inherit !important;"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11274,6 +11274,7 @@ notebookcheck.it##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
 notebookcheck.nl##div[style="display: inherit !important;"]
 notebookcheck.org##div[style="display: inherit !important;"]
+notebookcheck.se##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsoredUB
 oregonlive.com,mlive.com,cnet.com#?#.trc_related_container div[data-item-syndicated="true"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11269,6 +11269,7 @@ notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
 notebookcheck.it##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
+notebookcheck.nl##div[style="display: inherit !important;"]
 notebookcheck.org##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsoredUB

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11267,6 +11267,7 @@ nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
 notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
+notebookcheck.it##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
 notebookcheck.org##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11265,6 +11265,7 @@ nationalpost.com#?#.l-top-content
 nationalpost.com#?#.nativeadcontent
 nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
+notebookcheck.com##div[style="display: inherit !important;"]
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsored
 oregonlive.com,mlive.com,cnet.com#?#.trc-content-sponsoredUB
 oregonlive.com,mlive.com,cnet.com#?#.trc_related_container div[data-item-syndicated="true"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11266,6 +11266,7 @@ nationalpost.com#?#.nativeadcontent
 nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
 notebookcheck-ru.com##div[style="display: inherit !important;"]
+notebookcheck-tr.com##div[style="display: inherit !important;"]
 notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
 notebookcheck.info##div[style="display: inherit !important;"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11267,6 +11267,7 @@ nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
 notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
+notebookcheck.info##div[style="display: inherit !important;"]
 notebookcheck.it##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
 notebookcheck.nl##div[style="display: inherit !important;"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -11265,6 +11265,7 @@ nationalpost.com#?#.l-top-content
 nationalpost.com#?#.nativeadcontent
 nationalpost.com#?#.sponsored
 nationalpost.com#?#.widget_postmedia_layouts_ad
+notebookcheck.biz##div[style="display: inherit !important;"]
 notebookcheck.com##div[style="display: inherit !important;"]
 notebookcheck.net##div[style="display: inherit !important;"]
 notebookcheck.org##div[style="display: inherit !important;"]


### PR DESCRIPTION
Fixes #917

I've added their localized sites here as they seem to use the exact same code, so it's going to be easier to maintain in one list. Their only domain where I couldn't reproduce these kinds of ads is `https://www.notebookcheck.pl/`