### PR TITLE
M: Admez should be blocked only for .com domain

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -2128,8 +2128,8 @@
 /admeta.
 /admeta/cm?
 /admetamatch?
-/admez.
-/admez/*
+/admez.com
+/admez.com/*
 /admgr.
 /admicro2.
 /admicro_


### PR DESCRIPTION
AdBlock is now blocking my decent page in Czech. I think it should be blocked only for the com domain.

<img width="1679" alt="Snímek obrazovky 2020-04-30 v 9 29 47" src="https://user-images.githubusercontent.com/4738758/80683894-2f00e680-8ac5-11ea-9829-c853acbc9f7d.png">

Historically, only the com version should have been blocked, I think an error occurred:

![Snímek obrazovky 2020-04-30 v 9 31 41](https://user-images.githubusercontent.com/4738758/80684069-67a0c000-8ac5-11ea-8c94-90953814746e.png)

Results: https://github.com/easylist/easylist/search?q=admez&unscoped_q=admez

Thanks!