### PR TITLE
M: Unblocking adbar.jp

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1645,7 +1645,7 @@
 /adbanner2/*
 /adbanner_
 /adbanners/*
-/adbar.$domain=~adbar.fi|~adbar.io
+/adbar.$domain=~adbar.fi|~adbar.io|~adbar.jp
 /adbar/*
 /adbar2_
 /adbar_


### PR DESCRIPTION
Hi.

We are a web system and graphic design company in Japan, named "AD.BAR".
Now, our domain `adbar.jp` is blocked by easylist.

https://adbar.jp/

But we don't providing ads businesses on internet. And there is no plan.

Could you apply this rule?

Thanks.

Refs: #460

