### PR TITLE
A: https://www.coronadirect.be/

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2239,6 +2239,7 @@
 /navbar-analytics.js
 /naveggQry-
 /NavMultiTracking.
+/NetworkTracking.
 /naytev.min.js
 /nbc-stats/*
 /ncj-pixel.js


### PR DESCRIPTION
```
https://www.coronadirect.be/
https://www.extradom.pl/
https://www.taptogo.net/
https://www.macapartments.com/
https://www.nikonimgsupport.com/
https://www.yelp-support.com/
```