### PR TITLE
A: https://www.focus-wtv.be/nieuws/schadeclaim-van-82-miljoen-euro-casinodossier

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -589,6 +589,7 @@
 ||o2.cz^*-ga_o2cz_bundle.js?
 ||stat.novinky.cz^
 ! Dutch
+||analytics.rambla.be^
 ||klik.nrc.nl/ping?
 ||logs.ggweb.nl^
 ||marktplaats.nl/add_counter_image.


### PR DESCRIPTION
```
https://player.cdn01.rambla.be/?account_id=VzaPKg&item_id=WXPZlG
```