### PR TITLE
P: ksml.fi|savonsanomat.fi

### DIFF
--- a/easyprivacy/easyprivacy_whitelist_international.txt
+++ b/easyprivacy/easyprivacy_whitelist_international.txt
@@ -73,6 +73,7 @@
 @@||optimizely.addmilk.nl^$image,domain=simyo.nl
 ! Finnish
 @@||adobedtm.com^*/satelliteLib-$script,domain=gigantti.fi
+@@||api.cxense.com/public/widget/data?json=$script,domain=ksml.fi|savonsanomat.fi
 @@||cnetcontent.com/jsc/h.js$domain=atea.fi
 @@||d2wzl9lnvjz3bh.cloudfront.net/frosmo.easy.js$domain=lippu.fi
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
@@ -81,6 +82,7 @@
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
 @@||kiwi45.leiki.com/focus/$script,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
+@@||scdn.cxense.com/cx.js$script,domain=ksml.fi|savonsanomat.fi
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest
 @@||cloudvideoplatform.com/scripts/WebAnalytics.js$script


### PR DESCRIPTION
This rule:

`||cxense.com^`

Prevents most read articles section from showing articles.

("Luetuimmat" in Finnish).

https://www.ksml.fi/

![ksml](https://user-images.githubusercontent.com/17256841/83906857-feb80200-a76c-11ea-9871-b4da3b2086e5.PNG)

https://www.savonsanomat.fi/

![Savonsanomat](https://user-images.githubusercontent.com/17256841/83906908-142d2c00-a76d-11ea-8ba7-56809841edb2.PNG)

(Peter Lowe's list suffers the same issue @pgl)