### PR TITLE
Update easyprivacy_general.txt

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5056,7 +5056,7 @@ cgi-bin/counter
 /cmp/messaging.js
 ! Eulerian
 &pagegroup=*&url=$script
-/^https?:\/\/ea\..*\/[a-z0-9]{2,12}\.js/$script,~third-party
+/^https?:\/\/ea\..*\/ea\.js/$script,~third-party
 /^https?:\/\/eulerian..*\/[a-z0-9]{2,12}\.js/$script
 /ajax/eulerian/*
 /eulerian.js


### PR DESCRIPTION
Fixed overly general regex that is breaking Azure's Enterprise Agreement site, ea.azure.com.