### PR TITLE
P: A Facebook game won't load, buggle2.cookappsgames.com

### DIFF
--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -211,6 +211,7 @@
 @@||player.siriusxm.com/assets/AppMeasurement/VisitorAPI.js
 @@||player.sundaysky.com^$subdocument
 @@||pnas.org^*/fingerprint.js$script,~third-party
+@@||pro.ip-api.com/json/$xhr,domain=cookappsgames.com
 @@||ps.w.org/google-analytics-dashboard-for-wp/assets/
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.StreamSense.js
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.Viewability.js

--- a/easyprivacy/easyprivacy_whitelist.txt
+++ b/easyprivacy/easyprivacy_whitelist.txt
@@ -211,7 +211,7 @@
 @@||player.siriusxm.com/assets/AppMeasurement/VisitorAPI.js
 @@||player.sundaysky.com^$subdocument
 @@||pnas.org^*/fingerprint.js$script,~third-party
-@@||pro.ip-api.com/json/$xhr,domain=cookappsgames.com
+@@||pro.ip-api.com/json/$xmlhttprequest,domain=cookappsgames.com
 @@||ps.w.org/google-analytics-dashboard-for-wp/assets/
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.StreamSense.js
 @@||pshared.5min.com/Scripts/OnePlayer/Loggers/ComScore.Viewability.js


### PR DESCRIPTION
A Facebook game called Buggle2 won't load due to Easyprivacy rule.

https://www.facebook.com/search/apps/?q=buggle2&epa=SERP_TAB (here you can test the game if you have a Facebook account).

It's likely that other games could be affected so I whitelisted all Cookappsgames as there are many of them.

If I wanted to fix only this particular game, this rule would be enough:

`@@||pro.ip-api.com/json/$xmlhttprequest,domain=buggle2.cookappsgames.com`

But I consider it better to whitelist all Cookappsgames with this rule:

`@@||pro.ip-api.com/json/$xmlhttprequest,domain=cookappsgames.com`