### PR TITLE
A: discordapp.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -740,6 +740,7 @@
 ||digitalgov.gov/Universal-Federated-Analytics-Min.js
 ||directnews.co.uk/feedtrack/
 ||dirt.dennis.co.uk^
+||discordapp.com/api/v6/science
 ||disqus.com/api/ping?$third-party
 ||disqus.com/event.js?$script
 ||disqus.com/stats.html


### PR DESCRIPTION
This blocks the science endpoint of the Discord API which is used exclusively for tracking users.