### PR TITLE
amp.theguardian.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -148,6 +148,7 @@ windowsreport.com##.ai-attributes
 allkpop.com##.akp2_anchor_scr
 cryptoslate.com##.amfeix
 amp.usatoday.com##.artful-delights
+amp.theguardian.com###ad-undefined
 androidcentral.com,cordcutters.com,crackberry.com,imore.com,windowscentral.com##.article-leaderboard
 forbes.com##.article-speedbump
 alternativeto.net##.atf2


### PR DESCRIPTION
Affected site: 
`https://amp.theguardian.com/environment/2020/jul/09/co2-in-earths-atmosphere-nearing-levels-of-15m-years-ago`