### PR TITLE
Move pv.pjtsu.com to privacy

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2049,7 +2049,6 @@
 ||pinocularoud.site^
 ||pinresentag.info^
 ||pisism.com^
-||pjtsu.com^
 ||pjx1ky4xhwip.com^
 ||pkhhyool.com^
 ||pkmkkjwknvf.com^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1497,6 +1497,7 @@
 ||pushly.com/pushly-event-tracker
 ||pussy.org^*.cgi?pid=
 ||pussy.org^*/track.php
+||pv.pjtsu.com^
 ||px-cdn.net/*main.min.js
 ||px-cdn.net/api/v2/collector|
 ||px-cdn.net/b/s


### PR DESCRIPTION
pageviews.io is not an adserver, but a pageview counter service.
https://pageviews.io/privacy/ disclosure

pjtsu.com is a hosting internal subdomain that is used by hundreds of
legitimate websites, pv. is just one of them that happens to host a
pageview counter API.

All questions can be directed to support@pressjitsu.com