### PR TITLE
A: ore.spongepowered.org

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -2201,6 +2201,8 @@
 ||oncyprus.com^*/banners/
 ||onlineshopping.co.za/expop/
 ||optics.org/banners/
+||ore.stage.spongemc.org/assets/images/sponsors/
+||ore.spongepowered.org/assets/images/sponsors/
 ||paktribune.com^*/banner
 ||pdn-1.com^$domain=arenabg.ch
 ||pe.com^*/biice2scripts.js

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2748,6 +2748,7 @@ detroitnews.com###sponsor-flyout
 meteo-allerta.it,meteocentrale.ch,meteozentral.lu,severe-weather-centre.co.uk,severe-weather-ireland.com,vader-alarm.se###sponsor-info
 publicfinanceinternational.org###sponsor-inner
 itweb.co.za,submarinecablemap.com###sponsor-logo
+ore.spongepowered.org,ore.stage.spongemc.org##.sponsor-panel
 zymic.com###sponsor-partners
 talktalk.co.uk###sponsor-search
 opb.org###sponsor-small-default-location


### PR DESCRIPTION
This patch blocks the advertisements on the Ore plugin repository.

The patch applies to 2 domains:

1. `ore.spongepowered.org` - the production instance of Ore.
2. `ore.stage.spongemc.org` - the development instance of Ore.