### PR TITLE
P: post tracking blocked, sporing.posten.no

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -152,6 +152,7 @@
 @@||epub.ekh.no/*/static/analytics.js
 @@||google-analytics.com/analytics.js$domain=tv3play.no
 @@||klpinteraktiv.klp.no^*/Tracking.js?
+@@/tracking/static/js/$script,domain=sporing.posten.no|sporing.bring.no
 ! Polish
 @@||addthisedge.com/live/$xmlhttprequest,domain=serialomaniak.pl
 @@||adobedtm.com^*/satelliteLib-$script,domain=laredoute.pl

--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -152,7 +152,7 @@
 @@||epub.ekh.no/*/static/analytics.js
 @@||google-analytics.com/analytics.js$domain=tv3play.no
 @@||klpinteraktiv.klp.no^*/Tracking.js?
-@@/tracking/static/js/$script,domain=sporing.posten.no|sporing.bring.no
+@@/tracking/static/$domain=sporing.posten.no|sporing.bring.no
 ! Polish
 @@||addthisedge.com/live/$xmlhttprequest,domain=serialomaniak.pl
 @@||adobedtm.com^*/satelliteLib-$script,domain=laredoute.pl


### PR DESCRIPTION
Fixes #4710

Post tracking pages are blanked by Easyprivacy. Blanking depends on which browser is being used. There could be other factors as well. Script and css are at least blocked. After whitelisting them, I noticed a blocked xmlhttprequest.