### PR TITLE
M: removed rules - made redundant by generic ones

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -93,7 +93,6 @@ mapal.com###ctrlck
 droidchart.com,routerchart.com###cw
 dexigner.com###cwarn
 wsj.com###cx-notification
-dappertogs.co.uk###d-notification-bar
 racquetballwarehouse.com,rogerfederer.com###data_protection
 corso-saunamanufaktur.com,schaeffler.com###dataprotection
 debenhams.com###debCNwrap
@@ -111,7 +110,6 @@ fool.co.uk###dogfish
 aeriagames.com###dp2018dialog
 hetzner.com###dpi-banner
 drupal.org###drupalorg-crosssite-gdpr
-shatter-box.com###elGuestTerms
 live.com,microsoft.com,office.com,skype.com,visualstudio.com,windows.com,xbox.com###epb
 complex.com###eucn
 abetterrouteplanner.com###eula-div
@@ -760,10 +758,6 @@ istockphoto.com#?#.warning:-abp-has([data-cookie-type])
 play.google.com#?#.gb_g:-abp-contains(cookie)
 ! Used with generichide
 msi.com###ccc
-smallseotools.com###cookie-bar
-eteknix.com###cookie-law-info-bar
-depositfiles.com,depositfiles.org,dfiles.eu,dfiles.ru###cookie_popup
-tweaktown.com###cookies_footer_sec
 shirtsofcotton.com###udtDark
 bild.de,welt.de##.as-oil
 icq.com##.ca_wrap


### PR DESCRIPTION
`smallseotools.com###cookie-bar` has been made redundant by `###cookie-bar`

`eteknix.com###cookie-law-info-bar` has been made redundant by `###cookie-law-info-bar`

`depositfiles.com,depositfiles.org,dfiles.eu,dfiles.ru###cookie_popup` has been made redundant by `###cookie_popup`

`tweaktown.com###cookies_footer_sec` has been made redundant by `###cookies_footer_sec`

`dappertogs.co.uk###d-notification-bar` has been made redundant by `###d-notification-bar`

`shatter-box.com###elGuestTerms` has been made redundant by `###elGuestTerms`