### PR TITLE
M: bing.com

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -296,7 +296,7 @@
 ||bidz.com/contentarea/BidzHomePixel
 ||binaries4all.nl/misc/misc.php?*&url=http
 ||bing.com*^/c.gif?$image
-||bing.com/fd/ls/$~ping
+||bing.com/fd/ls/
 ||bing.com/partner/primedns
 ||bing.com/widget/metrics.js
 ||bing.com^*/GLinkPing.aspx


### PR DESCRIPTION
Remove `$~ping`, beacon tracking is getting through. I use bing pretty regularly & this will not break anything.

```
+11			www.bing.com	1	beacon	https://www.bing.com/fd/ls/lsp.aspx
+4			www.bing.com	1	beacon	https://www.bing.com/fd/ls/lsp.aspx?
+2	/ls.gif?	--	www.bing.com	1	beacon	https://www.bing.com/fd/ls/ls.gif?IG=E5AFB588F44A41F29F84FE11819A60B7&Type=Event.ClientInst&DATA=%7B%22T%22%3A%22CI.Info%22%2C%22TS%22%3A1596650620567%2C%22AppNS%22%3A%22idpfs_1.LB.1_1%22%2C%22K%22%3A%225118.1%22%2C%22Name%22%3A%22ImageViewer%22%2C%22Component%22%3A%22currentimg%22%2C%22url%22%3A%22https%3A%2F%2Fgraphene.limited%2F_Media%2Fhardware_faults-2.jpeg%22%2C%22page%22%3A%22ImageDetailMainImage%22%7D&log=UserEvent
+2	/ls.gif?	--	www.bing.com	1	beacon	https://www.bing.com/fd/ls/ls.gif?IG=E5AFB588F44A41F29F84FE11819A60B7&Type=Event.ClientInst&DATA=%7B%22T%22%3A%22CI.Info%22%2C%22TS%22%3A1596650620223%2C%22AppNS%22%3A%22idpfs_1.LB.1_1%22%2C%22K%22%3A%225070.1%22%2C%22Name%22%3A%22ImageViewer%22%2C%22Component%22%3A%22currentimg%22%2C%22url%22%3A%22https%3A%2F%2Fimagescdn.tweaktown.com%2Fnews%2F5%2F8%2F58847_04_microsoft-builds-ai-hardware-project-brainwave.jpg%22%2C%22page%22%3A%22ImageDetailMainImage%22%7D&log=UserEvent
```

This can be problematic on iOS: https://github.com/AdguardTeam/AdguardFilters/issues/37273