### PR TITLE
Fix wornandwound.com

### DIFF
--- a/easylist/easylist_whitelist_general_hide.txt
+++ b/easylist/easylist_whitelist_general_hide.txt
@@ -709,3 +709,4 @@ localeyes.dk#@#.text_ad
 localeyes.dk,pixiz.com,televall.com.mx,turkanime.tv,videopremium.tv#@#.text_ads
 menstennisforums.com#@#.top_ads
 coingamez.com,mangaumaru.com,milfzr.com,pencurimovie.cc#@#div[id^="div-gpt-ad"]
+wornandwound.com#@#.ad-grid


### PR DESCRIPTION
The addition of .ad-grid as a general blocker (https://github.com/easylist/easylist/commit/0f1aae82c5493b0a9e97940711eb844599735101#diff-eff6174a52fcc75be714f55adb5e94eb) broke non-ad sections of the wornandwound.com website. The site uses the term 'ad-grid' for sections unrelated to ads. Ads will still be blocked appropriately.