### PR TITLE
Whitelist bbad.com

### DIFF
--- a/easylist/easylist_whitelist.txt
+++ b/easylist/easylist_whitelist.txt
@@ -52,6 +52,7 @@
 @@||bannersnack.com/banners/$document,subdocument,domain=adventcards.co.uk|charitychristmascards.org|christmascardpacks.co.uk|kingsmead.com|nativitycards.co.uk|printedchristmascards.co.uk
 @@||bannersnack.net^$domain=bannersnack.com
 @@||basinnow.com^*/advertise-$image,domain=basinnow.com
+@@||bbad.com^
 @@||bbc.co.uk^*/adverts.js
 @@||bigfishaudio.com/banners/$image
 @@||blizzardwatch.com^*/bw-ads.js


### PR DESCRIPTION
Hi guys,

I thought I might create this pull request to create an exception for bbad.com. The reason why is because to my knowledge, there's nothing that's malicious nor that tracks its users with ads being run on that domain despite all domains and things named bbad being blocked by EasyList by default. Here's what's being run on that domain:

1. A Discourse instance - bbad.com
2. A Pleroma instance - fediverse.bbad.com
3. Two chats: blab.bbad.com and chat.bbad.com