### PR TITLE
A: address placeholder on 80+ websites e.g. the-history-of-japan.blog…

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20998,6 +20998,7 @@
 ##iframe[src^="http://ad.yieldmanager.com/"]
 ##img[alt^="Fuckbook"]
 ##p[id^="div-gpt-ad-"]
+##pre.ad-code
 ##script[src^="http://free-shoutbox.net/app/webroot/shoutbox/sb.php?shoutbox="] + #freeshoutbox_content
 ##span[data-component-type="s-ads-metrics"]
 ##topadblock


### PR DESCRIPTION
…spot.com

Originally found on this Japanese website `https://the-history-of-japan.blogspot.com/2020/04/2020youtubeup.html` but with Publicwww it turned out this is used by at least 80 international websites (search with "ad-code _ngcontent").

![the-history-of-japan](https://user-images.githubusercontent.com/58900598/90510072-47406280-e195-11ea-813e-a3f2ef39533e.png)

Env: Firefox 79.0 + uBO 1.29.0 default + AdGuard Japanese lists

Note: I kept `pre` just to avoid possible FP.