### PR TITLE
(nsfw) Fixed motherless mobile page

### DIFF
--- a/easylist_adult/adult_specific_block.txt
+++ b/easylist_adult/adult_specific_block.txt
@@ -1164,6 +1164,7 @@ $image,script,subdocument,third-party,webrtc,websocket,domain=camwhorestv.org
 @@||motherless.com/scripts/sprintf.min.js
 @@||motherless.com/scripts/store.min.js
 @@||motherless.com/scripts/swfobject.js
+@@||motherless.com/scripts/mobile/index.js
 |http://$script,domain=motherless.com
 |http://$third-party,xmlhttprequest,domain=motherless.com
 |https://$script,domain=motherless.com


### PR DESCRIPTION
Er... uhm... somebody told me the following :innocent:

motherless.com has a new mobile page, all scripts but a few exceptions are blocked. The mobile page introduces a new script missing on the exception list. The mobile page is broken (for example no video playback) if this script is missing, seems like there is no advertising stuff in this file so I think it's safe to whitelist it.