### PR TITLE
M: https://www.portaleducacao.com.br/curso-online-direito-pericia-judicial/p

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2627,7 +2627,7 @@
 ||sealine.pro^$third-party
 ||simility.com^$third-party
 ||spideraf.com^$third-party
-||vtex.com.br^$third-party
+||rc.vtex.com.br^$third-party
 ! Mining
 .1.1.1.l80.js^$third-party
 .n.2.1.js^$third-party


### PR DESCRIPTION
The `vtex.com.br` domain was added in https://github.com/easylist/easylist/commit/9e3b5cef93ab618d6cc8613324d71097a34fdb98, but the only requests with fingerprint have the `rc` subdomain (`rc.vtex.com.br`). Requests in other subdomains don't have privacy issues.