### PR TITLE
[FIX] fanboy_social_general_hide remove tag-social rule

### DIFF
--- a/fanboy-addon/fanboy_social_general_hide.txt
+++ b/fanboy-addon/fanboy_social_general_hide.txt
@@ -11477,7 +11477,6 @@
 ##.tab_social
 ##.tafSocialButton
 ##.tag-line-social
-##.tag-social
 ##.tags-share
 ##.talk-sharing__facebook
 ##.talk-sharing__other


### PR DESCRIPTION
This rule was added at a7d474d019e8ed99f as hidding part of
https://www.ibtimes.co.in/ice-age-roundworms-frozen-47000-years-wake-start-eating-if-nothing-happened-776230

This class no longer seems to appear in the given page and may block
wordpress content.
The `<article>` entries on wordpress will have class in the form
`tag-<name>` where `<name>` is the name of the tag used on the article

https://unodieuxconnard.com/2020/05/26/le-monde-dapres-naura-pas-lieu/
has several tags, including one "social", making `<article class="tag-social">`