### PR TITLE
A: tivi.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -48,7 +48,7 @@
 !
 ! ---------- Finnish ----------
 !
-||cdn.almamedia.fi/almacmp/$script
+||almamedia.fi/almacmp/$script
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -48,6 +48,7 @@
 !
 ! ---------- Finnish ----------
 !
+||cdn.almamedia.fi/almacmp/$script
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js


### PR DESCRIPTION
Alma media's cookie notification block for several websites, such as:

https://www.tivi.fi/
https://www.mikrobitti.fi/
https://www.arvopaperi.fi/

(There are more but those samples are probably enough.)