### PR TITLE
M: power.fi

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -68,7 +68,6 @@
 @@||googletagmanager.com/gtm.js?$domain=cdon.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
-@@||power.fi/Umbraco/Api/Tracking/$xmlhttprequest
 ! Greek
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest


### PR DESCRIPTION
This entry was made because I reported this issue in the past: https://github.com/easylist/easylist/issues/2859

The problem was that Easyprivacy broke order tracking on power.fi. However, order tracking api has been changed now:

![image](https://user-images.githubusercontent.com/17256841/74568149-036b6700-4f80-11ea-9ad8-066c5e488b7b.png)

ordertracking is now orderfollow.

https://www.power.fi/tuki/tilausten-seuranta/ can check on this link. Just write random numbers and random email and click "Hae" (Search).
