### PR TITLE
R: /thermostat. from easyprivacy_general.txt

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3719,7 +3719,6 @@
 /thbeacon/*
 /thcn_code.
 /thcn_code_
-/thermostat.
 /thermstats/*
 /thetracker.js
 /third-party-analitycs/*


### PR DESCRIPTION
This rule is too broad and will break home automation and IoT websites.

[Fixes #4114]