### PR TITLE
Add whitelist for dr.dk/drtv

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -845,3 +845,5 @@ www.google.com#@##videoads
 @@||adservice.com/wp-content/themes/adservice/$~third-party
 @@||publisher.adservice.com^$domain=publisher.adservice.com
 @@||publisher.adservice.com^$generichide
+! dr.dk/drtv
+@@||akamaihd.net^$domain=www.dr.dk


### PR DESCRIPTION
Certain video urls with subtitles are incorrectly blocked.
For example on https://www.dr.dk/drtv/se/ultra-gaming_-bottleflipper-til-doeden-i-fortnite_169470
The HLS video play is blocked
https://drod02m-vh.akamaihd.net/i/all/clear/streaming/ad/5e4a8970af5a6116e80d28ad/Bottleflipper-til-doed_78f14d534b594ab6b4bb371f8dd35a14_,312,476,974,1876,2483,3626,.mp4.csmil/master.m3u8?cc1=name=Dansk~default=no~forced=no~lang=da~uri=https://drod02m-vh.akamaihd.net/p/allx/clear/download/ad/5e4a8970af5a6116e80d28ad/subtitles/HardOfHearing-17187581-2a478cfb-a6f8-4db7-9e8e-51888df0df56/playlist.m3u8
Since the subtitle link contains the url /download/ad/