### PR TITLE
allow Matomo Wordpress plugin page

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2651,7 +2651,7 @@
 /mat0m0?
 /matomo-tracking.
 /matomo.js$domain=~github.com
-/matomo/*$domain=~github.com|~matomo.org
+/matomo/*$domain=~github.com|~matomo.org|~ps.w.org
 /maxymiser.
 /Maxymiser/*
 /mbcom.tracking.


### PR DESCRIPTION
At the moment, the images on https://wordpress.org/plugins/matomo/ are blocked because they are loaded from `https://ps.w.org/matomo/assets/icon-128x128.png?rev=220678` which matches the rule.