### PR TITLE
Critical, blank page fix, cookie list

### DIFF
--- a/fanboy-addon/fanboy_cookie_whitelist_general_hide.txt
+++ b/fanboy-addon/fanboy_cookie_whitelist_general_hide.txt
@@ -186,3 +186,4 @@ mymuesli.com#@#cookies_consent
 birramenabrea.com,marketerplus.pl#@#div[data-cookie]
 timeout.com#@#div[data-module="cookie_banner"]
 unicode.org#@#div[data-nconvert-cookie]
+www.hongkong.fi#@#.cookie-content


### PR DESCRIPTION
Cookie list causes a blank page on `www.hongkong.fi`. Made a fixing rule. Cookie notice remains blocked despite this rule. @ryanbr 