### PR TITLE
A: Gawker Affiliate Ads

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20154,6 +20154,7 @@
 ##[onclick^="window.open('https://www.brazzersnetwork.com/landing/"]
 ##[onclick^="window.open('window.open('//delivery.trafficfabrik.com/"]
 ##[src^="/Redirect.a2b?"]
+##a[data-ga*="commerce"]
 ##a[data-nvp*="'trafficUrl':'https://paid.outbrain.com/network/redir?"]
 ##a[href$="/vghd.shtml"]
 ##a[href*=".adform.net/"]


### PR DESCRIPTION
Hides sponsored/affiliate sidebar ads on Gawker media properties.