### PR TITLE
P: fix tver.jp video

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -687,7 +687,7 @@
 @@||gakushuin.ac.jp/ad/common/$~third-party
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nettavisen.no|rtlnieuws.nl|tbs.co.jp|tv.rakuten.co.jp|vlive.tv|wtk.pl
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nettavisen.no|rtlnieuws.nl|tbs.co.jp|tv.rakuten.co.jp|tver.jp|vlive.tv|wtk.pl
 @@||jmedj.co.jp/files/$image,~third-party
 @@||kanalfrederikshavn.dk^*/jquery.openx.js?
 @@||koshien-live.net/99/adtag.xml$domain=sportsbull.jp


### PR DESCRIPTION
URL: `https://tver.jp/corner/f0054634`
Issue: video images not shown - only sounds play.
Env: Brave 1.11.101 + uBO 1.27.10 default lists + AGJPN
Steps to reproduce:

1. As the contents is geo-restricted, use Japanese VPN - but it's possible they block some known VPN IPs.
2. If you get this questionnaire, just click "あとで" on to skip it.

![tver1](https://user-images.githubusercontent.com/58900598/88524318-253f3e80-d034-11ea-8bcd-d250caad672c.png)

3. Usually the video automatically starts, but you can of course click the play button if not. Now you'll get only sounds and not movie.

![tver2](https://user-images.githubusercontent.com/58900598/88524496-57e93700-d034-11ea-9500-a69ef86bed9f.png)

It should be:

![tver3](https://user-images.githubusercontent.com/58900598/88524572-7c451380-d034-11ea-925a-9e2786abbadc.png)
