### PR TITLE
Remove Shariff from fanboy_social_general_block.txt

### DIFF
--- a/fanboy-addon/fanboy_social_general_block.txt
+++ b/fanboy-addon/fanboy_social_general_block.txt
@@ -1954,8 +1954,6 @@
 /sharetw_
 /shareTwitter.
 /shareWidgetBackgrounds.
-/shariff-sharing/*
-/shariff.min.js
 /sharing-buttons.
 /sharing/sprites/*
 /sharing_icons/*


### PR DESCRIPTION
Shariff is a data privacy protected sharing possibility. It seems wrong to block it.