### PR TITLE
P: fix jmedj.co.jp

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -687,6 +687,7 @@
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|nettavisen.no|rtlnieuws.nl|tbs.co.jp|video.repubblica.it|vlive.tv
+@@||jmedj.co.jp/files/$image,~third-party
 @@||kanalfrederikshavn.dk^*/jquery.openx.js?
 @@||koshien-live.net/99/adtag.xml$domain=sportsbull.jp
 @@||krotoszyn.pl/uploads/pub/ads_files/$image,~third-party


### PR DESCRIPTION
URL: `https://www.jmedj.co.jp/`
Issue: Some useful images (e.g. article search, links to back issues of their magazine) are blocked by EasyList rules `files/ad/*` and `banner/ad/*`

![jmedj1](https://user-images.githubusercontent.com/58900598/85935349-c7331480-b92a-11ea-9e8c-63d59958a914.png)

![jmedj2](https://user-images.githubusercontent.com/58900598/85935350-c8644180-b92a-11ea-8969-f4446b38803f.png)

Env: Brave 1.10.97 (own blocker disabled) + uBO 1.27.10 default settings