### PR TITLE
The website www.adways.com is completely broken because all assets wi…

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3365,8 +3365,6 @@
 /advzones/*
 /adw.shtml
 /adw2.shtml
-/adways-
-/adways/*
 /adweb.$domain=~adweb.clarkson.edu|~adweb.com.au|~adweb.cz
 /adweb2.
 /adweb33.

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -693,7 +693,6 @@
 ||disqus.com/listPromoted?
 ||disy2s34euyqm.cloudfront.net^
 ||dizixdllzznrf.cloudfront.net^
-||dj5ag5n6bpdxo.cloudfront.net^
 ||djlf5xdlz7m8m.cloudfront.net^
 ||djr4k68f8n55o.cloudfront.net^
 ||dkd69bwkvrht1.cloudfront.net^


### PR DESCRIPTION
…th the rules /adways- /adways/* is being blocked by the list https://github.com/easylist/easylist/blob/master/easylist/easylist_general_block.txt

Our company website (http://www.adways.com) does not work anymore with your filters : /adways- and /adways/* and dj5ag5n6bpdxo.cloudfront.neton the easylist Adblock list.
We have also official online classes (https://www.fun-mooc.fr/) that require our libraries.
Sisley.com is broken too and is not an advertisement but a marketing interactive video (in collaboration with them) to present Sisley products with a tutorial on their ecommerce website. Why blocking Sisley products on Sisley website ?

The Adways name is never used to broadcast advertisment, the company use another name.