### PR TITLE
Unhide link-sharing feature on some Podcast sites

### DIFF
--- a/fanboy-addon/fanboy_social_whitelist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_whitelist_general_hide.txt
@@ -245,7 +245,7 @@ greatbritishchefs.com#@#.share-header
 vimeo.com#@#.share-icon
 golem.de,tumblr.com#@#.share-item
 recite.com#@#.share-left
-askubuntu.com,baidu.com,broadcast.app.net,imgur.com,mammothhq.com,mathoverflow.net,openstreetmap.org,serverfault.com,stackapps.com,stackexchange.com,stackoverflow.com,superuser.com,yandex.com,yandex.com.tr,yandex.ru,yandex.ua#@#.share-link
+askubuntu.com,baidu.com,broadcast.app.net,imgur.com,kuechenstud.io,logbuch-netzpolitik.de,mammothhq.com,mathoverflow.net,minkorrekt.de,openstreetmap.org,serverfault.com,stackapps.com,stackexchange.com,stackoverflow.com,superuser.com,yandex.com,yandex.com.tr,yandex.ru,yandex.ua#@#.share-link
 pornhub.com#@#.share-link-container
 autokult.pl,channelnewsasia.com,fotoblogia.pl,imgur.com,komorkomania.pl#@#.share-links
 channelnewsasia.com,recite.com#@#.share-list


### PR DESCRIPTION
Example ("Share" button on audio player): https://logbuch-netzpolitik.de/lnp249-qualitaetspromo