### PR TITLE
Add official Wikimedia domains to whitelist

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -1905,6 +1905,7 @@
 @@||vtstage.cbsinteractive.com/plugins/*_adplugin.swf
 @@||vzoozv.com^$domain=nme.com|trustedreviews.com
 @@||w.org/plugins/adsense-plugin/screenshot-$image,domain=wordpress.org
+@@||w.wiki^$generichide
 @@||wahoha.com^$~third-party
 @@||wahooads.com/Ads.nsf/$~third-party
 @@||wallpapersmania.com/ad/$image,~third-party
@@ -1938,6 +1939,15 @@
 @@||widgetserver.com/syndication/get_widget.html?*&widget.adplacement=$subdocument
 @@||wikia.com/__spotlights/spc.php?$xmlhttprequest
 @@||wikia.nocookie.net^*/images/$image
+@@||wikibooks.org^$generichide
+@@||wikidata.org^$generichide
+@@||wikimedia.org^$generichide
+@@||wikinews.org^$generichide
+@@||wikipedia.org^$generichide
+@@||wikiquote.org^$generichide
+@@||wikisource.org^$generichide
+@@||wikiversity.org^$generichide
+@@||wikivoyage.org^$generichide
 @@||wiktionary.org^$generichide
 @@||williamsauction.com/Resources/images/ads/$~third-party
 @@||winnipegsun.com/assets/js/dfp.js?


### PR DESCRIPTION
Add to whitelist all canonical domains for the Wikimedia movement, cf. https://www.wikimedia.org/ 
Note: w.wiki is the forthcoming official URL shortener, cf. https://meta.wikimedia.org/wiki/Wikimedia_URL_Shortener
Sidenote: See also the recent addition for Wiktionary at https://github.com/easylist/easylist/issues/3188 (thanks!)