### PR TITLE
A: generic Alma Media data policy banner block, iltalehti.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -42,6 +42,7 @@
 !
 ! ---------- Finnish ----------
 !
+||cdn.almamedia.fi/script/alma-require/*/require.min.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js
 ||sanoma.fi^*/sccm.js


### PR DESCRIPTION
Alma Media's data policy banner is being hid by these rules:

`##.alma-data-policy-banner`
`###alma-data-policy-banner`

I now added blocking to the script that loads that banner.

List of Alma Media's services: `https://www.almamedia.fi/palvelut/kaikki-palvelut`

(Not every Alma Media's service use this but many do).