### PR TITLE
P: messaging system breakage, bethesda.net

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -750,7 +750,8 @@ my.games##header > .gdpr
 weatherbug.com##notification-footer
 satispay.com##p[class^="cookie-banner"]
 truecaller.com##span > .max-w-md.shadow-lg
-bethesda.net##visor-alert
+! The rule below breaks messaging system: https://github.com/ryanbr/fanboy-adblock/issues/981
+! bethesda.net##visor-alert
 ! mobile.twitter.com
 mobile.twitter.com###react-root > div > div > .rn-gvpnoh
 mobile.twitter.com##.rn-gvpnoh.rn-eps6nq.rn-13qz1uu


### PR DESCRIPTION
https://github.com/ryanbr/fanboy-adblock/issues/981
https://github.com/ryanbr/fanboy-adblock/issues/1017

Both are referring to the same issue. There are some discussion how to block it properly, but now it's most important just to disable the problematic rule. Instead of removing it, it's better to leave it there as disabled so that no one else won't add it some day, being unaware of problems it causes.