### PR TITLE
P: evestment.com/api/analytics

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -89,6 +89,7 @@
 @@||ensighten.com^*/serverComponent.php?$script
 @@||eplayerhtml5.performgroup.com/js/tsEplayerHtml5/js/Eplayer/js/quantcast/$script
 @@||events-collector.spot.im/api/$domain=foxbusiness.com|foxnews.com
+@@||evestment.com/api/analytics/$domain=evestment.com
 @@||fastway.co.nz/Umbraco/Api/Tracking/
 @@||fccbrea.org^*/swfaddress.js
 @@||fifa.com^*/webanalytics.js?


### PR DESCRIPTION
Hello,

This PR restores a whitelist entry that was recently removed for `evestment.com`:

&nbsp;&nbsp;&nbsp;&nbsp;Original Addition: https://github.com/easylist/easylist/commit/62f09532389ec205ffdf7cc37fbf6574e3d61a07 by @monzta 
&nbsp;&nbsp;&nbsp;&nbsp;Recent Removal: https://github.com/easylist/easylist/commit/e95ef2da029ef7c648d60b5bdac1cacb7b4a5d5c

The removal of the whitelist entry is resulting in a broken experience for users of the evestment platform that are also using the privacy list.  Unfortunately, this means users have to disable their privacy extensions while using the application.  To learn more about eVestment:

- [crunchbase profile](https://www.crunchbase.com/organization/evestment-alliance)
- [glassdoor](https://www.glassdoor.com/Overview/Working-at-eVestment-EI_IE286633.11,20.htm)
- Recent press coverage/mentions (ctrl+f for name):
  - [Axios](https://www.axios.com/hedge-funds-continue-underperformance-8fe57240-8cbf-4241-a786-b6de490d3c01.html)
  - [citywire](https://citywireusa.com/professional-buyer/news/the-shops-topping-institutional-investors-searches-in-october/a1291570?ref=international-us-domestic-latest-news-list)
  - [Financial News](https://www.fnlondon.com/articles/hedge-funds-lose-another-30bn-as-performance-fails-to-convince-20191024)
  - [Opalesque](https://www.opalesque.com/industry-updates/5789/hedge-fund-industry-sees-6th-consecutive-quarter-of.html)
- [press release](https://www.nasdaq.com/about/press-center/nasdaq-completes-acquisition-evestment)

Why `/analytics`? eVestment has a product line named analytics and the APIs are namespaced accordingly: https://www.evestment.com/products/analytics/

Please let me know what other information I can provide, and thank you for helping to restore this entry.