### PR TITLE
ISSUE-4512: Update curalate.com EasyPrivacyList block.

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -652,6 +652,7 @@
 ||cts.vresp.com^
 ||cumulus-cloud.com/trackers/
 ||curalate.com^*/events.jsonp$third-party
+||curalate.com^*/events.png$third-party
 ||curate.nestedmedia.com^
 ||curated.fieldtest.cc^
 ||custom.search.yahoo.co.jp/images/window/*.gif

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -615,7 +615,6 @@
 ||csi-tracking.com^$third-party
 ||ctnsnet.com^$third-party
 ||cttracking02.com^$third-party
-||curalate.com^$third-party
 ||customer.io^$third-party
 ||customerconversio.com^$third-party
 ||customerdiscoverytrack.com^$third-party

--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -72,6 +72,7 @@
 @@||coremetrics.com*/eluminate.js
 @@||cqcounter.com^$domain=cqcounter.com
 @@||crowdtwist.com/img/$image
+@@||cdn.curalate.com^$script,~third-party
 @@||cvs.com/shop-assets/js/VisitorAPI.js
 @@||cxense.com/cx.js$domain=brandonsun.com|channelnewsasia.com|winnipegfreepress.com
 @@||d1z2jf7jlzjs58.cloudfront.net/p.js$script,domain=nfl.com


### PR DESCRIPTION
Details in: https://github.com/easylist/easylist/issues/4512

Instead of blocking all traffic to curalate.com, it specifically blocks Curalate's tracking urls. An example can be seen on this page which uses Curalate's javascript experience: https://www.macys.com/ce/splash/macyslove/