### PR TITLE
P: como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -77,8 +77,9 @@
 @@||d2wzl9lnvjz3bh.cloudfront.net/frosmo.easy.js$domain=lippu.fi
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
-@@||googletagmanager.com/gtm.js?$domain=cdon.fi
+@@||googletagmanager.com/gtm.js?$domain=cdon.fi|soundi.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
+@@||kiwi45.leiki.com/focus/$script,domain=soundi.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest

--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -77,9 +77,9 @@
 @@||d2wzl9lnvjz3bh.cloudfront.net/frosmo.easy.js$domain=lippu.fi
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
-@@||googletagmanager.com/gtm.js?$domain=cdon.fi|soundi.fi
+@@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
-@@||kiwi45.leiki.com/focus/$script,domain=soundi.fi
+@@||kiwi45.leiki.com/focus/$script,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest


### PR DESCRIPTION
Related articles section after an article is blocked by Easyprivacy.

Sample link: https://www.soundi.fi/uutiset/bruce-springsteen-palasi-livemusiikin-pariin-keskella-pandemiaa-vieraili-kelttipunk-suuruuden-keikalla/

![kuva](https://user-images.githubusercontent.com/17256841/83340338-83bf9900-a2df-11ea-97d6-e52b28c13a0d.png)

Fixed:

![kuva](https://user-images.githubusercontent.com/17256841/83340360-b8335500-a2df-11ea-8ed9-1fbcbf8f17f0.png)

**EDIT**: all those sister sites suffer the same issue.

Sample links:

https://www.como.fi/uutiset/tapani-kansa-tahkoaa-edelleen-massia-firmansa-kera-nousu-100-prosenttia/

https://www.episodi.fi/uutiset/huippuluokan-scifi-toimintaleffa-saa-jatkoa-tv-sarja-luvassa/

https://www.fum.fi/uutiset/ruusut-julkaisi-odotetun-kakkosalbuminsa-kuuntele-se-tasta/

https://www.inferno.fi/uutiset/rockista-on-tullut-perinnemusiikkia-haastattelussa-timo-rautiainen-trio-niskalaukaus/

https://www.rumba.fi/uutiset/spotifyn-top-50-listalla-hammennysta-herattaneen-artistin-kappaleet-poistettu-palvelusta/

https://www.tilt.fi/uutiset/uusien-ps4-pelien-pitaa-olla-ps5-yhteensopivia-tietyn-paivamaaran-jalkeen-onko-muutama-hittipeli-jatetty-ovelasti-paivan-ulkopuolelle/