### PR TITLE
A: Cookie blocking remnant, shirtsofcotton.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -765,3 +765,4 @@ mashable.com##.cookie-notice
 allmusic.com##.cookie-policy-box
 rp-online.de##.park-snackbar-cookies
 walmart.ca##.privacy-open > div > [class] > div[class^="css"]
+shirtsofcotton.com###udtDark


### PR DESCRIPTION
On `shirtsofcotton.com` there is a dark transparent cover. Obviously it's a leftover of the hidden cookie message.