### PR TITLE
sport360.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -108,7 +108,7 @@
 @@||cubeecraft.com/openx/$~third-party
 @@||cvs.com/webcontent/images/weeklyad/adcontent/$~third-party
 @@||cwtv.com^$generichide
-@@||dailymotion.com/embed/video/$subdocument
+@@||dailymotion.com/embed$subdocument
 @@||davidsilverspares.co.uk/graphics/*_ad.gif$~third-party
 @@||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
 @@||dianomi.com/partner/marketwatch/js/dianomi-marketwatch.js?$domain=marketwatch.com


### PR DESCRIPTION
Hello,

Thank you for adding our Player product to the whitelist. (see https://github.com/easylist/easylist/commit/949e23a)
Here a modification to remove `/video` too, because it's optional.

e.g. we can also embed a Playlist `dailymotion.com/embed/playlist` or preload the player with `dailymotion.com/embed`


Thanks in advance