### PR TITLE
A: nzz.ch adblock notice

### DIFF
--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -108,6 +108,7 @@ boligliv.dk,rumid.dk##div[style^="bottom: 0px; height: 1px; left: 0px;"]
 baguette.at###TopBtn
 valentins.de###arrow-up
 nzz.ch###articleMore
+nzz.ch##div.l--premain iframe
 testberichte.de###bck-t-tp
 androidnext.de###c4a_box
 reifenpresse.de###custom_html-2


### PR DESCRIPTION
This removes the adblock notice on nzz.ch. Screenshot of notice: https://ibb.co/9pxpG5w
