### PR TITLE
Fix Wirecutter Review callouts

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4741,7 +4741,7 @@ thecable.ng##.cableads_mid
 nst.com.my##.cadv
 winnipegfreepress.com##.cal-sponsor
 ieee.org##.callOutTitle
-thewirecutter.com,utorrent.com##.callout
+utorrent.com##.callout
 utorrent.com##.callout-recall
 catholicreview.org##.campaign-slider-wrap
 adorraeli.com##.candy


### PR DESCRIPTION
Hi there - 

This PR reverses a recent change to easylist that is negatively impacting our readers' experience on thewirecutter.com. For your background, Wirecutter recommends products based on extensive practical research, and our readers visit the site to read our recommendations and often purchase the products.

For more information, see this forum post: https://forums.lanik.us/viewtopic.php?f=64&t=42683

Would it be possible to reverse that change? Following are some details regarding the issue I'm attempting to address and its impact.

## Description of issue
On a review page (e.g. https://thewirecutter.com/reviews/best-smart-led-light-bulbs/), there are boxes assigned the CSS class `callout` that contain links to the product recommendations mentioned in the review (including prices).

Callouts are meant to be clear, visually distinct, and they contain helpful content and guidance for the reader; without them, it's much harder for the reader to understand what product recommendations we've made and why we've made them.

The products displayed in callouts are selected by our editorial team because we think that they are good products (not due to an advertising or promotional arrangement), and the callouts themselves are rendered server-side, so they don't negatively impact page load time or performance.

### Screenshots

**With an ad blocker on:**

![image](https://user-images.githubusercontent.com/1682088/53670976-34a13900-3c42-11e9-973d-3998181832a7.png)

**Without an ad blocker:**

![image](https://user-images.githubusercontent.com/1682088/53670996-45ea4580-3c42-11e9-825a-5db2999b7556.png)

Let me know if I can clarify anything about our content, how we make our recommendations (we disclose our editorial process and affiliate link arrangements [here](https://thewirecutter.com/about/)), or our technology stack.

Thank you so much in advance for your consideration

Eric Jorgensen
Engineering manager, Wirecutter
