### PR TITLE
A: analytics.spongeproject.net

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -158,6 +158,7 @@
 ||analytics.skyscanner.net^
 ||analytics.slashdotmedia.com^
 ||analytics.socialblade.com^
+||analytics.spongeproject.net^
 ||analytics.sportybet.com^
 ||analytics.teespring.com^
 ||analytics.thegedsection.com^


### PR DESCRIPTION
Sponge has recently introduced tracking to their plugin repository (https://github.com/SpongePowered/Ore/pull/904), using a self-hosted instance of Matomo. This was covered by an existing filter for Matomo, [until a change](https://github.com/SpongePowered/Ore/pull/906/commits/6e880be6b3e484f7f068dca6030cb97ffae9413a) was made in https://github.com/SpongePowered/Ore/pull/906 to use an alternative route.

---

**Update**: As indicated by @felixoi, tracking has been [removed from Ore](https://github.com/SpongePowered/Ore/commit/76cab84ed76532146121a6d9b7a9809c7332bdb8) - though the `analytics.spongeproject.net` site continues to exist (I'm informed that this is only a temporary change, and it will be back with a new domain), so I believe this patch still has merit.