### PR TITLE
A: tncred.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5443,6 +5443,7 @@
 ||runtnc.net^$document
 ||securesmrt-dt.com^$document
 ||syndication.exosrv.com^$document
+||tncred.com^$document
 ||trackerislive.com^$document
 ||yvsystem.com^$document
 ! IP addresses

--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -869,6 +869,7 @@
 ||tmdn2015x9.com^$popup,third-party
 ||tmtrck.com^$popup
 ||tmxhub.com^$popup
+||tncred.com^$popup,third-party
 ||tnctrx.com^$popup,third-party
 ||tnkexchange.com^$popup
 ||tonefuse.com^$popup,third-party


### PR DESCRIPTION
malvertising redirector, same as runtnc.net