### PR TITLE
 M: An old rule, sonera.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -515,9 +515,7 @@ pihlajalinna.fi###root > div[aria-live="polite"][role="alert"]
 satakunnanautotalo.fi##.AVS-evasteseloste-container
 kulttuurivihkot.fi##.activebar-container
 americanairlines.fi##.alert
-sonera.fi##.attention-notice
 vismasign.fi##.banner
-sonera.fi##.bottom-notifications
 hs.fi##.cb-container
 vertaa.fi##.cg-89.cg-97
 jenkki.fi##.container-agree


### PR DESCRIPTION
That domain is not in use anymore as Sonera has changed it's name to Telia.