### PR TITLE
P: nettiauto.com|nettikaravaani.com|nettikone.com|nettimokki.com|nettimoto.com|nettivaraosa.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -87,6 +87,7 @@
 @@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 @@||scdn.cxense.com/cx.js$script,domain=ksml.fi|savonsanomat.fi
+@@||script.nettix.fi^*analytics.js$script,domain=nettiauto.com|nettikaravaani.com|nettikone.com|nettimokki.com|nettimoto.com|nettivaraosa.com
 ! Hebrew
 @@||amazonaws.com/static.madlan.co.il/*/heatmap.json?$xmlhttprequest
 @@||cloudvideoplatform.com/scripts/WebAnalytics.js$script


### PR DESCRIPTION
Easyprivacy breaks "Sort according to" function and causes an endless loading screen.

Some screenshots, where to find that function:

![Näyttökuva (2)](https://user-images.githubusercontent.com/17256841/85905452-1cc8cd80-b814-11ea-9b79-a5f14735e465.png)

![nettimokki](https://user-images.githubusercontent.com/17256841/85905677-b5f7e400-b814-11ea-829b-e42462adcd9c.PNG)

![nettikone](https://user-images.githubusercontent.com/17256841/85905683-b98b6b00-b814-11ea-8718-d48555e62e2d.PNG)

(Didn't take multiple screenshots of similar looking "Sort according to" panels, just if they were different. Some sites have a similar panel.)

Sample links:

https://www.nettiauto.com/vaihtoautot?pto=10000&id_country[]=73&sortCol=price&ord=DESC

https://www.nettikaravaani.com/myydaan?pto=8000&sortCol=year&ord=DESC

https://www.nettikone.com/myydaan?pto=6000&id_country[]=73&sortCol=price&ord=DESC

https://www.nettimokki.com/pohjois-pohjanmaa/kuusamo?location=Kuusamo%2C%20Pohjois-Pohjanmaa&offset=1&sorting_list=4&

https://www.nettimoto.com/myydaan?pto=16000&sortCol=enrolldate&ord=DESC

https://www.nettivaraosa.com/haku?pto=7000&sortCol=partcat&ord=DESC