### PR TITLE
gamespot.com, medium.com, blog.bitsrc.io

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -1154,6 +1154,8 @@ techpp.com##.user-connect-buttons
 gamesrepublic.com##.user-gp
 gamesrepublic.com##.user-tw
 gamesrepublic.com##.user-yt
+gamespot.com##.share--column
+blog.bitsrc.io,medium.com##button > svg[width="29"][height="29"][class="q"]
 aa.com.tr##.ustBar-sosyal
 vanityfair.com##.utilities-top
 activision.com##.utility


### PR DESCRIPTION
I followed what Adguard social media did to solve this. Make necessary changes if required: 
Sites: 
`https://www.gamespot.com/articles/lets-watch-henry-cavill-seductively-build-a-gaming/1100-6479816/`
`https://medium.com/@lucky225/the-twitter-hack-what-exactly-happened-d8740d33c1c`
`https://blog.bitsrc.io/tools-for-consistent-javascript-code-style-56a6e93d75d?source=collection_category---4------5-----------------------`