### PR TITLE
M: go.trouter.skype.com is not a tracker

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -938,7 +938,6 @@
 ||go.com/capmon/GetDE/?
 ||go.optifuze.com^
 ||go.toutapp.com^$third-party
-||go.trouter.skype.com^
 ||goadv.com^*/track.js
 ||goaww.com/stats.php
 ||godaddy.com/js/gdwebbeacon.js


### PR DESCRIPTION
This is not a telemetry/tracking service but a channel for delivering some backend-to-client notifications.

Various features don't work in Skype on web if blocked: audio/video calls, contact list updates, profile/avatar changes don't appear until manually reloaded etc.