### PR TITLE
a generic filter ##[class*="mobilead"] added for mobile ads

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -19725,6 +19725,7 @@
 ##FBS-AD
 ##LEADERBOARD-AD
 ##[ad-id^="googlead"]
+##[class*="mobilead"]
 ##[href*="//xml.revrtb.com/"]
 ##[href^="https://hilltopads.com/"]
 ##[href^="https://maskip.co/"]


### PR DESCRIPTION
Sample page: `https://www.cpubenchmark.net/` (browser window needs to be resized small enough so that the mobile ad will appear on the bottom)