### PR TITLE
Mixer.com follow button

### DIFF
--- a/fanboy-addon/fanboy_social_general_hide.txt
+++ b/fanboy-addon/fanboy_social_general_hide.txt
@@ -5037,7 +5037,7 @@
 ##.follow-author-mini
 ##.follow-bar
 ##.follow-bar-wrapper
-##.follow-block
+domain=~mixer.com##.follow-block
 ##.follow-btn
 ##.follow-button
 ##.follow-button-facebook


### PR DESCRIPTION
The channel follow button on streaming site Mixer.com was being hidden by this filter.