### PR TITLE
A: add a common app-banner script

### DIFF
--- a/fanboy-addon/fanboy_annoyance_general_block.txt
+++ b/fanboy-addon/fanboy_annoyance_general_block.txt
@@ -51,6 +51,7 @@
 /iphoneapp-icon.
 /jquery.androidbanner.js
 /jquery.simplemodal.$script,domain=breakingdefense.com
+/jquery.smartbanner.
 /jquery.snow.js
 /js-mobile-*/header_$script
 /let-it-snow.


### PR DESCRIPTION
According to `https://forums.lanik.us/viewtopic.php?f=23&t=44444` app-banners on mobile sites should be addressed by Annoyances list. This script is quite commonly seen on my browsing e.g.
```{}
https://books.rakuten.co.jp/e-book/?l-id=ipn-header-menu-g101
https://www.livefans.jp/
https://www.swiss.com/
http://tabizine.jp/
```
and I haven't found a problem by blocking it. Of note, AdGuard Annoyances also has been blocking it.