### PR TITLE
 M: removed rules - made redundant by generic ones

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -27,11 +27,9 @@ abload.de,autoampel.de,cewe-print.de,dynamo-fanshop.de,elegant.be,firma5.com,liv
 start-nrw.de###cpopup
 ruegenwalder.de###csdialogbd
 ruegenwalder.de###csdialogmd2
-scheune-gluecksburg.de###d-notification-bar
 rentalens.ch###dabar
 interhyp.de###data-protection__layer
 sovd.de###datenschutzfenster
-gehalt.de###datenschutzlayer
 shopwelt.de###dateschutzinfo
 alldent-zahnzentrum.de###dialog
 elektrotresen.de,fliesenoutlet.com,stw.berlin###disclaimer
@@ -48,7 +46,6 @@ gruene-bundestag.de###info_message
 haehnchengrillstation.de,inovartis.eu,kanzlei-mueller-wuppertal.de,lankes-zirndorf.de###infobar
 krombacher.de###js-tracking-notice
 art-studios-inprogress.de###kb-container
-klebetape.de###keksdose
 bioapotheke.de###landing_page_popup
 bmw.de###layerWrapper
 gorreri.de###loggedbar
@@ -407,7 +404,6 @@ ceske-sjezdovky.cz##form[style^="display:block;position: fixed;"]
 movieview.dk###cookie
 gricultureandfood.dk###cookies
 duf.dk###cw
-pricerunner.dk###data-protection-notification
 zueblin.dk###dsgvo
 gartneriraadgivningen.dk###infobar
 udlodningsmidler.dk###lbmodal
@@ -841,7 +837,6 @@ reactor.pl###einfo
 rozwojowiec.pl###fixedBar
 instytutlogopedyczny.pl###flash-msg
 tysol.pl###floatReklama
-atman.pl###gbpl_oba
 eksiegarnia.pl###gora0
 prosto.pl###id-rules
 sosulski.pl###inf
@@ -1101,7 +1096,6 @@ cifempleo.com,ferrovial.com,gaes.es,infodefensa.com,moviles.com,movistarriders.g
 ssangyong.es###eltexto
 salonocasion.com###fb-cd
 shotsdeciencia.com###guacBg8
-ing.es,ingdirect.es###ico_banner
 hora.com.es###ley
 masvision.es###lycok
 paginasamarillas.es###m-notification--bottom


### PR DESCRIPTION
`scheune-gluecksburg.de###d-notification-bar` has been made redundant by `###d-notification-bar`

`pricerunner.dk###data-protection-notification` has been made redundant by `###data-protection-notification`

`gehalt.de###datenschutzlayer` has been made redundant by `###datenschutzlayer`

`atman.pl###gbpl_oba` has been made redundant by `###gbpl_oba`

`ing.es,ingdirect.es###ico_banner` has been made redundant by `###ico_banner`

`klebetape.de###keksdose` has been made redundant by `###keksdose`