### PR TITLE
A: Add adpartner.cz to whitelist

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -127,6 +127,7 @@
 @@||adnigma.com/TemplateRun/js/DialogTag.js$domain=batmanstream.com|primewire.is
 @@||adotube.com/adapters/as3overstream*.swf?$domain=livestream.com
 @@||adotube.com/crossdomain.xml$object-subrequest
+@@||adpartner.cz^$document
 @@||adroll.com/j/roundtrip.js$domain=eurogamer.net|nintendolife.com|onehourtranslation.com|rockpapershotgun.com|usgamer.net|vg247.com
 @@||ads.adap.tv/applist|$object-subrequest,domain=wunderground.com
 @@||ads.adaptv.advertising.com^$xmlhttprequest,domain=easyrecipesite.com


### PR DESCRIPTION
Adpartner.cz is car parts distributor and not ad provider.