### PR TITLE
M: poki cookie element hide, 123pelit.com

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -10996,7 +10996,7 @@
 ##ytd-mealbar-promo-renderer
 ##ytg-notification-footer
 ! poki (https://github.com/ryanbr/fanboy-adblock/issues/1166)
-###app-root.c > .s
+###app-root.c > .z
 ! coches.net / vibbo.com / milanuncios.com / infojobs.net
 ##.sui-CmpUi > .sui-MoleculeNotification
 ! selle-proust.fr / schwabenhaus.de / funnelytics.io


### PR DESCRIPTION
This has changed. So that's why this update.

This is used on many domains, not on just `123pelit.com`

I however wonder if this rule would be better?

`##div#app-root.c > aside`