### PR TITLE
M: removed redundant rules

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -93,7 +93,6 @@ mapal.com###ctrlck
 droidchart.com,routerchart.com###cw
 dexigner.com###cwarn
 wsj.com###cx-notification
-dappertogs.co.uk###d-notification-bar
 racquetballwarehouse.com,rogerfederer.com###data_protection
 corso-saunamanufaktur.com,schaeffler.com###dataprotection
 debenhams.com###debCNwrap
@@ -111,7 +110,6 @@ fool.co.uk###dogfish
 aeriagames.com###dp2018dialog
 hetzner.com###dpi-banner
 drupal.org###drupalorg-crosssite-gdpr
-shatter-box.com###elGuestTerms
 live.com,microsoft.com,office.com,skype.com,visualstudio.com,windows.com,xbox.com###epb
 complex.com###eucn
 abetterrouteplanner.com###eula-div
@@ -762,7 +760,7 @@ play.google.com#?#.gb_g:-abp-contains(cookie)
 msi.com###ccc
 smallseotools.com###cookie-bar
 eteknix.com###cookie-law-info-bar
-depositfiles.com,depositfiles.org,dfiles.eu,dfiles.ru###cookie_popup
+depositfiles.com,dfiles.eu,dfiles.ru###cookie_popup
 tweaktown.com###cookies_footer_sec
 shirtsofcotton.com###udtDark
 bild.de,welt.de##.as-oil


### PR DESCRIPTION
`depositfiles.org###cookie_popup` has been made redundant by `###cookie_popup`

`dappertogs.co.uk###d-notification-bar` has been made redundant by `###d-notification-bar`

`shatter-box.com###elGuestTerms` has been made redundant by `###elGuestTerms`

This is a fixed version of my previous request from a couple of days ago. Checked for the usage of generichide. @Khrin