### PR TITLE
A: generic cookie note block, sm-mega.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -182,6 +182,7 @@
 /cookie-info.
 /cookie-information.
 /cookie-law-$~script
+/cookie-law-info-public.js
 /cookie-law.js
 /cookie-madeincima.
 /cookie-madeincima/*


### PR DESCRIPTION
Cookie note hid by these rules:

`###cookie_hdr_showagain`
`###cookie-law-info-bar`
`###cookie-law-info-again`
`###cliSettingsPopup`

Added now a generic script to block it.