### PR TITLE
Add perimeterx.net to whitelist

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -558,6 +558,7 @@
 @@||paypalobjects.com^*/opinionLab.js$domain=paypal.com
 @@||paypalobjects.com^*/pixel.gif$domain=youngcons.com
 @@||pbskids.org/js/ga-current.js
+@@||perimeterx.net^
 @@||petametrics.com^*.js?$script,domain=nylon.com|space.com
 @@||pillsbury.com/Shared/StarterKit/Javascript/ntpagetag.js
 @@||pillsbury.com/Shared/StarterKit/Javascript/UnicaTag.js


### PR DESCRIPTION
PerimeterX is a security service protecting sites from malicious automated attacks/bots, and inspecting malicious scripts (see www.perimeterx.com).
the scripts served from the perimeterx.net domain and information sent to that domain is used solely for security and fraud detection purposes, and isn't shared with any 3rd party. 
by blocking the scripts or preventing the data collection it will impact hundreds of large sites using the perimeterx services, and may block users from accessing the sites.

adding the domain to the whitelist per @brahma-dev recommendation, and following issue https://github.com/easylist/easylist/pull/3724