### PR TITLE
update blocklist to whitelist smartads.io

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -6007,7 +6007,7 @@
 /smartad.
 /smartad/*
 /smartAd?
-/smartads.$domain=~smartads.cz
+/smartads.$domain=~smartads.cz|~smartads.io
 /smartadserver.$domain=~smartadserver.com|~smartadserver.com.br|~smartadserver.de|~smartadserver.es|~smartadserver.fr|~smartadserver.it|~smartadserver.pl|~smartadserver.ru
 /smartlinks.epl?
 /smb/ads/*


### PR DESCRIPTION
Analytics platform domain being blocked. This is used for analytics and in no way is used to serve ads. Sending a PR for whitelisting the domain. Not sure if this is the process. Thank you!