### PR TITLE
remove gravityrd-services.com

### DIFF
--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -132,7 +132,6 @@
 ||google.com/uds/?file=orkut&
 ||goroost.com^$third-party
 ||gravity.com^$third-party
-||gravityrd-services.com^$third-party
 ||grazeit.com^$third-party
 ||groupon.com^*/affiliate_widget/$third-party
 ||grvmedia.com^$third-party


### PR DESCRIPTION
This domain is used for getting in-site recommendations and search results from Yusp by Gravity R&D on many sites around the web. I consider it an error to block the whole domain altogether, as it degrades the normal operation (e.g. predictive search) of certain sites.