### PR TITLE
A: general cookie block, www.blogit.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -624,6 +624,7 @@
 /nl-cookie-law.js
 /notification.js*browserId=$script
 /ocgcookie?
+/oil/*-RELEASE.chunk.js
 /onetrustConsent.js
 /opendotcom-cookie/*
 /opt-in-select/cookie/*


### PR DESCRIPTION
Easylist cookie already has rules to hide "oil cookie" notification:

`##.as-oil[data-qa="oil-Layer"]`
`##.as-oil-content-overlay`

I added a rule to block the script behind them.