### PR TITLE
M: Tweak and Fix https://github.com/easylist/easylist/commit/ad1a003

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2402,7 +2402,8 @@
 .n.2.1.js^$third-party
 .n.2.1.l50.js^$third-party
 .n.2.1.l60.js^$third-party
-/^(http|https|ws|wss):\/\/([0-9a-z\.-_]+)\.(accountant|bid|cf|club|cricket|date|download|faith|fun|ga|gdn|gq|loan|men|ml|network|ovh|party|pro|pw|racing|review|rocks|science|site|space|stream|tk|top|trade|webcam|win|xyz|zone)\.\/(.*)/$script,third-party,websocket,xmlhttprequest,domain=~btorrent.xyz|~kiedywakacje.pl|~myinterview.com|~webtorrent.io
+/^(https?|wss?):\/\/([0-9a-z\-]+\.)?([0-9a-z\-]+\.)(accountant|bid|cf|club|cricket|date|download|faith|fun|ga|gdn|gq|loan|men|ml|network|ovh|party|pro|pw|racing|review|rocks|science|site|space|stream|tk|top|trade|webcam|win|xyz|zone)\.\/(.*)/$script,subdocument,websocket,xmlhttprequest
+/^(https?|wss?):\/\/([0-9a-z\-]+\.)?([0-9a-z\-]+\.)(accountant|bid|cf|club|cricket|date|download|faith|fun|ga|gdn|gq|loan|men|ml|network|ovh|party|pro|pw|racing|review|rocks|science|site|space|stream|tk|top|trade|webcam|win|xyz|zone)\/(.*)/$third-party,websocket,domain=~instant.io|~file.pizza|~kiedywakacje.pl|~myinterview.com|~webtorrent.io
 /cdn-cgi/pe/bag2?r[]=*eth-pocket.de
 ||0x1f4b0.com^$third-party
 ||1beb2a44.space^$third-party


### PR DESCRIPTION
The **1st filter** will prevent the abuse of the absolute domain name [**FQDN**](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) (_tld with a trailing dot_).

e.g. https://vgy.me/sVmCVJ.png
```
https://www.hostingcloud.science./URB0.js
https://www.freecontent.party./URB0.js
```

The **2nd filter** will
- merged the old existing `$websocket` [**TLD** filters](https://github.com/easylist/easylist/commit/ad1a0035ccb6696221d7151322db2fae7b678f6d#diff-dbc51871bdd5cf7971a65ef9684d2248L2402)  (e.g. `.accountant^$third-party,websocket`, ...) in to one regex filter.
- removed `btorrent.xyz` added [\_here\_](https://github.com/easylist/easylist/commit/e0a18ad) (not affected because of the `$third-party` option).
- fix `instant.io` and `file.pizza`
-- https://vgy.me/Dmkxzd.png
-- https://vgy.me/cIlUqT.png