### PR TITLE
M: getdrip.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -873,7 +873,6 @@
 ||getblueshift.com^$third-party
 ||getclicky.com^$third-party
 ||getconversion.net^$third-party
-||getdrip.com^$third-party
 ||getetafun.info^$third-party
 ||getfreebl.com^$third-party
 ||getsmartlook.com^$third-party

--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -115,7 +115,6 @@
 ||garss.tv^$third-party
 ||georiot.com^$third-party
 ||get8bit.com^$third-party
-||getdrip.com^$third-party
 ||getglue.com^$third-party
 ||getkudos.me^$third-party
 ||getmailcounter.com^$third-party


### PR DESCRIPTION
Drip is an ecommerce CRM and is often used for form submissions (eg. newsletter signup or contact form submissions), etc via the Drip JS API. Blocking this JS causes many forms to break.