### PR TITLE
##.ad-banners general filter added

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -8350,6 +8350,7 @@
 ##.A__smallSuperbannerAdvert-main
 ##.AcceptableTextAds
 ##.Accordion_ad
+##.ad-banners
 ##.Ad--header
 ##.Ad--sidebar
 ##.Ad-300x100


### PR DESCRIPTION
Ad containers left unblocked (location: down from the middle page).
`https://www.tv7.fi/`

 A general filter can be made:
`##.ad-banners`

 
![pI3FoNF4_o](https://user-images.githubusercontent.com/17256841/68071010-59742000-fd7e-11e9-88f7-f50cf0441c03.png)

(Originally mentioned here: `https://forums.lanik.us/viewtopic.php?f=62&t=43756`)