### PR TITLE
P: fix toonippo.co.jp videos

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -153,7 +153,7 @@
 @@||sankei.co.jp/js/analytics/skd.Analysis.js$script
 @@||sanspo.com/parts/chartbeat/$xmlhttprequest
 @@||suumo.jp/sp/js/beacon.js$script,~third-party
-@@||uliza.jp/IF/RequestVideoTag.aspx$script,domain=kobe-np.co.jp
+@@||uliza.jp/IF/RequestVideoTag.aspx$script,domain=kobe-np.co.jp|toonippo.co.jp
 @@||webcdn.stream.ne.jp^*/referrer.js$domain=stream.ne.jp
 ! Korean
 @@||daumcdn.net/tiara/js/v1/tiara.min.js$domain=tv.kakao.com


### PR DESCRIPTION
URL: `https://www.toonippo.co.jp/articles/-/359682`
Issue: video doesn't appear.

![toonippo1](https://user-images.githubusercontent.com/58900598/83405690-07949500-a448-11ea-9cfb-ebef03859f07.png)

![toonippo2](https://user-images.githubusercontent.com/58900598/83405695-0a8f8580-a448-11ea-94c5-c8e6372fa29f.png)

Env: Brave 1.8.96 (its blocker turned off) + uBO 1.27.10 with default filter lists