### PR TITLE
M: removed redundant specific hiding rules

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1036,7 +1036,6 @@ modernluxury.com###div-rectangle-1
 modernluxury.com###div-rectangle-2
 articlesnatch.com###div-under-video
 abbotsfordgasprices.com,albertagasprices.com,barriegasprices.com,bcgasprices.com,calgarygasprices.com,edmontongasprices.com,gasbuddy.com,halifaxgasprices.com,hamiltongasprices.com,kwgasprices.com,londongasprices.com,manitobagasprices.com,montrealgasprices.com,newbrunswickgasprices.com,newfoundlandgasprices.com,novascotiagasprices.com,nwtgasprices.com,ontariogasprices.com,ottawagasprices.com,peigasprices.com,quebeccitygasprices.com,quebecgasprices.com,reginagasprices.com,saskatoongasprices.com,saskgasprices.com,torontogasprices.com,vancouvergasprices.com,victoriagasprices.com,winnipeggasprices.com###div728
-streamcloud.eu###divExoLayerWrapper
 klfm967.co.uk###divHeaderBannerRight
 classiccars.com###divLeaderboard
 israelnationalnews.com###divMaavaron2In
@@ -3698,7 +3697,6 @@ alarabiya.net,atlanticfarmfocus.ca,burnsidenews.com,capebretonpost.com,cbncompas
 6abc.com,9news.com.au,abc11.com,abc13.com,abc30.com,abc7.com,abc7chicago.com,abc7news.com,abc7ny.com,ack.net,adelnews.com,advocatepress.com,agjournalonline.com,aledotimesrecord.com,amestrib.com,apalachtimes.com,autofocus.ca,barnstablepatriot.com,bcdemocratonline.com,beautifuldecay.com,bizjournals.com,biznews.com,blueridgenow.com,boonevilledemocrat.com,boston.com,businessinsider.com.au,cantondailyledger.com,capecodtimes.com,carmitimes.com,charlestonexpress.com,cheapism.com,chillicothetimesbulletin.com,chipleypaper.com,cnn.com,columbiadailyherald.com,courier-tribune.com,cpuboss.com,crestviewbulletin.com,dailycomet.com,dailycommercial.com,dailysun.co.za,dailytidings.com,desertdispatch.com,digg.com,dispatch.com,dnainfo.com,doverpost.com,downforeveryoneorjustme.com,driven.co.nz,eastpeoriatimescourier.com,ecr.co.za,electrek.co,engineeringnews.co.za,etcanada.com,examiner-enterprise.com,fayobserver.com,firehouse.com,fosters.com,fowlertribune.com,foxbusiness.com,foxnews.com,funkidslive.com,gadsdentimes.com,gainesville.com,galesburg.com,galvanews.com,geneseorepublic.com,glamour.com,golf.com,goupstate.com,gpuboss.com,greenwooddemocrat.com,hamburgreporter.com,hbr.org,heralddemocrat.com,heraldtribune.com,hockessincommunitynews.com,hollywoodreporter.com,hopestar.com,houmatoday.com,hsvvoice.com,ign.com,intouchweekly.com,jacarandafm.com,jacksonville.com,jdnews.com,journaldemocrat.com,journalstandard.com,kbb.com,kinston.com,komando.com,lajuntatribunedemocrat.com,lincolncourier.com,lonokenews.net,macstories.net,mailtribune.com,mcdonoughvoice.com,middletowntranscript.com,milfordbeacon.com,miningweekly.com,mobilesyrup.com,modernhealthcare.com,moneysense.ca,morningstar.com,mpnnow.com,mtshastanews.com,myfitnesspal.com,naminum.com,nbcnews.com,ncnewspress.com,newbernsj.com,newportindependent.com,news-journalonline.com,newschief.com,newsherald.com,newsrepublican.com,niufm.com,norwichbulletin.com,nwfdailynews.com,nzherald.co.nz,ocala.com,olneydailymail.com,oriongazette.com,paris-express.com,pbcommercial.com,pekintimes.com,picayune-times.com,pjstar.com,poconorecord.com,pontiacdailyleader.com,pressargus.com,pressmentor.com,providencejournal.com,pulaskinews.net,radicalresearch.co.uk,radio531pi.com,recordnet.com,recordonline.com,refinery29.com,reviewatlas.com,ridgecrestca.com,rollingstone.com,rrstar.com,savannahnow.com,scroll.in,scsuntimes.com,seacoastonline.com,seattletimes.com,shelbystar.com,siftingsherald.com,siskiyoudaily.com,sj-r.com,slate.com,sltrib.com,southcoasttoday.com,srpressgazette.com,ssdboss.com,stackexchange.com,starcourier.com,starfl.com,starnewsonline.com,stockhouse.com,stuttgartdailyleader.com,sussexcountian.com,swtimes.com,taftmidwaydriller.com,telegram.com,teutopolispress.com,the-dispatch.com,theaustralian.com.au,thedestinlog.com,thegurdontimes.com,thehawkeye.com,thehindu.com,theledger.com,thelocal.at,thelocal.ch,thelocal.de,thelocal.dk,thelocal.es,thelocal.fr,thelocal.it,thelocal.no,thelocal.se,themercury.com.au,thenewslens.com,thesuntimes.com,thetimesnews.com,thrillist.com,toofab.com,tuscaloosanews.com,vanburencountydem.com,vice.com,vvdailypress.com,waltonsun.com,washingtontimesreporter.com,whitehalljournal.com,wickedlocal.com,woodfordtimes.com,xboxdvr.com,youtube.com,zerohedge.com##.ad-container
 cnet.com##.ad-leader-middle
 faithit.com##.ad-wrapper + .widget-area
-belfasttelegraph.co.uk##.ad.item
 bnqt.com##.ad05
 djhungama.net,famously-dead.com,famouslyarrested.com,famouslyscandalous.com,gamrreview.com,indiatimes.com,lolcounter.com,rodalenews.com,thestandard.com.hk,timesofindia.com,weathernationtv.com,webmaster-source.com##.ad1
 mpog100.com##.ad3
@@ -3781,7 +3779,6 @@ playboy.com##.ads-column > h2
 dailywot.com,girlgames4u.com,roblox.com,spotify.com,xing.com##.ads-container
 gumtree.com##.ads-partner-anyvan
 vdare.com##.ads-vdare
-hitfreegames.com,hwinfo.com,twogag.com##.ads2
 twogag.com##.ads5
 twogag.com##.adsPW
 twogag.com##.adsPW2
@@ -3793,18 +3790,13 @@ smallseotools.com##.adsbygoogle + script + center[id^="img"]
 about.com,bloomberg.com,borfast.com,cdrinfo.com,comesrilanka.com,dpivst.com,howmanyleft.co.uk,instantpulp.com,mysmartprice.com,nintandbox.net,nycity.today,over-blog.com,plurk.com,portugalresident.com,scitechdaily.com,sgentrepreneurs.com,techsupportalert.com,tolonews.com,wikihoops.com,wlds.com##.adsense
 search.b1.org##.adslabel
 animeid.com##.adspl
-cheapies.nz##.adstop
-gamerant.com##.adtester-container
 desertdispatch.com,f1fanatic.co.uk,geeky-gadgets.com,highdesert.com,indiatoday.in,journalgazette.net,lgbtqnation.com,miamitodaynews.com,myrecipes.com,thevoicebw.com,vvdailypress.com,wsj.com##.adtext
 reason.com,rushlimbaugh.com##.adtitle
 ansamed.info,baltic-course.com,carsdirect.com,cbc.ca,cctv.com,cineuropa.org,cpuid.com,facebook.com,flicks.co.nz,futbol24.com,getwapi.com,howstuffworks.com,intoday.in,isearch.omiga-plus.com,jetphotos.com,maritimejobs.com,massappeal.com,mnn.com,mtv.com,mysuncoast.com,newagebd.net,ok.co.uk,ponged.com,prohaircut.com,qone8.com,roadfly.com,rockol.com,runamux.net,search.v9.com,tunemovies.to,ultimate-guitar.com,vh1.com,webssearches.com,zbani.com##.adv
-gsmarena.com##.adv-bottom
 luxury-insider.com##.adv-info
 vidstream.io##.adv-space
 veoh.com##.adv-title
-gsmarena.com##.adv-top
 btn.com##.adv-widget
-bdnews24.com##.adv1
 futbol24.com##.adv2
 prohaircut.com##.adv3
 yesasia.com##.advHr
@@ -3993,7 +3985,6 @@ doubleviking.com,egoallstars.com,egotastic.com,fleshbot.com,lastmenonearth.com,w
 knowyourmeme.com##.aztc
 techspot.com##.azureDiv
 preloaders.net##.b-728
-livejournal.com##.b-adv
 dailyvoice.com,qatarliving.com##.b-banner
 revelist.com##.b-container
 easyvectors.com##.b-footer
@@ -4047,7 +4038,6 @@ ariacharts.com.au,nation.sc,techshout.com##.banner-1
 nation.sc##.banner-2
 dailynewsegypt.com##.banner-250
 nation.sc##.banner-3
-nbcsports.com,onrpg.com,usahealthcareguide.com##.banner-300-250
 alltop.com##.banner-background
 schoolguide.co.za##.banner-bar
 schoolguide.co.za##.banner-bar-bot
@@ -4432,7 +4422,6 @@ karachicorner.com##.bsa180
 karachicorner.com##.bsa300
 karachicorner.com##.bsa336
 twtmore.com##.bsa_wrap
-thedailyvox.co.za##.bsac
 bloggertemplateplace.com##.bsainpost
 mysteriousuniverse.org,wbond.net##.bsap
 easyvectors.com,mangable.com,textmechanic.com,tutorial9.net,webdesign.org,winrumors.com##.bsarocks
@@ -4660,7 +4649,6 @@ intouchweekly.com,newsbtc.com##.content-banner
 crmbuyer.com,ectnews.com,linuxinsider.com,macnewsworld.com,technewsworld.com##.content-block-slinks
 songlyrics.com##.content-bottom-banner
 techrepublic.com##.content-bottom-leaderboard
-techrepublic.com##.content-bottom-mpu
 pcwdld.com##.content-bottom-wrapper
 1049.fm##.content-footer-promo
 pwinsider.com##.content-left
@@ -4680,7 +4668,6 @@ crmbuyer.com,ectnews.com,linuxinsider.com,macnewsworld.com,technewsworld.com##.c
 fijilive.com##.content-top
 futuresmag.com##.content-top-banner
 techrepublic.com,zdnet.com##.content-top-leaderboard
-techrepublic.com##.content-top-mpu
 gizmochina.com,pcwdld.com##.content-top-wrapper
 yellowpages.bw,yellowpages.co.ls,yellowpages.co.zm##.contentBannerHolderLarge
 girlsgogames.com##.contentListSkycontainer
@@ -5230,7 +5217,6 @@ autotrader.co.uk##.gpt-banner--billboard-container
 sportinglife.com##.gpt-container
 dictionary.com##.gpt-content-wrapper
 townhall.com##.gpt-header
-dailypost.co.uk##.gpt-sticky-sidebar
 twentytwowords.com##.gray-fullwidth
 slantmagazine.com##.gray_bg
 slantmagazine.com##.gray_bgBottom
@@ -5275,7 +5261,6 @@ screenindia.com##.hd
 cricfree.sc,cricfree.tv##.hd-head-button
 pbnation.com##.hdrLb
 pbnation.com##.hdrSq
-caymannewsservice.com##.head-banner468
 dnaindia.com##.head-region
 vogue.co.uk##.headFullWidth
 mariopiperni.com,tmrzoo.com##.headbanner
@@ -9805,62 +9790,29 @@ gelbooru.com#?#:-abp-properties(base64)
 ! Site Specific filters (used with $generichide)
 autoevolution.com###\5f wlts
 citationsy.com###aaaaaaaaaa
-googlesyndication.com###adunit
-oregonlive.com###adv_network
 static.adf.ly###container
-upi.com###div-ad-inread
-upi.com###div-ad-top
 idg.com.au###float_leaderboard_bottom
 dospelis.com###frame-holder
-macdailynews.com###header-ads
-arnnet.com.au###leaderboard-bottom-ad
 kenkenpuzzle.com###leaderboard-container
 lifewire.com###leaderboard_2-0
 telecompetitor.com###sidetopbanner
 telecompetitor.com###singlepostbanner
 deadline.com###skin-ad-section
 cinemablend.com###slot_drawer
-mingle2.com###textlink_ads_placeholder
 computerworlduk.com###topLeaderboard > .leaderboard
-mingle2.com###topbannerad
-janjuaplayer.com###video_ads_overdiv
-sctimes.com##.ad-bottom
-standard.co.uk##.ad-center
 nme.com##.ad-container
-universityherald.com##.ad-sample
-uptobox.com##.ad-square
-findthedata.com##.ad-text
 greenbaypressgazette.com,sctimes.com##.ad-wrap-none
-dailymail.co.uk,spanishdict.com##.ad-wrapper
-dailymail.co.uk##.adHolder
-comicbook.com##.ad_blk
 spin.com##.ad_desktop_placeholder
 autoevolution.com##.adcont970
-cinemablend.com##.ads_slot
-tomshardware.com##.adsbox
-afreesms.com,dailymail.co.uk,israellycool.com,mma-core.com,technoshouter.com##.adsbygoogle
-technobuffalo.com##.adspot
-universityherald.com##.adunit_rectangle
 modmy.com##.article-leaderboard
 filecrypt.co##.bams
-wccftech.com##.banner-ad
 samaup.com##.bannernone
 playwire.com##.bolt-ad-container
-menshealth.com##.breaker-ad
-freewarefiles.com##.center-gray-ad-txt
-zippyshare.com##.center_ad
 zdnet.com##.content-bottom-leaderboard
-womenshealthmag.com##.dfp-tag-wrapper
-broadwayworld.com##.ezoic-ad
-wccftech.com##.featured-ad
 last.fm##.full-bleed-ad-container
-nme.com##.header-advert-wrapper
 freewarefiles.com##.homepage_300x600adslot
 courier-journal.com##.inline-share-btn
 computerworlduk.com##.jsAdContainer > #dynamicAd1
-mediafire.com##.lb-ad
-menshealth.com,runnersworld.com,womenshealthmag.com##.leaderboard-ad
-mediafire.com##.lr-ad
 history.com##.m-in-content-ad-row
 ubergizmo.com##.mediumbox_container
 ubergizmo.com##.mediumbox_container_incontent
@@ -9978,7 +9930,6 @@ msn.com##iframe[src="about:blank"]
 ! Bing
 bing.com###b_results > li:not(.b_algo):not(.b_ans):not(.b_pag):not(.aca_algo):not(.aca_algo_count):not(.b_msg)
 bing.com###mm_pla
-bing.com###verticalads
 bing.com##.ad_cvr
 bing.com##.ad_sc
 bing.com##.adbDef


### PR DESCRIPTION
I used an automatic tool: https://abpvn.com/ruleChecker/redundantRuleChecker.html to find redundant rules. The following rules on the left are from this (specific hide) list. All of them have a corresponding generic hiding rule in the generic hiding list, that makes all these specific rules redundant.

`googlesyndication.com###adunit` has been made redundant by `###adunit`

`oregonlive.com###adv_network` has been made redundant by `###adv_network`

`upi.com###div-ad-inread` has been made redundant by `###div-ad-inread`

`upi.com###div-ad-top` has been made redundant by `###div-ad-top`

`streamcloud.eu###divExoLayerWrapper` has been made redundant by `###divExoLayerWrapper`

`macdailynews.com###header-ads` has been made redundant by `###header-ads`

`arnnet.com.au###leaderboard-bottom-ad` has been made redundant by `###leaderboard-bottom-ad`

`mingle2.com###textlink_ads_placeholder` has been made redundant by `###textlink_ads_placeholder`

`mingle2.com###topbannerad` has been made redundant by `###topbannerad`

`bing.com###verticalads` has been made redundant by `###verticalads`

`janjuaplayer.com###video_ads_overdiv` has been made redundant by `###video_ads_overdiv`

`sctimes.com##.ad-bottom` has been made redundant by `##.ad-bottom`

`standard.co.uk##.ad-center` has been made redundant by `##.ad-center`

`universityherald.com##.ad-sample` has been made redundant by `##.ad-sample`

`uptobox.com##.ad-square` has been made redundant by `##.ad-square`

`findthedata.com##.ad-text` has been made redundant by `##.ad-text`

`dailymail.co.uk,spanishdict.com##.ad-wrapper` has been made redundant by `##.ad-wrapper`

`belfasttelegraph.co.uk##.ad.item` has been made redundant by `##.ad.item`

`dailymail.co.uk##.adHolder` has been made redundant by `##.adHolder`

`comicbook.com##.ad_blk` has been made redundant by `##.ad_blk`

`hitfreegames.com,hwinfo.com,twogag.com##.ads2` has been made redundant by `##.ads2`

`cinemablend.com##.ads_slot` has been made redundant by `##.ads_slot`

`tomshardware.com##.adsbox` has been made redundant by `##.adsbox`

`afreesms.com,dailymail.co.uk,israellycool.com,mma-core.com,technoshouter.com##.adsbygoogle` has `
`been made redundant by `##.adsbygoogle`

`technobuffalo.com##.adspot` has been made redundant by `##.adspot`

`cheapies.nz##.adstop` has been made redundant by `##.adstop`

`gamerant.com##.adtester-container` has been made redundant by `##.adtester-container`

`universityherald.com##.adunit_rectangle` has been made redundant by `##.adunit_rectangle`

`gsmarena.com##.adv-bottom` has been made redundant by `##.adv-bottom`

`gsmarena.com##.adv-top` has been made redundant by `##.adv-top`

`bdnews24.com##.adv1` has been made redundant by `##.adv1`

`livejournal.com##.b-adv` has been made redundant by `##.b-adv`

`nbcsports.com,onrpg.com,usahealthcareguide.com##.banner-300-250` has been made redundant by `##.banner-300-250`

`wccftech.com##.banner-ad` has been made redundant by `##.banner-ad`

`menshealth.com##.breaker-ad` has been made redundant by `##.breaker-ad`

`thedailyvox.co.za##.bsac` has been made redundant by `##.bsac`

`freewarefiles.com##.center-gray-ad-txt` has been made redundant by `##.center-gray-ad-txt`

`zippyshare.com##.center_ad` has been made redundant by `##.center_ad`

`techrepublic.com##.content-bottom-mpu` has been made redundant by `##.content-bottom-mpu`

`techrepublic.com##.content-top-mpu` has been made redundant by `##.content-top-mpu`

`womenshealthmag.com##.dfp-tag-wrapper` has been made redundant by `##.dfp-tag-wrapper`

`broadwayworld.com##.ezoic-ad` has been made redundant by `##.ezoic-ad`

`wccftech.com##.featured-ad` has been made redundant by `##.featured-ad`

`dailypost.co.uk##.gpt-sticky-sidebar` has been made redundant by `##.gpt-sticky-sidebar`

`caymannewsservice.com##.head-banner468` has been made redundant by `##.head-banner468`

`nme.com##.header-advert-wrapper` has been made redundant by `##.header-advert-wrapper`

`mediafire.com##.lb-ad` has been made redundant by `##.lb-ad`

`menshealth.com,runnersworld.com,womenshealthmag.com##.leaderboard-ad` has been made redundant by `##.leaderboard-ad`

`mediafire.com##.lr-ad` has been made redundant by `##.lr-ad`