### PR TITLE
Only block assets.speedcurve.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1871,7 +1871,7 @@
 ||spamanalyst.com^$third-party
 ||spectate.com^$third-party
 ||speed-trap.com^$third-party
-||assets.speedcurve.com^$third-party
+||speedcurve.com/js/lux.js^$third-party
 ||spklw.com^$third-party
 ||splittag.com^$third-party
 ||splurgi.com^$third-party

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1871,7 +1871,7 @@
 ||spamanalyst.com^$third-party
 ||spectate.com^$third-party
 ||speed-trap.com^$third-party
-||speedcurve.com^$third-party
+||assets.speedcurve.com^$third-party
 ||spklw.com^$third-party
 ||splittag.com^$third-party
 ||splurgi.com^$third-party


### PR DESCRIPTION
Disclaimer: I work for SpeedCurve. Currently there is a blanket block on speedcurve.com, which blocks our tracking JS. Unfortunately it also blocks legitimate assets like images in our emails. This commit would update the rule to only block assets.speedcurve.com, which still blocks our tracking JS (https://assets.speedcurve.com/js/lux.js?id=10001) without affecting other assets (https://alerts.speedcurve.com/n.php?hash=e60772c337c8f9ad8319fd4416359323698ffdfde0b0638fe2ad583f9302ad36&width=600).

Thanks!