### PR TITLE
Remove datadome.co

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -343,7 +343,6 @@
 ||compteur.org^$third-party
 ||count.fr^$third-party
 ||countus.fr^$third-party
-||datadome.co^$third-party
 ||deliv.lexpress.fr^$third-party
 ||do09.net^$third-party
 ||edt02.net^$third-party


### PR DESCRIPTION
Hi, I'm Gilles, Head of Engineering at DataDome.
datadome.co is a cybersecurity solution to protect websites against the bad bot activity. We don't use information for any other purpose than detecting fraud and bad bots.
Blocking our JS may generate blocking access to some of the major french websites (PagesJaunes, LeParisien, Blablacar...). more information on detection [here](https://datadome.co/how-to-detect-malicious-bots/)
This is something already discussed a few months ago on those PRs : #673 and #997

This PR is a proposal to revert a [commit](https://github.com/easylist/easylist/commit/6843b5ff0d5733052dce19c1a70c42e2b7947fef#diff-1a58c0a4c8e32e93aa7240cd96af3279) delivered a few days ago.