### PR TITLE
dmcdn.net/pxl/ is not a Tracker

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -576,7 +576,6 @@
 ||divxden.com^*/tracker.js
 ||djtunes.com^*&__utma=
 ||dl.meliacloud.com^
-||dmcdn.net/pxl/$domain=dailymotion.com
 ||dmcdn.net/track/$domain=dailymotion.com
 ||dmeserv.newsinc.com^
 ||dmp.marketgid.com^


### PR DESCRIPTION
hello,

We (Dailymotion) noticed that our domain "dmcdn.net/pxl/" has been blocked by your List (EasyPrivacy).
This is not a Tracker but a tool to enhance our Player. (https://api.dmcdn.net/pxl/cpe/client.min.js and https://api.dmcdn.net/pxl/cpe/app.min.js)


This is the same problem as here (you already solved) : https://github.com/easylist/easylist/pull/3606

Blocking this domain breaks our website

Can you remove this rule from your list, please ? 

We already asked to Easy List FR and Easy List (see above) and our request has been accepted by their maintainers.

Here an example of website that break because of this list :
- https://www.dailymotion.com/dm/partner/demo

Thanks in advance
