### PR TITLE
a general filter, ###consent_c added

### DIFF
--- a/fanboy-addon/fanboy_cookie_general_hide.txt
+++ b/fanboy-addon/fanboy_cookie_general_hide.txt
@@ -65,6 +65,7 @@
 ###CWCookie
 ###CenturiaCookieMonster
 ###ConsentBanner
+###consent_c
 ###ConsentCookie
 ###ConsentLayerWrapper
 ###Consentement-cookies


### PR DESCRIPTION
Element encountered on this site: `https://keepass.info/help/base/faq_tech.html` (I'll give a link to a subpage in order to show that hiding this element doesn't break scrolling.)

C is probably an abbreviation of cookie. That's why I think this would do as a general filter.