### PR TITLE
R: d3f5l8ze0o4j2m.cloudfront.net from easylist_thirdparty.txt

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -616,7 +616,6 @@
 ||d3bvcf24wln03d.cloudfront.net^
 ||d3dphmosjk9rot.cloudfront.net^
 ||d3dytsf4vrjn5x.cloudfront.net^
-||d3f5l8ze0o4j2m.cloudfront.net^
 ||d3f9mcik999dte.cloudfront.net^
 ||d3fzrm6pcer44x.cloudfront.net^
 ||d3hitamb7drqut.cloudfront.net^


### PR DESCRIPTION
The domain is used by Women’s Refuge New Zealand's Shielded Site Project, which is for victims of abuse to ask for help. See here: https://shielded.co.nz/

## Filter affected:

```
||d3f5l8ze0o4j2m.cloudfront.net^
```

## 1st/3rd-party sites affected:

* https://www.asb.co.nz/
* https://z.co.nz/
* https://www.stats.govt.nz/
* https://www.thewarehouse.co.nz/
* https://www.trademe.co.nz/
* https://www.countdown.co.nz/
* https://women.govt.nz/
* http://www.ausa.org.nz/
* https://imoved.me/
* http://www.olympic.org.nz/
* https://www.momentum.co.nz/
* https://www.sjs.co.nz/
* https://thespinoff.co.nz/
* https://www.pagani.co.nz/
* https://www.nzpost.co.nz/
* https://www.ird.govt.nz/
* https://www.easygiving.nz/charities/
* https://www.happymumhappychild.co.nz/
* https://www.bnz.co.nz/
* https://www.tower.co.nz/
* https://library.huttcity.govt.nz/
* http://www.kidpower.org.nz/
* http://www.miseryguts.co.nz/
* https://www.goodnest.co.nz/
* https://girlguidingnz.org.nz/
* https://wellingtonzoo.com/
* https://www.baybuzz.co.nz/
* https://www.waimakariri.govt.nz/
* https://www.eapservices.co.nz/
* https://www.waikatodhb.health.nz/
* http://www.bossleyarchitects.co.nz/
* https://accessgranted.nz/
* https://www.silverstripe.org/
* https://sia.govt.nz/

## How is it broken?

Clicking on the shielded logo button does not open the shielded tool.

## Description why it should be removed:

It blocks a tool that helps victims of abuse. The domain does not contain any advertisements, trackers or 3rd party content.
