### PR TITLE
Remove default Material-UI classname

### DIFF
--- a/fanboy-addon/fanboy_annoyance_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_general_hide.txt
@@ -2371,7 +2371,6 @@
 ##[data-target="#newsletter-modal"]
 ##a[title="Daily Email Newsletter"]
 ##div[class*="NewsletterSubscribe_"]
-##div[class^="MuiSnackbar-"]
 ##div[class^="NewsletterForm_"]
 ##div[class^="NewsletterPopup_"]
 ##div[class^="mpp-container-position"]


### PR DESCRIPTION
.div[class^="MuiSnackbar-"] is blocked by Fanboy’s Annoyance List, but it's a class name of a core component of Material-UI. https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt. This library has more than 1m active developers using it, so it's probably affecting millions of end users 

We have seen a similar issue in the past with Material Design Lite: https://forums.lanik.us/viewtopic.php?f=64&t=35849&p=114412&hilit=Snackbar#p114412. 
This issue was first reported on GitHub by three of our users:
 - https://github.com/mui-org/material-ui/issues/19124
 - https://github.com/mui-org/material-ui/issues/19169
- https://github.com/mui-org/material-ui/issues/19564

We think that the rule should be removed from the list. Having the class name in the filter list doesn't help anyways because the other websites can simply patch their script to generate a different, obfuscated name.
To be honest, the snackbar widget isn't particularly intrusive. I don't see why the maintainers wanted to block it in the first place.