### PR TITLE
M: downdetector Australian / Canadian

### DIFF
--- a/fanboy-addon/fanboy_social_whitelist.txt
+++ b/fanboy-addon/fanboy_social_whitelist.txt
@@ -677,8 +677,8 @@
 @@||allestörungen.at^$generichide
 @@||allestörungen.ch^$generichide
 @@||allestörungen.de^$generichide
-@@||aussieoutages.com^$generichide
-@@||canadianoutages.com^$generichide
+@@||downdetector.com.au^$generichide
+@@||downdetector.ca^$generichide
 @@||downdetctor.cl^$generichide
 @@||downdetector.ae^$generichide
 @@||downdetector.co.nz^$generichide


### PR DESCRIPTION
`@@||aussieoutages.com^$generichide` reddirect to `downdetector.com.au`
`@@||canadianoutages.com^$generichide` reddirect to `downdetector.ca`


both have now incorrect hidden Twitter / Facebook / Instagram / Snapchat monitoring buttons.

---

Optionally, I can restore old domains ending with "`outages.com`"