### PR TITLE
A: https://www.takeda.com/ja-jp/ CNAME issue

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -369,6 +369,7 @@
 @@/cdn-cgi/images/trace/captcha/js/h/transparent.gif$image,~third-party
 ! uBO-CNAME (Specific allowlists)
 @@||n8s.jp^$script,domain=nikkei.com
+@@||takeda.com.dxcloud.episerver.net^$domain=takeda.com
 ! facebook related (https://forums.lanik.us/viewtopic.php?f=64&t=43722)
 @@||facebook.com/common/referer_frame.php$subdocument,domain=facebook.com
 @@||messenger.com/common/referer_frame.php$subdocument,domain=messenger.com


### PR DESCRIPTION
URL: `https://www.takeda.com/ja-jp/`
Issue: Broken layout by EasyPrivacy rule `||episerver.net^$third-party` on Firefox + uBO

![takeda](https://user-images.githubusercontent.com/58900598/88916948-eadad900-d2a1-11ea-8569-b78af53319eb.png)

![takeda2](https://user-images.githubusercontent.com/58900598/88917369-9e43cd80-d2a2-11ea-9954-5fcf3bc66e24.png)


Env: Firefox 79.0 + uBO 1.28.4 <strong>+ CleanBrowsing DNS</strong>

With this fix still the rest of episerver trackers are blocked. It's not necessary to allow scripts too for layout but apparently they're necessary for some site function.