### PR TITLE
fanboy-addon: whitelist odoo.com for subscription widget

### DIFF
--- a/fanboy-addon/fanboy_annoyance_whitelist_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_whitelist_general_hide.txt
@@ -86,3 +86,4 @@ tactxflashlights.com#@#.widget_subscribe
 twellow.com#@#a[href="http://www.twellow.com/"]
 nasa.gov#@#backtotop
 reddit.com#@#img[alt="submit to reddit"]
+odoo.com#@#.subscription-widget


### PR DESCRIPTION
This widget is used to display the current price of the subscription, not to subscribe to a newsletter or shit

Before this commit the form on https://odoo.com/trial was hidden as the class subscription-widget is set on the main element of the form

_Disclaimer_: I am working for the company behind odoo.com but I don't think we are doing anything fishy