### PR TITLE
Block tracking for CollegeZoom.org

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -505,6 +505,7 @@
 ||current.com/tracking.htm?
 ||customerservicejobs.com/common/track/
 ||cyberlink.com/analytics/
+||d3ctdq1tizxw7c.cloudfront.net/v15/content/output/desktop.js
 ||da.virginmedia.com^
 ||dabs.com/AbacusTest/clientinfo_bk.gif
 ||dailyfinance.com/tmfstatic/vs.gif?


### PR DESCRIPTION
https://www.collegezoom.org/travelrewards.us
https://www.hostingfiber.com/wix.com
https://www.pageinsider.org/google.com
https://www.softwarecube.org/thin/angrybirds.com