### PR TITLE
block metrics.readme.io

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1250,6 +1250,7 @@
 ||metrics.dailymotion.com^
 ||metrics.ee.co.uk^
 ||metrics.extremetech.com^
+||metrics.readme.io^
 ||metrics.tbliab.net^
 ||metrics.ted.com^
 ||metrics.washingtonpost.com^


### PR DESCRIPTION
Used on https://readme.io, and any other documentation sites that use readme, such as https://developer.box.com