### PR TITLE
Fix headforpoints.com hrefs

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -6445,7 +6445,7 @@ zippyshare.com##a[href*=".inclk.com/"]
 whatismyreferer.com##a[href*="/?offer_id="]
 itweb.co.za##a[href*="/adclick.php?"]
 benzinga.com,wplift.com##a[href*="/go/"]
-headforpoints.com##a[href*="/hfp/"]
+headforpoints.com##.widget--aside.widget
 sundayworld.co.za##a[href*="/linkout/"]
 spokesman.com##a[href*="/marketing/"]
 movie-censorship.com##a[href*="/out.php?"]


### PR DESCRIPTION
The current filter is too aggressive, and removes text from the main article. I removed the current filter, and added one for the right-hand widget which will remove the ad that was the real target of this rule.  