### PR TITLE
exclude another exoclick subdomain

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -4201,7 +4201,7 @@
 /exo-force-render.js
 /exo120x60.
 /exobanner.
-/exoclick.$domain=~exoclick.com|~exoclick.kayako.com
+/exoclick.$domain=~exoclick.com|~exoclick.kayako.com|~exoclick.bamboohr.co.uk
 /exoclick/*$domain=~exoclick.com
 /exoclickright.
 /exoclickright1.


### PR DESCRIPTION
It doesn´t allow forms to be submitted on bamboohr.

Example: https://exoclick.bamboohr.co.uk/jobs/view.php?id=19