### PR TITLE
A: cookie note block, alppimatkat.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -42,6 +42,7 @@
 !
 ! ---------- Finnish ----------
 !
+||alppimatkat.fi/api/*/notifications$xmlhttprequest,domain=alppimatkat.fi
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js
 ||sanoma.fi^*/sccm.js


### PR DESCRIPTION
Here is the link without an asterisk: https://www.alppimatkat.fi/api/v1/notifications

That text on that link speaks only about cookie policy stuff. It has no other functions.