### PR TITLE
A: https://gitads.io/

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20801,6 +20801,7 @@
 ##a[href^="https://track.totalav.com/"]
 ##a[href^="https://track.trkinator.com/"]
 ##a[href^="https://track.ultravpn.com/"]
+##a[href^="https://tracking.gitads.io/"]
 ##a[href^="https://tracking.truthfinder.com/?a="]
 ##a[href^="https://trackjs.com/?utm_source"]
 ##a[href^="https://traffic.bannerator.com/"]


### PR DESCRIPTION
Remove links to gitads.io's tracking server.

Example repo containing an ad: https://github.com/acmesh-official/acme.sh/blob/bb7c11adf1c5940990f58b99dc7db9f0e1ab1a1a/README.md