### PR TITLE
Update easylist_specific_block.txt - rarbg

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -1069,7 +1069,8 @@
 ||dvdvideosoft.com^*/banners/
 ||dwarfgames.com/pub/728_top.
 ||dyncdn.celebuzz.com/assets/
-||dyncdn.me/static/20/js/expla*.js$domain=rarbg.is|rarbg.to|rarbg.unblocked.work|rarbgmirror.com|rarbgproxy.org
+||dyncdn.me/static/20/js/expla*.js$domain=rarbg.is|rarbg.to|rarbgmirror.com|rarbgproxy.org
+||totalstatic.com/static/20/js/expla*.js$domain=rarbg.is|rarbg.to|rarbgmirror.com|rarbgproxy.org
 ||e90post.com/forums/images/banners/
 ||eacash.streamplay.to^
 ||earthlink.net^*/promos/


### PR DESCRIPTION
- removed from line 1072 the domain 'rarbg.unblocked.work' as it no longer works
- added an extra filter (based on line 172, i.e. dyncdn.me) for 'totalstatic.com'
because for the domain rarbgproxy.org they've changed the URL for the `expla85.js` script from dyncdn.me to totalstatic.com, while for the other rarbg mirrors it's still dyncdn.me.

Screenshot from uBO's logger:
![2018-07-04_233203](https://user-images.githubusercontent.com/723651/42293386-862ff080-7fe2-11e8-8884-27ee85fa1e06.jpg)