### PR TITLE
Simplified and corrected Zazzle entries

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -2023,8 +2023,10 @@
 @@||zap2it.com/ads/newsletter/$image,~third-party
 @@||zattoo.com/?advideo/*;vidAS=PRE_ROLL;$object-subrequest
 @@||zattoo.com/advertising/channelswitch/$subdocument
-@@||zcache.com*/advertising$image,domain=zazzle.com
-@@||zcache.com^*_advertisement_$image,domain=zazzle.com
+@@||zcache.ca^$image,domain=zazzle.ca
+@@||zcache.co.nz^$image,domain=zazzle.co.nz
+@@||zcache.co.uk^$image,domain=zazzle.co.uk
+@@||zcache.com^$image,domain=zazzle.com
 @@||zedo.com/crossdomain.xml$object-subrequest
 @@||zedo.com/jsc/c5/fhs.js$domain=rrstar.com
 @@||zedo.com/swf/$domain=startv.in


### PR DESCRIPTION
The entries that allowed Zazzle's CDN to serve images on Zazzle's websites were not broad enough.  Also, Zazzle has 4 English websites 4 different English-speaking countries.