### PR TITLE
Alma media cookie script

### DIFF
--- a/fanboy-addon/fanboy_cookie_international_specific_block.txt
+++ b/fanboy-addon/fanboy_cookie_international_specific_block.txt
@@ -42,6 +42,7 @@
 ! ---------- Finnish ----------
 !
 ||sanoma.fi^*/sccm.js
+||alma-cmp.almamedia.io/*/*/*.js$script
 !
 ! ---------- Greek ----------
 !


### PR DESCRIPTION
The cookie notification is blocked on Alma media's websites by these hiding rules:

`##.alma-data-policy-banner`
`###alma-data-policy-banner`

But Alma media's cookie message has recently started to quickly blink at times, meaning that these hiding rules don't work 100 % efficiently. Blocking a cookie script in the background will work better.

A couple of Alma media owned websites to test with:
`https://www.iltalehti.fi/`
`https://www.tivi.fi/`