### PR TITLE
P: symbolab.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -276,6 +276,7 @@
 @@||summitracing.com/global/images/bannerads/
 @@||supercartoons.net/ad-preroll.html
 @@||survey.g.doubleclick.net^$script,domain=sporcle.com
+@@||symbolab.com^$generichide
 @@||t.st/files/$script,domain=thestreet.com
 @@||tampermonkey.net^$script,domain=tampermonkey.net
 @@||thefreedictionary.com^$generichide


### PR DESCRIPTION
Fix for adblock detection, sample link: https://www.symbolab.com/solver/functions-calculator/68480%2F%5Cleft(2%2F24%2F365%5Cright)%3D1953518059%2Fx

![](https://user-images.githubusercontent.com/35370833/54316966-3e338500-45e2-11e9-85fe-bb1b1a0153a8.png)

This is already part of Ubo's internal filters but there are in my opinion grounds to add this as part of Easylist as well.

https://github.com/uBlockOrigin/uAssets/issues/5124