### PR TITLE
A: Other leady.cz tracking domains

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -342,6 +342,8 @@
 ||stat.ringier.cz^$third-party
 ||stats.mf.cz^
 ||t.leady.cz^
+||track.leady.cz^
+||t.leady.com^
 ! Danish
 ||blogtoppen.dk^*/bt_tracker.js
 ||counter.nope.dk^$third-party


### PR DESCRIPTION
Other tracking domains used by leady.cz - current one is insufficient :-/.