### PR TITLE
Increasing the git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+dist: bionic
+
 # https://docs.travis-ci.com/user/languages/python/
 language: python
 
+python: "3.7"
 # https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 # https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
 git:
-  depth: 3
+  depth: 10
 
 # https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
 install:
@@ -25,7 +25,7 @@ before_script:
 
 # https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step
 script:
-  - git clone --depth=3 -b gh-pages "https://$GITHUB_TOKEN@github.com/easylist/easylist" output
+  - git clone --depth=10 -b gh-pages "https://$GITHUB_TOKEN@github.com/easylist/easylist" output
   - flrender -i easylist=. easylist.template output/easylist.txt
   - flrender -i easylist=. easyprivacy.template output/easyprivacy.txt
   - flrender -i easylist=. fanboy-social.template output/fanboy-social.txt


### PR DESCRIPTION
Do to the high number of PR that's need rebase, i think it might b a good idea to add a few seconds to the TravisCi running time by increasing the `git clone --depth=10` from `3` to `10`

If this doesn't solve the [PR's that needs rebasing](https://github.com/easylist/easylist/pulls?q=is%3Apr+is%3Aopen+label%3A%22Git+Rebase+Needed%22), just reverse the depth to 2 or 3