### PR TITLE
Update easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -7828,6 +7828,7 @@
 ###t7ad
 ###tabAdvertising
 ###table_ads
+###TAdBlockOverlayWrapper
 ###tailResultAd
 ###takeover-ad
 ###takeover_ad


### PR DESCRIPTION
Popup that addresses adblock users with the prompt to disable the adblocker, e.g. on https://www.t-online.de/nachrichten/panorama/buntes-kurioses/id_88073190/zwischen-rheinland-pfalz-und-hessen-kinder-zwingen-ice-lokfuehrer-zu-notbremsung.html