### PR TITLE
Amended 3 IP-based entries

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -938,10 +938,10 @@
 ||zeroredirect9.com^$popup,third-party
 ||zryydi.com^$popup,third-party
 ! IP addresses
-||130.211.$popup,third-party
-||142.91.$popup,third-party
+||130.211.$popup,third-party,domain=~in-addr.arpa
+||142.91.$popup,third-party,domain=~in-addr.arpa
 ||185.147.34.126^$popup,third-party
-||216.21.13.$popup
+||216.21.13.$popup,domain=~in-addr.arpa
 ||5.45.79.15^$popup
 ! IP Regex (commonly used, hax'd IP addresses)
 /^https?:\/\/(35|104)\.(\d){1,3}\.(\d){1,3}\.(\d){1,3}\//$popup,third-party


### PR DESCRIPTION
I found a small problem in a self-converted version of EasyList wherein `142.91.65.100.in-addr.arpa` was falsely blocked by `||142.91.`.

While I am aware that I've got a pretty weak point on stand on, considering entries with both `$popup` *and* `$third-party` were never meant to be used for broad IP blocking ever, I feel that the risk of blocking reverse lookups remain present even if just under pretty specific circumstances.

To my pleasant surprise, RegEx-based entries (At least those that were not specific) were unaffacted by this, which makes for a decent argument for not converting e.g. `/(https?:\/\/)104\.154\..{100,}/$document` into `://104.154.$document,domain=~in-addr.arpa` after all.