### PR TITLE
Remove: honeybadger.io

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1063,7 +1063,6 @@
 ||hivps.xyz^$third-party
 ||hlserve.com^$third-party
 ||hmstats.com^$third-party
-||honeybadger.io^$third-party
 ||hoood.info^$third-party
 ||hopurl.org^$third-party
 ||hospitality-optimizer.com^$third-party


### PR DESCRIPTION
Hey y'all, I emailed with @monzta in 2018 and they removed us from this list once before. Could you remove this entry again? [Honeybadger.io](https://www.honeybadger.io) is an error reporting service for web developers. We also have a strong [anti-tracking policy](https://www.honeybadger.io/do-not-track/) ourselves.

Our customers use our honeybadger.io domain in two ways:

1. Some use our CDN, js.honeybadger.io to serve our [client-side JavaScript error reporting library](https://docs.honeybadger.io/lib/javascript/index.html). Others install this package via NPM.
2. Once installed, our library reports client-side errors to api.honeybadger.io

Both of these operations are currently blocked, which is negatively affecting our customers (especially the second operation: access to api.honeybadger.io).

Could you please remove us again? Thanks!!