### PR TITLE
Delist simply.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -4969,7 +4969,6 @@
 ||silstavo.com^$third-party
 ||simpan.online^$third-party
 ||simpio.com^$third-party
-||simply.com^$third-party
 ||simplyhired.com^$third-party
 ||simvinvo.com^$third-party
 ||sindatontherrom.info^$third-party


### PR DESCRIPTION
We aquired the domain simply.com and are launching a webhosting project on it. However the domain is blocked by you, due to past advertising activity (before we bought it).

Can you delist the domain from your blocklists?