### PR TITLE
block natero

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -644,9 +644,11 @@
 ||euroleague.tv^*/tracking.js
 ||ev.kck.st^
 ||event-reporting-dot-webylytics.appspot.com^
+||event.natero.com^
 ||eventlog.jackpot.de^
 ||eventlogger.soundcloud.com^
 ||events.jora.com^
+||events.natero.com^
 ||events.privy.com^
 ||events.reddit.com^
 ||events.redditmedia.com^


### PR DESCRIPTION
The analytics script comes from https://event.natero.com/scripts/natero_analytics.min.js and the events are posted to `events.natero.com`