### PR TITLE
R: bugherd.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -374,7 +374,6 @@
 ||btstatic.com^$third-party
 ||btttag.com^$third-party
 ||bubblestat.com^$third-party
-||bugherd.com^$third-party
 ||bunchbox.co^$third-party
 ||burstbeacon.com^$third-party
 ||burt.io^$third-party


### PR DESCRIPTION
BugHerd is an ~8 year old SaaS product that allows users to log visual feedback on their websites.

A few months ago, we removed a chunk of code which has not been in use for a long time; setting a third-party cookie when we didn't identify a user.

Cookies are now only set on bugherd.com for authenticated users. If you're an unauthenticated user, you simply make a request to our embedded script (sidebar.js), and depending on if the user has "anonymous feedback" enabled or not, the response is either an empty file or the code to execute to render a "send feedback" tab in the UI. This "anonymous feedback" feature is not something we promote in sales material, and is used on very few of our customer accounts.

Our business model (and code!) is not interested in tracking a user or exposing their privacy. If the above does not meet the requirements to remove the BugHerd domain from the list, please let us know what will.