### PR TITLE
Remove app.launchdarkly.com block

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -265,7 +265,6 @@
 ||api.wipmania.com^
 ||apm-engine.meteor.com^$third-party,xmlhttprequest
 ||app.cdn-cs.com/__t.png?
-||app.launchdarkly.com^
 ||app.link^$third-party
 ||app.opmnstr.com/v2/geolocate/
 ||app.yesware.com/t/$third-party


### PR DESCRIPTION
Hi!

It seems Launchdarkly was blocked in [this commit](https://github.com/easylist/easylist/commit/951cb820f215a981649bc53d29898133f6a1dffd).  

This block happened [once before](https://github.com/easylist/easylist/issues/391) and was rolled back in favor of only blocking [tracking](https://github.com/easylist/easylist/commit/0356394b6210143110e2226018aafbabb5acc3b7) via Launchdarkly.

In short Launchdarkly is a thirty party service one can integrate with to turn certain features on or off. It's not directly tied to ads or  banners and the tracking aspects are completely optional. The newly implemented block will definitely affect some services negatively, since they rely on this to e.g. roll out new features to a subset of users.

ping @ryanbr 