### PR TITLE
A: https://www.suedostschweiz.ch/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -13,6 +13,7 @@
 ||adcrowd.com^$third-party
 ||addcontrol.net^$third-party
 ||admeira.ch^$third-party
+||adquality.ch^$third-party
 ||adrank24.de^$third-party
 ||adtraxx.de^$third-party
 ||adzoe.de^$third-party


### PR DESCRIPTION
```
https://www.suedostschweiz.ch/
https://www.tagblatt.ch/
https://www.luzernerzeitung.ch/
https://www.ticinonews.ch/
https://www.rontaler.ch/
```