### PR TITLE
P: anna.fi|kaksplus.fi

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -79,7 +79,7 @@
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
-@@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
+@@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest

--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -79,7 +79,7 @@
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
-@@||kiwi45.leiki.com/focus/$script,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
+@@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest


### PR DESCRIPTION
Easyprivacy prevents some articles from appearing.

Sample link: https://anna.fi/hyvinvointi/liikunta/anna-energiaa-livetreeniryhma-treenaa-kotona-liity-nyt

Suosittelemme (Recommended)
Lue myös (Also read)

![kuva](https://user-images.githubusercontent.com/17256841/83536812-687da500-a4fc-11ea-9d34-5627fea650c2.png)

Made a whitelist rule, I also simplied an existing rule as it's not reasonable to have separate rules with different subdomains. (kiwi45.leiki.com, kiwi66.leiki.com).

Edit: also `kaksplus.fi` suffers similar issue. "Suosittelemme" (Recommended) section is missing.

Sample link:

https://www.kaksplus.fi/lifestyle/lapsimessut-peruttiin-kokonaan-talta-vuodelta-ei-viela-ensi-maaliskuussakaan/

Before whitelisting:
![poistettu](https://user-images.githubusercontent.com/17256841/83929638-c92b0d00-a79c-11ea-8ac2-b17ff8583d98.PNG)

After whitelisting:
![takaisin](https://user-images.githubusercontent.com/17256841/83929669-e65fdb80-a79c-11ea-8bac-0e940cfd6f5d.PNG)
