### PR TITLE
A: https://vrv.co/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -2329,6 +2329,7 @@
 ||votigo.com/contests/t/
 ||voyages-sncf.com^*/vsca.js
 ||voyeurhit.com/js/a2210.js
+||vrv.co/ip
 ||vs.target.com^
 ||vs4food.com/ERA/era_rl.aspx
 ||vstat.vidigy.com^


### PR DESCRIPTION
similar to https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L510.
both VRV and Crunchyroll are operated by Otter Media.
example URL(geo-restricted to US): https://vrv.co/watch/G62P49XM6
request made from(`cx-vilos-ads` script): https://static.vrv.co/vilos/assets/vendri.js to: https://static.vrv.co/ip 
```js
  function ipv4AddressFetch() {
    var a,
    b = new XMLHttpRequest,
    c = 'object' == typeof device && device.hasOwnProperty('ip');
    if (c) return a = '//' + window.location.host + '/ip',
    console.log('Vendri; A9 API; ipv4AddressFetch; endpoint', a),
    b.open('GET', a, !0),
    b.onreadystatechange = function () {
      b.readyState === b.DONE && (200 === b.status ? device.ip = parseIpv4Response(b.response)  : (console.warn('Vendri; A9 API; failure to retrieve client IP address: ' + b.status), device.ip = '127.0.0.1'))
    },
    b.error = function (a) {
      console.warn('Vendri; A9 API; error getting client iP address', a),
      device.ip = '127.0.0.1'
    },
    b.send(),
    b
  }
```