### PR TITLE
M: linkedin.com | cookie notification filter update

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -315,7 +315,7 @@ sunweb.co.uk##.absolute-dialog
 greenfields.eu##.accept-alert
 akeebabackup.com,imunify360.com,luxos.com,reshade.me,v-tac.eu##.activebar-container
 ticketmaster.ca##.agree-terms
-adata.com,ahlulbayt.tv,altervista.org,askdifference.com,asklion.co.uk,bankid.com,cfainstitute.org,convert-my-image.com,costaclub.com,efinancialcareers.com,hattrick.org,kenweego.com,lawyersonline.co.uk,lifescience.net,linkedin.com,lonelyplanet.com,m-a.org.uk,nature.com,netweather.tv,norwegian.com,pozyx.io,supercell.com,theonlinesurgery.co.uk,tindie.com,ukpressonline.co.uk,vernemq.com,viewsonic.com,viewsoniceurope.com,youngsseafood.co.uk##.alert
+adata.com,ahlulbayt.tv,altervista.org,askdifference.com,asklion.co.uk,bankid.com,cfainstitute.org,convert-my-image.com,costaclub.com,efinancialcareers.com,hattrick.org,kenweego.com,lawyersonline.co.uk,lifescience.net,lonelyplanet.com,m-a.org.uk,nature.com,netweather.tv,norwegian.com,pozyx.io,supercell.com,theonlinesurgery.co.uk,tindie.com,ukpressonline.co.uk,vernemq.com,viewsonic.com,viewsoniceurope.com,youngsseafood.co.uk##.alert
 espn.com##.alert--fixed
 goodmorningamerica.com,historicengland.org.uk##.alert-banner
 labour.org.uk##.alert-bar-footer
@@ -765,6 +765,7 @@ my.games##header > .gdpr
 weatherbug.com##notification-footer
 satispay.com##p[class^="cookie-banner"]
 truecaller.com##span > .max-w-md.shadow-lg
+linkedin.com##.global-alert--isExpanded.global-alert--yield.global-alert
 ! mobile.twitter.com
 mobile.twitter.com###react-root > div > div > .rn-gvpnoh
 mobile.twitter.com##.rn-gvpnoh.rn-eps6nq.rn-13qz1uu

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -765,7 +765,7 @@ my.games##header > .gdpr
 weatherbug.com##notification-footer
 satispay.com##p[class^="cookie-banner"]
 truecaller.com##span > .max-w-md.shadow-lg
-linkedin.com##.global-alert--isExpanded.global-alert--yield.global-alert
+linkedin.com##.global-alert
 ! mobile.twitter.com
 mobile.twitter.com###react-root > div > div > .rn-gvpnoh
 mobile.twitter.com##.rn-gvpnoh.rn-eps6nq.rn-13qz1uu


### PR DESCRIPTION
Note! This will only hide the banner that is visible for users not logged in:

![Linkedin ulkona](https://user-images.githubusercontent.com/17256841/75095819-b9970800-55a1-11ea-9636-3e9d6f13b3d4.PNG)

Remade this old pull req https://github.com/easylist/easylist/pull/3277 that is partly redundant. The redundant rule it has is this one: `###global-alert-queue` that is not in use anymore in Linkedin.

That pull req also has this rule `###artdeco-global-alert-container` that is relevant, but it's a bit problematic. It's a filter to hide the cookie banner at the top for logged users, but if it's applied, the top banner will be detached from the top when the site is scrolled down. That's why I would not apply it. (This is occasional problem you probably are aware of). Check the screenshot below:

­
­
­![kuva](https://user-images.githubusercontent.com/17256841/75099579-e9f39c00-55cb-11ea-8633-1a6b7b04e350.png)
