### PR TITLE
A: www.tori.fi

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -653,8 +653,8 @@
 ||puutarha.net/ffsw-pushcrew.js
 ||puutarha.net/statb.asp
 ||stat.mtv3.fi^
+||tori.fi/img/none.gif$image
 ||ts.fi^*/spring.js
-||www.tori.fi/img/none.gif$image
 ! Greek
 ||skroutz.gr/analytics/
 ||vidads.gr/imp/

--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -654,6 +654,7 @@
 ||puutarha.net/statb.asp
 ||stat.mtv3.fi^
 ||ts.fi^*/spring.js
+||www.tori.fi/img/none.gif$image
 ! Greek
 ||skroutz.gr/analytics/
 ||vidads.gr/imp/


### PR DESCRIPTION
https://www.tori.fi/

Note, I think it's better to retain prefix `www.` in this case because the word `tori` is a general Finnish word that could be used as a suffix in other domain names.

One example: http://keskustori.fi/ (could be more)