### PR TITLE
Block only cdn.speedcurve.com so the webapp still works

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2103,7 +2103,7 @@
 ||spamanalyst.com^$third-party
 ||spectate.com^$third-party
 ||speed-trap.com^$third-party
-||speedcurve.com^$third-party
+||cdn.speedcurve.com^$third-party
 ||spklw.com^$third-party
 ||splittag.com^$third-party
 ||splurgi.com^$third-party


### PR DESCRIPTION
SpeedCurve is a performance monitoring tool used by many software developers. The current rule makes the web app inaccessible and breaks images in emails. It should only block cdn.speedcurve.com, which serves the data collection script on other websites.