### PR TITLE
A: https://www.nationalgeographic.fr/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2315,6 +2315,7 @@
 ||yieldsoftware.com^$third-party
 ||yjtag.jp^$third-party
 ||ymetrica1.com^$third-party
+||youbora.com^$third-party
 ||youmetrix.co.uk^$third-party
 ||your-counter.be^$third-party
 ||youramigo.com^$third-party


### PR DESCRIPTION
```
https://www.nationalgeographic.fr/environnement/le-vortex-de-dechets-du-pacifique-nord-ferait-trois-fois-la-taille-de-la-france
```