### PR TITLE
P: fix mashingup.jp

### DIFF
--- a/easylist/easylist_whitelist_general_hide.txt
+++ b/easylist/easylist_whitelist_general_hide.txt
@@ -506,7 +506,7 @@ lespac.com#@#.inner_ad
 classifiedads.com#@#.innerad
 gizbrain.com,szlifestyle.com#@#.insert-post-ads
 silveradoss.com#@#.ipsAd
-elektro.info.pl#@#.is-sponsored
+elektro.info.pl,mashingup.jp#@#.is-sponsored
 magazines-download.com#@#.item-ads
 amazinglytimedphotos.com#@#.item-container-ad
 rollingstone.com#@#.js-sticky-ad


### PR DESCRIPTION
URL: `https://www.mashingup.jp/2020/05/citizen_xc_basiccollection_5.html?itm_source=article_link&itm_campaign=https://www.mashingup.jp/2020/05/iges_7_b.html&itm_content=https://www.mashingup.jp/2020/05/citizen_xc_basiccollection_5.html`
Issue: sponsored articles are completely hidden.

![mashingup1](https://user-images.githubusercontent.com/58900598/83943033-bb749680-a833-11ea-9fd0-720a038cbef5.png)

![mashingup2](https://user-images.githubusercontent.com/58900598/83943035-bdd6f080-a833-11ea-9a46-c9e5c5441d84.png)

Env: Brave 1.9.76 (its blocker turned off) + uBO 1.27.10 default lists