### PR TITLE
dadi.technology is not a tracking server

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -570,7 +570,6 @@
 ||d41.co^$third-party
 ||dable.io^$third-party
 ||dacounter.com^$third-party
-||dadi.technology^$third-party
 ||dailycaller-alerts.com^$third-party
 ||dapxl.com^$third-party
 ||dashboard.io^$third-party


### PR DESCRIPTION
Its purpose is web services testing, CMSes and the like, nothing to do with ads, tracking or privacy problems.