### PR TITLE
A: seedpeer.me

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5494,6 +5494,8 @@ indianexpress.com##.ipad
 investorplace.com##.ipm-sidebar-ad-text
 osbot.org##.ipsWidget_inner
 twitter.com##.is-promoted
+seedpeer.me##.is-success
+seedpeer.me##.is-warning
 telegraph.co.uk##.isaSeason
 veehd.com##.isad
 drivearcade.com,freegamesinc.com##.isk180
@@ -7685,6 +7687,7 @@ foodprocessorsdirect.com##.zoneWidth100
 tomsguide.com,tomshardware.com##.zonepub
 isearch.whitesmoke.com##:not(.item):not(.stats) + * + .item
 sitepoint.com##ADS-WEIGHTED
+seedpeer.me##p:nth-of-type(4)
 justwatch.com##PUBLICATION-BLOCK
 trademe.nz##TM-SPONSOR-LINKS
 youtube.com##YTM-PROMOTED-VIDEO-RENDERER
@@ -9797,6 +9800,7 @@ codeproject.com,indiewire.com##iframe[style][src]
 ! gelbooru.com
 gelbooru.com##.contain-push > .hidden-xs
 gelbooru.com##.contain-push > center > [class]
+seedpeer.me##.content > p
 gelbooru.com##a[href*=".r18."]
 gelbooru.com##a[target="_blank"] > div
 gelbooru.com##a[target="_blank"] > img
@@ -9899,6 +9903,7 @@ moviefone.com##.zergnet
 ign.com##.zergnet-container
 baltimoresun.com,boston.com,calgaryherald.com,capitalgazette.com,carrollcountytimes.com,chicagotribune.com,citypaper.com,courant.com,dailypress.com,deathandtaxesmag.com,edmontonjournal.com,edmunds.com,financialpost.com,gofugyourself.com,hearthhead.com,ign.com,infinitiev.com,latimes.com,leaderpost.com,lolking.net,mcall.com,montrealgazette.com,nasdaq.com,nationalpost.com,orlandosentinel.com,ottawacitizen.com,pcmag.com,ranker.com,sandiegouniontribune.com,saveur.com,sherdog.com,spin.com,sun-sentinel.com,theprovince.com,thestarphoenix.com,timeanddate.com,tmn.today,torontosun.com,twincities.com,vancouversun.com,vibe.com,windsorstar.com,wowhead.com##.zergnet-holder
 gelbooru.com##[href*="adtng.com/"]
+seedpeer.me##[href*="//downloadsafer.com/"]
 broadwayworld.com##[id="outbrain_widget_"]
 revclouds.com##a[href^="http://adtrack123.pl/"]
 flashx.tv##a[href^="http://data.committeemenencyclopedicrepertory.info/"]


### PR DESCRIPTION
**Fake download buttons.**
To reproduce: search for something, click on a link.

**Links to downloadsafer.com**
There are two. One of the bottom of the website on any page, and on torrent page there is a text: "To start this download, you need a free bitTorrent client like µTorrent." And "µTorrent" is a hyperlink which leads to a 404 page on downloadsafer.com, instead of µTorrent's actual website. downloadsafer.com seems pretty shady to me, partly due to the text under the banner: "Powered by Adaware".