### PR TITLE
Do not block legendstracking.com js file

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -428,6 +428,7 @@
 @@||krxd.net^$script,domain=nbcnews.com
 @@||l.yimg.com/g/combo/*/comscore.$script
 @@||leeaws.com/api-cache/chartbeat/?host=$xmlhttprequest,domain=tucson.com
+@@||legendstracking.com/js/legends-tracking.js
 @@||lenovo.com^*/GoogleAnalytics.js
 @@||leretourdelautruche.com/map/nuke/heatmap.js
 @@||lesacasino.com^*/EMERPEventCollector.$script,subdocument


### PR DESCRIPTION
legendstracking.com is a website to track people during sport events while running/cycling with a GPS chip.

The file
http://XXX.legendstracking.com/js/legends-tracking.js?00001 (where XXX is the name of the race)
is used to load the GPS tracking information, this is not about
tracking the visitor

For instance, go to http://beartrail.legendstracking.com/ getting a blank page instead of getting the map of the race because it matches the rule `-tracking.js?`

Warning, first time contributing to easylist, I am not sure it is the best syntax to do so, advises appreciated.