### PR TITLE
Remove Amplitude's product website

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -125,7 +125,6 @@
 ||amy.gs/track/
 ||analytic.imlive.com^
 ||analytics.adfreetime.com^
-||analytics.amplitude.com^
 ||analytics.archive.org^
 ||analytics.bloomberg.com^
 ||analytics.brave.com^


### PR DESCRIPTION
**Filter affected:**
`||analytics.amplitude.com^`
in [easyprivacy_specific.txt](https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L128)


**1st/3rd-party sites affected:**
https://analytics.amplitude.com


**How is it broken?**
The website and associated APIs are completely blocked.


**Description why it should be removed:**
This is Amplitude's product website and should not be being used for any tracking.

Our event ingestion API is instead under the api.amplitude.com domain which should be covered by this filter: https://github.com/easylist/easylist/blob/d307599f60f309adbad32b5c442027ca376fd6b0/easyprivacy/easyprivacy_trackingservers.txt#L194


In regards to the [issue](https://github.com/uBlockOrigin/uAssets/issues/4649) that caused this filter to be added:
- I will be discussing the privacy concerns with the team responsible for the blog website.
- We will be fixing the Mutiny integration so that it correctly respects the DNT flag (and temporarily disabling it until we do).
- We will be removing the https://analytics.amplitude.com/data/growth/ad-check request.

@ryanbr and @smed79 if you have any other concerns with removing this filter please let me know and I'll do my best to address them.