### PR TITLE
P: como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|rytmi.com|soundi.fi|tilt.fi

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -82,10 +82,14 @@
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
+@@||images.sprinklecontent.com/270/170/$image,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|rytmi.com|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
 @@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
+@@||proxy.strossle.it/proxy.html$subdocument,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|rytmi.com|soundi.fi|tilt.fi
 @@||scdn.cxense.com/cx.js$script,domain=ksml.fi|savonsanomat.fi
+@@||widgets.spklw.com/v1/data/$xmlhttprequest,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|rytmi.com|soundi.fi|tilt.fi
+@@||widgets.sprinklecontent.com/v2/$script,xmlhttprequest,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|rytmi.com|soundi.fi|tilt.fi
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest
 @@||cloudvideoplatform.com/scripts/WebAnalytics.js$script


### PR DESCRIPTION
Recommended ("Suosittelemme" in Finnish) articles section after an article is blocked by Easyprivacy.

Sample link:
https://www.soundi.fi/uutiset/bruce-springsteen-palasi-livemusiikin-pariin-keskella-pandemiaa-vieraili-kelttipunk-suuruuden-keikalla/

Before (marked place where that section should be):

![ilman](https://user-images.githubusercontent.com/17256841/83341225-89ba7780-a2e9-11ea-9ff8-1f5330f3ad4c.PNG)

After:

![kuva](https://user-images.githubusercontent.com/17256841/83341227-95a63980-a2e9-11ea-88c5-b71803ded6aa.png)

(Some articles inside the "After" picture are ads, they are visible because I didn't have Easylist enabled.)

All listed sister sites in the title also suffer the same issue.

Sample links:

https://www.como.fi/uutiset/tapani-kansa-tahkoaa-edelleen-massia-firmansa-kera-nousu-100-prosenttia/

https://www.episodi.fi/uutiset/huippuluokan-scifi-toimintaleffa-saa-jatkoa-tv-sarja-luvassa/

https://www.fum.fi/uutiset/ruusut-julkaisi-odotetun-kakkosalbuminsa-kuuntele-se-tasta/

https://www.inferno.fi/uutiset/rockista-on-tullut-perinnemusiikkia-haastattelussa-timo-rautiainen-trio-niskalaukaus/

https://www.rumba.fi/uutiset/spotifyn-top-50-listalla-hammennysta-herattaneen-artistin-kappaleet-poistettu-palvelusta/

http://www.rytmi.com/uutiset/palkittu-blueskonkari-micke-bjorklof-juhlistaa-yhtyeineen-uraansa-25-vuotiskiertueella/

https://www.tilt.fi/uutiset/uusien-ps4-pelien-pitaa-olla-ps5-yhteensopivia-tietyn-paivamaaran-jalkeen-onko-muutama-hittipeli-jatetty-ovelasti-paivan-ulkopuolelle/