### PR TITLE
Update easylist_thirdparty.txt

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -63,7 +63,6 @@
 ||ad.aquamediadirect.com^$third-party
 ||ad.bitbay.net^$third-party
 ||ad.bitmedia.io^
-||ad.e-kolay.net^$third-party
 ||ad.flux.com^
 ||ad.foxnetworks.com^
 ||ad.ghfusion.com^$third-party
@@ -90,7 +89,6 @@
 ||ad.r.worldssl.net^
 ||ad.rambler.ru^
 ||ad.realmcdn.net^$third-party
-||ad.reklamport.com^
 ||ad.sensismediasmart.com.au^
 ||ad.sharethis.com^$third-party
 ||ad.smartclip.net^
@@ -101,13 +99,11 @@
 ||ad.vidaroo.com^
 ||ad.winningpartner.com^
 ||ad.wsod.com^$third-party
-||ad.zaman.com.tr^$third-party
 ||ad2links.com/js/$third-party
 ||adap.tv/redir/client/static/as3adplayer.swf
 ||adap.tv/redir/plugins/$object-subrequest
 ||adap.tv/redir/plugins3/$object-subrequest
 ||adaptv.advertising.com^$third-party
-||add.bugun.com.tr^
 ||addme.com/images/addme_$third-party
 ||adf.ly/?$subdocument,~third-party,domain=adf.ly
 ||adf.ly/images/banners/
@@ -130,7 +126,6 @@
 ||adserv.legitreviews.com^$third-party
 ||adsrv.eacdn.com^$third-party
 ||adss.dotdo.net^
-||adstest.zaman.com.tr^$third-party
 ||adswizz.com/adswizz/js/SynchroClient*.js$third-party
 ||adtech.advertising.com^$third-party
 ||advanced-intelligence.com/banner


### PR DESCRIPTION
`Bugun` and `Zaman `newspapers were closed.Also `e-kolay.net` was closed.

This rule already exists in the Turkish filter.
`||ad.reklamport.com^$third-party `

https://github.com/AdguardTeam/AdguardFilters/blob/ad31a58f7a5fe741a6fdb99a775f636125ae88ca/TurkishFilter/sections/adservers.txt#L63