### PR TITLE
a general filter ###euConsent added

### DIFF
--- a/fanboy-addon/fanboy_cookie_general_hide.txt
+++ b/fanboy-addon/fanboy_cookie_general_hide.txt
@@ -259,6 +259,7 @@
 ###ECScookiepanel
 ###EPDirectiveInfo
 ###EP_cookiesPopup
+###euConsent
 ###EUCOOK
 ###EUCookie
 ###EUCookie-Banner


### PR DESCRIPTION
This kind of element encountered on `www.virustotal.com`

That message might not be visible for users outside of EU despite using an eu based proxy. I live in EU and I tried foreign proxies (US, Indonese) but still saw that message even though I should have not.

My personal screenshot: https://user-images.githubusercontent.com/17256841/67633368-bfacfe80-f8b7-11e9-83c5-4a88b722b2f5.png

Others have seen that notice also: https://github.com/NanoAdblocker/NanoFilters/issues/349