### PR TITLE
M: Moved an adserver Easyprivacy -> Easylist

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -676,6 +676,7 @@
 ||adtotal.pl^$third-party
 ||adtpix.com^$third-party
 ||adtrace.org^$third-party
+||adtraction.com^$third-party
 ||adtransfer.net^$third-party
 ||adtrgt.com^$third-party
 ||adtrieval.com^$third-party

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -907,7 +907,6 @@
 ||adten.eu^$third-party
 ||adtlgc.com^$third-party
 ||adtr.io^$third-party
-||adtraction.com^$third-party
 ||bonnieradnetwork.se^$third-party
 ||brandmetrics.com^$third-party
 ||citypaketet.se^$third-party


### PR DESCRIPTION
It's listed under "Swedish" section. But it's headquarters are now in London so it's not "Swedish" anymore in that sense. :D

It can be encountered on this link: https://pakkotoisto.com/

It does connect to a domain that sounds like tracking (track.adtraction.com) but it's probably used for both ads and tracking. It's frontpage on adtraction.com suggests that it's for ads.