### PR TITLE
Sanoma Oyj additional cookie script, blocking added

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -43,6 +43,8 @@
 !
 ||sanoma.fi^*/sccm.js
 ||sanoma.fi^*/sccm-b.js
+||sanoma.fi^*/sccm-c.js
+
 !
 ! ---------- Greek ----------
 !

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -44,7 +44,6 @@
 ||sanoma.fi^*/sccm.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js
-
 !
 ! ---------- Greek ----------
 !

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -42,6 +42,7 @@
 ! ---------- Finnish ----------
 !
 ||sanoma.fi^*/sccm.js
+||sanoma.fi^*/sccm-b.js
 !
 ! ---------- Greek ----------
 !


### PR DESCRIPTION
Sanoma Oyj has a new cookie scripts that are being used for example here: `https://www.is.fi/` 

![Näyttökuva (95)](https://user-images.githubusercontent.com/17256841/69743019-63ebc480-1146-11ea-8144-cf0e431ef7dd.png)


But the old rule is still used also, here example: `https://www.hs.fi/`

That's why it's the best option to have every one of them.

If they add even more (d, e, f etc..) it's better to think another way for this.