### PR TITLE
P: fix locipo.jp videos

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -689,7 +689,7 @@
 @@||gakushuin.ac.jp/ad/common/$~third-party
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|nettavisen.no|rtlnieuws.nl|tbs.co.jp|video.repubblica.it|vlive.tv
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nettavisen.no|rtlnieuws.nl|tbs.co.jp|video.repubblica.it|vlive.tv
 @@||jmedj.co.jp/files/$image,~third-party
 @@||kanalfrederikshavn.dk^*/jquery.openx.js?
 @@||koshien-live.net/99/adtag.xml$domain=sportsbull.jp


### PR DESCRIPTION
URL: `https://locipo.jp/creative/b8d8898e-b493-42bc-a890-6eb175a47a8e?list=b2b78c58-38c3-4e40-aab3-7ba636cedb4d`
Issue: video can't be played.
Env: Brave 1.10.97 (its blocker turned off) + uBO 1.27.10 default lists + AG JPN
Note: apparently the page itself is not geo-restricted but if I use US VPN I got an error on playing the video.