### PR TITLE
M: https://app.datadoghq.com/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1154,7 +1154,7 @@
 ||loggingapi.spingo.com^
 ||loglady.skypicker.com^
 ||logs-api.shoprunner.com^
-||logs.datadoghq.com^
+||logs.datadoghq.com^$third-party
 ||logs.spilgames.com^
 ||logs.thebloggernetwork.com^
 ||logs.vmixcore.com^


### PR DESCRIPTION
### List the website(s) you're having issues:

https://app.datadoghq.com/logs/livetail

### What happened?

Since [this commit](https://github.com/easylist/easylist/commit/accb36d7e0b0352bd7dd947a3c32b0f97c9b7c63), domain `logs.datadoghq.com` is blocked. But the Datadog website is using the domain `live.logs.datadoghq.com` as an API, so it breaks legitimate user usages.

### List Subscriptions you're using:

easyprivacy

### Suggested change

Block the `logs.datadoghq.com` domain only for third party usages.