### PR TITLE
PerimeterX isn't a tracking or ad service

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1615,7 +1615,6 @@
 ||performanceanalyser.net^$third-party
 ||performancerevenues.com^$third-party
 ||performtracking.com^$third-party
-||perimeterx.net^$third-party
 ||perion.com^$third-party
 ||permutive.com^$third-party
 ||personalicanvas.com^$third-party


### PR DESCRIPTION
PerimeterX is a security service, protecting websites from automated attackers. 
information isn't sold or shared with third parties and is used solely in order to protect the web sites.
We suggest removing the perimeterx.net domain from the list.