### PR TITLE
Fix for the radioplus.be website.

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -32,6 +32,7 @@
 @@||tag.aticdn.net^*/smarttag.js$domain=mon.compteczam.fr
 @@||ultimedia.com/api/widget/getwidget/$xmlhttprequest,domain=ouest-france.fr
 @@||vuplay.co.uk/stats/adobe/*/VisitorAPI.js$script,domain=radioplus.be
+@@||cdn.vuplay.co.uk/stats/adobe/*/AppMeasurement.js$script,domain=radioplus.be
 ! Bulgarian
 @@||google-analytics.com/analytics.js$domain=novatv.bg
 ! Chinese


### PR DESCRIPTION
The website radioplus.be does not fucntion correctly if you try to use the player, because the filter /appmeasurement.js is blocking the script https://cdn.vuplay.co.uk/stats/adobe/2.1.0/AppMeasurement.js

I added an exception that allows this script for the website radioplus.be
![fix](https://user-images.githubusercontent.com/3041834/72899761-f499e780-3d26-11ea-843b-9c13dde2b345.png)
