### PR TITLE
Adding Akamai browser fingerprinting paths

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -297,6 +297,7 @@
 /__utm.js
 /__varnish_geoip
 /__wsm.gif
+/_bm/*.js
 /_dts.gif?
 /_lib/ga.js
 /_owa.gif?
@@ -445,6 +446,7 @@
 /ajaxtracker.
 /ajx/ptrack/*
 /akam/*/pixel_
+/akam/10/*
 /akamai/pixy.gif
 /akamai_analytics_
 /AkamaiAnalytics.


### PR DESCRIPTION
Akamai deploy obfuscated scripts from these paths. One path has common scripts that can be accessed on any Akamai-served domain with fingerprinting enabled. The other path serves coded scripts that change per session. The two groups of scripts are structurally different, but use similar attacks.

The scripts are highly invasive and attack a broad surface of the web-browser. They assemble a large fingerprint and send it back to Akamai. They are served from the same domain as the visited site, because the site is deployed through Akamai's CDN.

Attacks used by the scripts include canvas fingerprinting, ActiveX, performance profiling, and font enumeration, plus many more.

PS: It's strange that a privacy list is managed on a forum that uses Google ReCaptcha and requires a personally-identifiable email address. I think this is a bad policy. It prevents privacy-interested people contributing. I tried joining the forum to discuss this first and could not.