### PR TITLE
ced.sascdn.com/tag/*/smart.js$domain=dr.dk

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -663,7 +663,8 @@
 @@||bancodevenezuela.com/imagenes/publicidad/$~third-party
 @@||banki.ru/bitrix/*/advertising.block/$stylesheet
 @@||blocket.se^*/advertisement.js
-@@||ced.sascdn.com/tag/*/smart.js$domain=dr.dk
+! cdn.sascdn.com -> https://github.com/easylist/easylist/issues/4558
+!@@||ced.sascdn.com/tag/*/smart.js$domain=dr.dk
 @@||cloudinary.com/portalbici/advertisements/$domain=portalbici.es
 @@||custojusto.pt/user/myads/$~third-party
 @@||daumcdn.net/adfit/static/ad-native.min.js$domain=daum.net


### PR DESCRIPTION
As mentioned in issue https://github.com/easylist/easylist/issues/4558 there is apperently no longer any needs for whitelisting sascdn on `dr.dk`

But sinece @monzta haven't replied with why he/she have made this whitelisting I'm choosing to only out comment it to begin with