### PR TITLE
A: online-convert.com

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -5379,6 +5379,7 @@
 ###pxa-cookie-bar
 ###q-cookie-box
 ###q8-cookie-compliance
+###qg-toast
 ###qPrivacyBanner
 ###qb_cookie_consent_main
 ###qball_co_cookie-footer
@@ -7018,6 +7019,7 @@
 ##.consent-modal__overlay
 ##.consent-panel
 ##.consent-popup
+##.consent-toast
 ##.consent-wrapper
 ##.consent-wrapper-active
 ##.consent.cookies
@@ -10358,6 +10360,7 @@
 ##.qc-cmp-showing
 ##.qc-cmp-ui-container
 ##.qd-cookie-popup
+##.qg-consent
 ##.qni-cookmsg
 ##.qp-cookies-alert
 ##.r-cookie-bar


### PR DESCRIPTION
Cookie banner block, general rule.

https://www.online-convert.com/

Fixes #5549