### PR TITLE
Adjust takealot.com rule

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1986,7 +1986,7 @@
 ||tags.news.com.au^$script
 ||tags.transportdirect.info^
 ||tagx.nytimes.com^
-||takealot.com^*/collect
+||takealot.com/rest/^*/collect
 ||talktalk.co.uk^*/log.html
 ||talktalk.co.uk^*/tracking/
 ||target.com/ci/$script


### PR DESCRIPTION
This is a continuation of this commit: https://github.com/easylist/easylist/commit/0f3122ca2874cdbc986797565b4e5e0a97a92cdd

TAKEALOT.com is South Africa's largest e-commerce platform. 

This commit https://github.com/easylist/easylist/commit/0f3122ca2874cdbc986797565b4e5e0a97a92cdd modified the rule. 

The rule is still blocking collect orders on our customer checkout. For example, the following URI is being blocked:  https://secure.takealot.com/buy/collect/pickup-points

This is a continuation of this issue https://forums.lanik.us/viewtopic.php?t=42030. 

This PR is to make the URI more specific to only block user tracking endpoint on our API, which looks like http://api.takealot.com/rest/v-1-4-2/collect. 



