### PR TITLE
P: https://support.steampowered.com/kb_article.php?ref=7728-QESJ-4420#switch

### DIFF
--- a/fanboy-addon/fanboy_social_whitelist.txt
+++ b/fanboy-addon/fanboy_social_whitelist.txt
@@ -497,6 +497,7 @@
 @@||stipple.cachefly.net^$domain=stipple.com
 @@||stuff.co.nz/video/*.mp4$media
 @@||style.aliunicorn.com/js/$script,domain=alibaba.com
+@@||support.steampowered.com/images/faq/steam_link/*_steam.png$image,~third-party
 @@||swappa.com/static/icons/social/login_$image
 @@||symantec.com/content/*/about/images/social/b-$image
 @@||syndication.twitter.com/tweets.json?*&callback=$script


### PR DESCRIPTION
Non-social images in article on Steam itself were blocked by Steam social icon filter `/images/*steam.png` from fanboy_social_general_block.