### PR TITLE
A: www.op.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -163,6 +163,7 @@
 /consent-banner-
 /consent-management.js
 /consent-manager.js
+/consent.js
 /consent.min.js?
 /consent/manager/*$script
 /consent/message.js

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -555,6 +555,7 @@ ifolor.fi##.dialogBanner--align-bottom
 vr.fi##.headerContents > .infoMessages
 lidl.fi,pelit.fi,telia.fi##.notification
 helmet.fi##.notifier_warning
+www.op.fi##.ocm-container--banner
 suomi24.fi##.s24_cc_banner-wrapper
 terveystalo.com##.st-consent-banner
 lehtodigital.fi##[class^="__ld_cookie_"]


### PR DESCRIPTION
Cookie banner general blocking rule and a specific hiding rule.

I left "_www_" intentionally to the beginning of the specific rule in order to avoid false positives as the url is very short and "_op_" could be an ending of another domain also.

https://www.op.fi/