### PR TITLE
Remove filter: `/newrelic.*`

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2080,7 +2080,6 @@
 /neustar.beacon.
 /new.cnt.aspx?
 /newlog.php?
-/newrelic.$domain=~newrelic.com
 /newscount/*
 /newSophus/*
 /newsstat/*


### PR DESCRIPTION
<!-- Just include the website URL in the Title line of this issue report -->

### List the website(s) you're having issues:

`http(s)://newrelic.*`

### What happens?

New Relic internal services (i.e. `newrelic.SERVICE_HERE.com`) don't work properly. All sort of different resources get blocked.

### List Subscriptions you're using:

EasyPrivacy

### Your settings

- OS/version: any
- Browser/version: any that supports extensions
- Adblock Extension/version: AdBlock, AdBlockPlus, Fanboy

### Other details:

It's understandable for this project to block beacon and tracking, but blocking an entire domain is extreme (and doesn't seem to be the norm for any other domain).

New Relic is a legitimate business and should be treated as such.

The rule I'm removing doesn't help any user, but just disrupts anybody using `newrelic.*` domains, i.e. New Relic employees.

In fact, the rule just means: `block any 'newrelic.*' EXCEPT on '*.newrelic.com'`.