### PR TITLE
A: adserver, ts.fi

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -721,6 +721,7 @@
 ||adsvcs.com^$third-party
 ||adsvert.com^$third-party
 ||adsvids.com^$third-party
+||adswiper.eu^$third-party
 ||adsxgm.com^$third-party
 ||adszom.com^$third-party
 ||adtag.cc^$third-party


### PR DESCRIPTION
These Citymarket images (ads) are loaded from domain adswiper.eu.

![image](https://user-images.githubusercontent.com/17256841/74222287-d3407180-4cbc-11ea-96d1-534287a4f80e.png)


Direct link to an ad sample: https://cdn-1.adswiper.eu/images/958cf588fe324f9a8aebee5d871d817a/8_kirjolohi.jpg