### PR TITLE
A: terveystalo.com

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -45,6 +45,7 @@
 !
 ! ---------- Finnish ----------
 !
+||analytics-consent-manager.azureedge.net^$third-party
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -45,7 +45,7 @@
 !
 ! ---------- Finnish ----------
 !
-||analytics-consent-manager.azureedge.net^$third-party
+||analytics-consent-manager.azureedge.net^$third-party,domain=terveystalo.com
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -530,35 +530,36 @@ waarmaarraar.nl##div[style="margin: 20px; padding-left:20px; padding-right:20px;
 !
 ! ---------- Finnish ----------
 !
-atea.fi###cookie
-dna.fi###dna-gdpr-info
-kotimaa24.fi###kotimaa-cookie-notification
-telia.fi###lekaneBanner_privacyAnnouncement
-napsu.fi###napsu_cc
-sentraali.fi###popmake-4055
-pihlajalinna.fi###root > div[aria-live="polite"][role="alert"]
 alppimatkat.fi###toast-container
-yhteiso.telia.fi###yhteiso-evasteet
-satakunnanautotalo.fi##.AVS-evasteseloste-container
-kulttuurivihkot.fi##.activebar-container
 americanairlines.fi##.alert
-vismasign.fi##.banner
+atea.fi###cookie
+blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
+dna.fi###dna-gdpr-info
+dplay.fi##div[class^="notification"]
 happypancake.fi##.bar.jsx-341223085
+helmet.fi##.notifier_warning
 hs.fi##.cb-container
-vertaa.fi##.cg-89.cg-97
+ifolor.fi##.dialogBanner--align-bottom
 jenkki.fi##.container-agree
 kitchentime.fi##.cookie
-blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
-ifolor.fi##.dialogBanner--align-bottom
-vr.fi##.headerContents > .infoMessages
-lidl.fi,pelit.fi,telia.fi##.notification
-helmet.fi##.notifier_warning
-suomi24.fi##.s24_cc_banner-wrapper
+kotimaa24.fi###kotimaa-cookie-notification
+kulttuurivihkot.fi##.activebar-container
 lehtodigital.fi##[class^="__ld_cookie_"]
-sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
-vapaasana.swedishforum.net##div[class^="conteneur"][class$="IE"] ~ style ~ div[id]:not([class])
-dplay.fi##div[class^="notification"]
+lidl.fi,pelit.fi,telia.fi##.notification
 linnunrata.org##div[style^="position:fixed;right:0;top:0;"]
+napsu.fi###napsu_cc
+pihlajalinna.fi###root > div[aria-live="polite"][role="alert"]
+satakunnanautotalo.fi##.AVS-evasteseloste-container
+sentraali.fi###popmake-4055
+sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
+suomi24.fi##.s24_cc_banner-wrapper
+telia.fi###lekaneBanner_privacyAnnouncement
+terveystalo.com##.st-consent-banner
+vapaasana.swedishforum.net##div[class^="conteneur"][class$="IE"] ~ style ~ div[id]:not([class])
+vertaa.fi##.cg-89.cg-97
+vismasign.fi##.banner
+vr.fi##.headerContents > .infoMessages
+yhteiso.telia.fi###yhteiso-evasteet
 !
 ! ---------- Greek ----------
 !

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -530,36 +530,36 @@ waarmaarraar.nl##div[style="margin: 20px; padding-left:20px; padding-right:20px;
 !
 ! ---------- Finnish ----------
 !
-alppimatkat.fi###toast-container
-americanairlines.fi##.alert
 atea.fi###cookie
-blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
 dna.fi###dna-gdpr-info
-dplay.fi##div[class^="notification"]
+kotimaa24.fi###kotimaa-cookie-notification
+telia.fi###lekaneBanner_privacyAnnouncement
+napsu.fi###napsu_cc
+sentraali.fi###popmake-4055
+pihlajalinna.fi###root > div[aria-live="polite"][role="alert"]
+alppimatkat.fi###toast-container
+yhteiso.telia.fi###yhteiso-evasteet
+kulttuurivihkot.fi##.activebar-container
+americanairlines.fi##.alert
+satakunnanautotalo.fi##.AVS-evasteseloste-container
+vismasign.fi##.banner
 happypancake.fi##.bar.jsx-341223085
-helmet.fi##.notifier_warning
 hs.fi##.cb-container
-ifolor.fi##.dialogBanner--align-bottom
+vertaa.fi##.cg-89.cg-97
 jenkki.fi##.container-agree
 kitchentime.fi##.cookie
-kotimaa24.fi###kotimaa-cookie-notification
-kulttuurivihkot.fi##.activebar-container
-lehtodigital.fi##[class^="__ld_cookie_"]
-lidl.fi,pelit.fi,telia.fi##.notification
-linnunrata.org##div[style^="position:fixed;right:0;top:0;"]
-napsu.fi###napsu_cc
-pihlajalinna.fi###root > div[aria-live="polite"][role="alert"]
-satakunnanautotalo.fi##.AVS-evasteseloste-container
-sentraali.fi###popmake-4055
-sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
-suomi24.fi##.s24_cc_banner-wrapper
-telia.fi###lekaneBanner_privacyAnnouncement
-terveystalo.com##.st-consent-banner
-vapaasana.swedishforum.net##div[class^="conteneur"][class$="IE"] ~ style ~ div[id]:not([class])
-vertaa.fi##.cg-89.cg-97
-vismasign.fi##.banner
+blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
+ifolor.fi##.dialogBanner--align-bottom
 vr.fi##.headerContents > .infoMessages
-yhteiso.telia.fi###yhteiso-evasteet
+lidl.fi,pelit.fi,telia.fi##.notification
+helmet.fi##.notifier_warning
+suomi24.fi##.s24_cc_banner-wrapper
+terveystalo.com##.st-consent-banner
+lehtodigital.fi##[class^="__ld_cookie_"]
+sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
+vapaasana.swedishforum.net##div[class^="conteneur"][class$="IE"] ~ style ~ div[id]:not([class])
+dplay.fi##div[class^="notification"]
+linnunrata.org##div[style^="position:fixed;right:0;top:0;"]
 !
 ! ---------- Greek ----------
 !


### PR DESCRIPTION
Cookie banner hide & block filters for https://www.terveystalo.com/. Note: I also rearranged Finnish addresses in the hiding list in alphabetical order.

I was at first about to make that network filter general, but it's not in use in any other domains so a specific rule is enough.

https://publicwww.com/websites/%22analytics-consent-manager.azureedge.net%22/