### PR TITLE
Revert "A: https://www.forbes.com/sites/sergeiklebnikov/2020/01/06/wa…

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -3270,7 +3270,6 @@
 ||ue696vbd9l.bid^$third-party
 ||ugmfvqsu.ru^
 ||ukp2pool.uk^$third-party
-||unlock-protocol.com^$third-party
 ||unrummaged.com^$third-party
 ||uoldid.ru^
 ||uoldid.ru^$third-party


### PR DESCRIPTION
Hello!

This PR reverts the addition of unlock-protocol.com to the list of trackers.

Unlock is not a tracker and does not collect _any_ personal data about visitors. Our whole code is actually [open source and on github](https://github.com/unlock-protocol/unlock/).

We provide an easy way for creators to monetize their content or features by asserting that their visitors own a "key to the creators' lock". The key is a non-fungible token granted to the visitor if they pay the required amount to the creator.

It's decentralized and permissionless and allows creators to replace ads (which too often come with trackers) or even regular payments systems (which most often means the customer has to disclose personal information) with something that's privacy respectful!

We'd love it if you re-considered!
Thanks