### PR TITLE
A: https://www.gigaho.com/2018/10/a00098.html

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -678,6 +678,7 @@
 @@||g.doubleclick.net/gampad/ads?$domain=pccomponentes.com
 @@||g.doubleclick.net/gpt/pubads_impl_$script,domain=pccomponentes.com
 @@||gakushuin.ac.jp/ad/common/$~third-party
+@@||gigaho.com^$generichide
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|nettavisen.no|news.tbs.co.jp|rtlnieuws.nl|video.repubblica.it|vlive.tv


### PR DESCRIPTION
https://github.com/easylist/easylist/issues/4863
https://github.com/uBlockOrigin/uAssets/issues/6929

URL: `https://www.gigaho.com/2018/10/a00098.html`
Issue: texts are hidden.

![gigaho1](https://user-images.githubusercontent.com/58900598/81672383-0b567c80-9485-11ea-845f-aafd38d5cfbd.png)

![gigaho2](https://user-images.githubusercontent.com/58900598/81672402-101b3080-9485-11ea-9f79-696d334341d0.png)

This is also an issue that Brave's shield must be turned off regardless of global settings.