### PR TITLE
remove hscta from tracking servers list

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1080,7 +1080,6 @@
 ||hqhrt.com^$third-party
 ||hs-analytics.net^$third-party
 ||hsadspixel.net^$third-party
-||hscta.net^$third-party
 ||hubvisor.io^$third-party
 ||hudb.pl^$third-party
 ||humanclick.com^$third-party


### PR DESCRIPTION
Could `hscta.net` please be removed from this list? This script will not track events without `hs-analytics.net` also on the page, which is correctly blocked.

PR adding this https://github.com/easylist/easylist/commit/e8f1ea5be7b490a155534b62cc8a34d9c18cf656

@ryanbr