### PR TITLE
Remove /track/click/... filter breaking gmail

### DIFF
--- a/easylist/easylist_general_block_popup.txt
+++ b/easylist/easylist_general_block_popup.txt
@@ -80,7 +80,6 @@
 /showads/*$popup
 /spopunder^$popup
 /srvclk.php?$popup
-/track/click/*$popup,third-party
 /watch?*&refer=$popup
 /watch?key=$popup,third-party
 /watch?refer=$popup


### PR DESCRIPTION
List the website(s) you're having issues:
https://mail.google.com

What happens?
Clicking some links in mails open window which is immediately closed.
Exactly same behavior as described here: http://old-support.getadblock.com/discussions/problems/79284-adblock-closing-tabs-without-asking

Affects links from mandrill as well as possible others

List Subscriptions you're using:
EasyList

Your settings
OS/version:
Linux / same on Windows 10

Browser/version:
Chrome 68

Adblock Extension/version:
Adblock plus


Disabling this rule in Adblock devtools solves the issue:
```
https://mandrillapp.com/track/click/306xxxxxxxxxxxxxxxogle.com | POPUP | /track/click/*$popup,third-partyEasyList
-- | -- | --
```