### PR TITLE
Block google_ads_iframe when name attribute is used instead of id

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20522,6 +20522,7 @@
 ##div[itemtype="http://www.schema.org/WPAdBlock"]
 ##iframe[id^="google_ads_frame"]
 ##iframe[id^="google_ads_iframe"]
+##iframe[name^="google_ads_iframe"]
 ##iframe[src^="http://ad.yieldmanager.com/"]
 ##iframe[src^="http://cdn1.adexprt.com/"]
 ##iframe[src^="http://cdn2.adexprt.com/"]


### PR DESCRIPTION
As seen on: `https://ww.electrek.co/2020/01/06/tesla-model-3-to-be-5000-cheaper-in-new-jersey-turnpike-getting-electrified/#`

```html
<iframe id="ksskpi_ehw_mjveqi_/1049447/Ipigxvio_Wmkrep_1b1_0" title="3rd party ad content" name="google_ads_iframe_/1049447/Electrek_Signal_1x1_0" width="1" height="1" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" srcdoc="<script>(function() { if (!window.$aproxy) {
        let _aTopWin = window.parent.$aproxy.get_top_level_window(window.parent);window.$aproxy = _aTopWin.$aproxy_init(window, _aTopWin.$aproxy.config).inject();window.$aproxy.set_base_url(window.parent.$aproxy.get_base_url().href);window.$aproxy.set_ad_selectors(window.parent.$aproxy.ad_selectors);window.$aproxy.injectPostMessageLogic(window);
        document.currentScript.remove(); } }())</script>" style="border: 0px; vertical-align: bottom;" data-google-container-id="1" data-load-complete="true"></iframe>
```