### PR TITLE
remove ||ekstat.com/js/ek$script filter

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -928,7 +928,6 @@
 ! Turkish
 ||c.gazetevatan.com^
 ||d.haberler.com^
-||ekstat.com/js/ek$script
 ||haberler.com/dinamik/
 ||p.milliyet.com.tr^
 ||sahibinden.com/sbbi/


### PR DESCRIPTION
this filter causes many problems, effects users' surfing experience. Because website main javascript files are serving from this resource.

example blocked resource urls are:

- https://ekstat.com/js/ek$i-combo.js
- https://ekstat.com/js/ek$i-defer.js

we must have very specific blocker filters if this resource contains ads.

affected website: https://eksisozluk.com