### PR TITLE
Fix breakage on McClatchy sites

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -1,5 +1,6 @@
 @@/build/js/analytics.$script,domain=lx.com|nbcbayarea.com|nbcboston.com|nbcchicago.com|nbcconnecticut.com|nbcdfw.com|nbclosangeles.com|nbcmiami.com|nbcnewyork.com|nbcphiladelphia.com|nbcsandiego.com|nbcwashington.com|necn.com|telemundo40.com|telemundo48elpaso.com|telemundoarizona.com|telemundolasvegas.com|telemundopr.com
 @@/cgi-bin/counter_module?action=list_models$subdocument,~third-party
+@@/yozons-lib/core.js$script,~third-party,domain=bellinghamherald.com|bnd.com|bradenton.com|centredaily.com|charlotteobserver.com|elnuevoherald.com|fresnobee.com|heraldonline.com|heraldsun.com|idahostatesman.com|islandpacket.com|kansas.com|kansascity.com|kentucky.com|ledger-enquirer.com|macon.com|mcclatchydc.com|mercedsunstar.com|miamiherald.com|modbee.com|myrtlebeachonline.com|newsobserver.com|sacbee.com|sanluisobispo.com|star-telegram.com|sunherald.com|thenewstribune.com|theolympian.com|thestate.com|tri-cityherald.com
 @@||1001trackstats.com/api/$xmlhttprequest,domain=songstats.com
 @@||ad.crwdcntrl.net^$script,domain=investopedia.com
 @@||adblockanalytics.com/ads.js|


### PR DESCRIPTION
Without this exception, the script at `https://assets.adobedtm.com/launch-ENe8f70e36bc2f473e93435c31a9a5ba80.min.js` throws an error and deletes the whole body element... 😅 Easy to reproduce in ABP by enabling EasyPrivacy.

![image](https://user-images.githubusercontent.com/16567977/89744300-8e35a600-da79-11ea-84c8-c3355f552430.png)

Fixed in uBo unbreak already: https://github.com/NanoMeow/QuickReports/issues/1477 (since Jul 2019)

Alternatively, you could modify this allow filter `@@||adobedtm.com/launch-$script` to 

```
@@||adobedtm.com/launch-$script,domain=~bellinghamherald.com|~bnd.com|~bradenton.com|~centredaily.com|~charlotteobserver.com|~elnuevoherald.com|~fresnobee.com|~heraldonline.com|~heraldsun.com|~idahostatesman.com|~islandpacket.com|~kansas.com|~kansascity.com|~kentucky.com|~ledger-enquirer.com|~macon.com|~mcclatchydc.com|~mercedsunstar.com|~miamiherald.com|~modbee.com|~myrtlebeachonline.com|~newsobserver.com|~sacbee.com|~sanluisobispo.com|~star-telegram.com|~sunherald.com|~thenewstribune.com|~theolympian.com|~thestate.com|~tri-cityherald.com
```

