### PR TITLE
Reallow ?type=pageview&

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5055,7 +5055,6 @@
 ?trackGroup=*&referrer=
 ?trackingCategory=
 ?triggertags=
-?type=pageview&
 ?type=performance&
 ?type=ping&$~subdocument
 ?url=*&id=*&res=*&ref=


### PR DESCRIPTION
This breaks some sites that use Zendesk for support.

This rule was added as part of https://github.com/easylist/easylist/commit/ca1225e827cadd4929e1ecc38e4a85dc02f60f3b. I would argue this was added erroneously as it's far too generic a change for the intention of the original commit.