### PR TITLE
A: optinmonster scripts

### DIFF
--- a/fanboy-addon/fanboy_social_thirdparty.txt
+++ b/fanboy-addon/fanboy_social_thirdparty.txt
@@ -148,6 +148,7 @@
 ||networkedblogs.com^$third-party
 ||newsharecounts.com^$third-party
 ||opensharecount.com^$third-party
+||opmnstr.com^$third-party
 ||pinterest.com/images/$third-party
 ||pinterest.com/js/pinit_main.js$third-party
 ||pinterest.com/v1/urls/count.json$third-party


### PR DESCRIPTION
Optinmonster is extremely user-hostile set of scripts, blocking content, detecting adblocks, forcing people to give up their emails to see what they have already downloaded into their browser. In general it behaves more like malware than something you voluntairly download to your computer. 
 
I think its very beneficial for people to get rid off this if this is not what they have been looking for.

I noticed that they are trying very hard to not be detected, by buying more and more domains, ie:

```
||optinmonster.com^$third-party
||optmnstr.com^$third-party
||optmstr.com^$third-party
||optnmnstr.com^$third-party
||optnmstr.com^$third-party
```

But lets try to keep them in check, because what they do is pretty high on the scale of being completely useless and counterproductive on the web.

I suspect they will be buying `op*m?n?s?t?r?.com` domains now, since they reached peak on `opt*` so maybe a good regexp would be more appropriate. Unfortunately im pretty bad at regexp and im certainly not an expert on regexp performance, so this is the best i can suggest - https://regex101.com/r/8zUn2F/1

https://optinmonster.com/

Test site: https://contentdistribution.com/seo-content-writer/

Before:
<img width="867" alt="image" src="https://user-images.githubusercontent.com/546845/65832229-31962600-e2c1-11e9-860c-aed6f475a7b2.png">
 
Edit: I removed the "after" screenshot (for possibly copyright reasons).