### PR TITLE
P: fix simplii.com

### DIFF
--- a/easylist_cookie/easylist_cookie_whitelist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_whitelist_general_hide.txt
@@ -85,7 +85,7 @@ bing.com,czuczu.pl#@#.cc-container
 morningstar.ca#@#.cc_container
 onet.pl#@#.cmp-app_gdpr
 consent.yahoo.com,lawrievetgroup.co.uk,oath.com#@#.consent-container
-consent.yahoo.com,lawrievetgroup.co.uk,payments.amazon.ca,payments.amazon.co.jp,payments.amazon.co.uk,payments.amazon.com,payments.amazon.com.au,payments.amazon.com.br,payments.amazon.de,payments.amazon.es,payments.amazon.fr,payments.amazon.in,payments.amazon.it#@#.consent-wrapper
+consent.yahoo.com,lawrievetgroup.co.uk,simplii.com,payments.amazon.ca,payments.amazon.co.jp,payments.amazon.co.uk,payments.amazon.com,payments.amazon.com.au,payments.amazon.com.br,payments.amazon.de,payments.amazon.es,payments.amazon.fr,payments.amazon.in,payments.amazon.it#@#.consent-wrapper
 boursorama.com,nuxeo.com#@#.cookie-banner
 janrain.com,moemax.de,rituals.com,xxxlshop.de#@#.cookie-bar
 rituals.com#@#.cookie-bar-wrapper


### PR DESCRIPTION
### URL

`https://online.simplii.com/ebm-resources/public/client/web/index.html#/transfers/accounts/add/terms`

You must have a Simplii Financial bank account to access the above URL.

### What happens?

When Fanboy's Annoyance List is enabled, you can't consent to the pre-authorized debit agreement. If you can't consent, then no-fee bank-to-bank money transfers may be completely impossible.

### My settings

I'm using uBO 1.27.10 on Chromium 81 on 32-bit Xubuntu 18.04.4 LTS.  I have Fanboy's Annoyance List enabled, which is the source of the problem.

### Screenshot

![image](https://user-images.githubusercontent.com/10241454/84325493-da7f6b00-ab48-11ea-91c1-f8ede64d34d0.png)

### Conclusion

I thank you for all the effort you put into maintaining your lists!