### PR TITLE
A: block akiba-souken.com push notification

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -651,6 +651,7 @@
 @@||tab.gladly.io/newtab/|$document,subdocument
 ! Non-English
 @@||abril.com.br^$generichide
+@@||ad-api-v01.uliza.jp^$script,xmlhttprequest,domain=golfnetwork.co.jp
 @@||ad.atown.jp/adserver/$domain=ad.atown.jp
 @@||adswizz.com/adswizz/js/SynchroClient*.js$script,third-party,domain=esradio.libertaddigital.com
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=abola.pt|gamestar.de|los40.com

--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -651,7 +651,6 @@
 @@||tab.gladly.io/newtab/|$document,subdocument
 ! Non-English
 @@||abril.com.br^$generichide
-@@||ad-api-v01.uliza.jp^$script,xmlhttprequest,domain=golfnetwork.co.jp
 @@||ad.atown.jp/adserver/$domain=ad.atown.jp
 @@||adswizz.com/adswizz/js/SynchroClient*.js$script,third-party,domain=esradio.libertaddigital.com
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=abola.pt|gamestar.de|los40.com

--- a/fanboy-addon/fanboy_notifications_general_block.txt
+++ b/fanboy-addon/fanboy_notifications_general_block.txt
@@ -46,6 +46,7 @@
 /push/subscribe.
 /push_app.js
 /push_newsletter_
+/push_notification.
 /push_notification/*
 /push_notification_
 /push_subscription.


### PR DESCRIPTION
URL: `https://akiba-souken.com/article/46268/`
Issue: push notification not blocked by current rules of Fanboy Annoyances/Notifications Blocking List.

![akiba-souken](https://user-images.githubusercontent.com/58900598/89424640-01d26d00-d773-11ea-8b6c-0257f0378b61.png)

Env: Brave 1.11.104 + uBO 1.28.4 default + Fanboy Annoyances lists