### PR TITLE
M: Removing pxlad.io it's not a tracker and prevents access to api.pxlad.io

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1706,7 +1706,6 @@
 ||putags.com^$third-party
 ||pxf.io^$third-party
 ||pxi.pub^$third-party
-||pxlad.io^$third-party
 ||pymx5.com^$third-party
 ||pzkysq.pink^$third-party
 ||q-counter.com^$third-party


### PR DESCRIPTION
Removing the all domain pxlad.io prevents users functionalities that need to access api.pxlad.io