### PR TITLE
A: gamefaqs.gamespot.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -813,5 +813,6 @@ mashable.com##.cookie-notice
 allmusic.com##.cookie-policy-box
 rp-online.de##.park-snackbar-cookies
 walmart.ca##.privacy-open > div > [class] > div[class^="css"]
+gamefaqs.gamespot.com###onetrust-consent-sdk
 ! Multi-national sites
 spot-a-shop.at,spot-a-shop.de,spot-a-shop.fi,spot-a-shop.fr,spot-a-shop.pl,spot-a-shop.se###__next > div > div > div[class^="css"]


### PR DESCRIPTION
Cookie hiding rule. Specific rule needed, because gamefaqs.gamespot.com has generichide-filter.