### PR TITLE
U: #3567

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -4547,7 +4547,7 @@ _zag_cookie.
 cgi-bin/counter
 ||meetrics.netbb-
 ! Prism tracking
-/prism.js
+|http*://prism.app-us1.com/prism.js
 ! Mining
 -coin-hive.js
 -coin-hive/$script


### PR DESCRIPTION
Fixed blocking ALL prism.js files instead of the one that actually should be blocked.

This fixes #3567 