### PR TITLE
Remove Nation Media Group specific hide

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5274,7 +5274,7 @@ newsobserver.com##.focus_box
 inquirer.net##.fontgraysmall
 greatbritishlife.co.uk##.foot-banners
 radiozindagi.com##.foot_top
-donegaltv.ie,emergencyemail.org,monitor.co.ug,nation.co.ke,thecitizen.co.tz##.footer
+donegaltv.ie,emergencyemail.org##.footer
 healthcentral.com##.footer--promo
 ksstradio.com,scientificamerican.com,spectator.co.uk##.footer-banner
 directorslive.com##.footer-banner-img


### PR DESCRIPTION
Hi! Will building a new website for Nation.co.ke (for the Nation Media Group), I encountered the issues that our footer (with classname `.footer`) was getting removed by ad blockers. Since this was a hide for previous versions of websites of the Nation Media Group, this can be removed.