### PR TITLE
P: A Facebook game won't load, cookappsgames.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -229,6 +229,7 @@
 @@||pntrs.com^$image,domain=catalogfavoritesvip.com|freeshipping.com|freeshippingrewards.com|habandvipplus.com|inthecompanyofdogsvip.com|naturesjewelryvip.com|northstylevip.com|pyramidcollectionvip.com|serengeticatalogvip.com|travelplus.com
 @@||portal.autotrader.co.uk/advert/$~third-party
 @@||powercolor.com/image/ad/$~third-party
+@@||pro.ip-api.com/json/$xhr,domain=cookappsgames.com
 @@||procato.com/_pub/advertisement.js
 @@||productioncars.com/pics/menu/
 @@||promo.com/shopify-backend/*/user-videos/$xmlhttprequest


### PR DESCRIPTION
A Facebook game called Buggle2 won't load due to Easyprivacy rule.

https://www.facebook.com/search/apps/?q=buggle2&epa=SERP_TAB

It's likely that other games could be affected so I whitelisted all cookappsgames as there are many of them.