### PR TITLE
Blocked tracking for spot.im

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2221,3 +2221,5 @@
 ||jsrdn.com/s/cs.js
 ! Rewrite to internal resources filters for Adblock Plus
 ||d1z2jf7jlzjs58.cloudfront.net^$rewrite=abp-resource:blank-js,domain=voici.fr
+||spot.im/api/^*/events
+||pix.spot.im/api/^*/pixels


### PR DESCRIPTION
Spot.im is a commenting system implemented on various websites such as foxnews and techcrunch. 