### PR TITLE
P: disqus comments blocked, aniwatcher.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -122,6 +122,7 @@
 @@||dianomi.com/recirculation.epl?id=$subdocument
 @@||digiads.com.au/css/24032006/adstyle.css
 @@||digiads.com.au/images/shared/misc/ad-disclaimer.gif
+@@||disqus.com/embed.js$script
 @@||doubleclick.net/ddm/$image,domain=aetv.com|fyi.tv|history.com|mylifetime.com|speedtest.net
 @@||doubleclick.net/favicon.ico$image,domain=goal.com
 @@||doubleclick.net/gpt/pubads_impl_$script,domain=accuweather.com|epaper.timesgroup.com|webmd.com


### PR DESCRIPTION
Sample link: https://aniwatcher.com/fate-grand-order-zettai-majuu-sensen-babylonia-episode-14

I made a general whitelist rule because I have strong feeling that this issue could exist on numerous domains.

Issue report: https://github.com/easylist/easylist/issues/4732 (already closed by the user)

Because this could affect many domains, it would be good to fix it asap.

@monzta ?