### PR TITLE
 Restore basic page functionality to ZeroHedge.

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -8091,6 +8091,7 @@
 ||creyboif.bid^$third-party
 ||crgfbmzsk.com^$third-party
 ||crheaeqw.com^$third-party
+||crhvyali.com^$third-party
 ||crijpgcer.com^$third-party
 ||crjsrbyybipozq.com^$third-party
 ||crkgtnad.com^$third-party


### PR DESCRIPTION
@ryanbr Not sure of the goal of this specific exclusion a couple of days ago but all sitewide JS is stored in this directory and it broke comments, menus, etc. Getting lots of complaints form our adblock plus users. Thanks!