### PR TITLE
P: gigantti.fi

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -64,6 +64,7 @@
 ! Finnish
 @@||adobedtm.com^*/satelliteLib-$script,domain=gigantti.fi
 @@||cnetcontent.com/jsc/h.js$domain=atea.fi
+@@||dynamicyield.com/api/*/api_static.js$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js?$domain=cdon.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi


### PR DESCRIPTION
Test link: https://www.gigantti.fi/catalog/tietokoneet/fi_naytot/naytot

![Näyttökuva (107)](https://user-images.githubusercontent.com/17256841/74477063-3d226c00-4eb3-11ea-836b-0067f2a0b071.png)

dynamicyield.com filter causes breakages. Sorting products according to specific criteria doesn't work, nothing happens. After making this whitelist, sorting according to criteria works.