### PR TITLE
Remove airswap.io from this list

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1521,7 +1521,6 @@
 ||prnewswire.com/rit.gif?
 ||prnewswire.com/rt.gif?
 ||proac.nationwide.com^
-||production.airswap.io^
 ||projop.dnsalias.com/intranet-crm-tracking/
 ||prontohome.com/permuto.do
 ||propertyfinder.ae/js/ga.js


### PR DESCRIPTION
The URL for airswap.io is a widget for using the AirSwap platform. It must be explicitly added by a developer per https://developers.airswap.io/

It is not a popup or banner ad.