### PR TITLE
M: cquotient.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -582,7 +582,6 @@
 ||cpmstar.com^$third-party
 ||cpx.to^$third-party
 ||cqcounter.com^$third-party
-||cquotient.com^$third-party
 ||craftkeys.com^$third-party
 ||craktraffic.com^$third-party
 ||crashfootwork.com^$third-party


### PR DESCRIPTION
This domain is used to provide product recommendations for e-commerce sites, like Disney, Kate Spade, Michaels, Gamestop, Under Armor, Pandora, and many others. 

Blocking this domain prevents shopping recommendations from showing up. These are not third party advertisements, these are simply shopping recommendations for products that are sold on the same store that person is currently on.

The recommendations look something like this:
<img width="962" alt="Screen Shot 2020-07-16 at 12 30 15 PM" src="https://user-images.githubusercontent.com/49987929/87698230-339e7800-c761-11ea-9560-d666fd7a2be1.png">
