### PR TITLE
Enable report banners for pingdom

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7934,7 +7934,7 @@ takeover_background.
 takeover_banner_
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
-||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com|~share.pingdom.com
+||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com|~pingdom.com
 ||online.*/promoredirect?key=
 ||ox-d.*^auid=
 ||serve.*/promoload?

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7934,7 +7934,7 @@ takeover_background.
 takeover_banner_
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
-||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com
+||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com|share.pingdom.com
 ||online.*/promoredirect?key=
 ||ox-d.*^auid=
 ||serve.*/promoload?

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7934,7 +7934,7 @@ takeover_background.
 takeover_banner_
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
-||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com|share.pingdom.com
+||com/banners/$image,object,subdocument,domain=~thetvdb.com|~tooltrucks.com|~share.pingdom.com
 ||online.*/promoredirect?key=
 ||ox-d.*^auid=
 ||serve.*/promoload?


### PR DESCRIPTION
Added whitelist for Pingdoms sharing banners to this very hungry rule.
Example of banner can be found here;  https://share.pingdom.com/banners/0a7716fc

These images are generated by customers, and not meant for advertising.