### PR TITLE
P: fix FP on three JP sites

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -260,7 +260,7 @@ asterisk.org,ifokus.se#@#.ad-sidebar
 wegotads.co.za#@#.ad-source
 10tv.com#@#.ad-square
 speedtest.net#@#.ad-stack
-jobmail.co.za,junkmail.co.za,version2.dk#@#.ad-text
+isewanferry.co.jp,jobmail.co.za,jreu-h.jp,junkmail.co.za,nexco-hoken.co.jp,version2.dk#@#.ad-text
 buccaneers.com,dallascowboys.com,jaguars.com,kcchiefs.com,liveside.net,neworleanssaints.com,patriots.com,philadelphiaeagles.com,seahawks.com,steelers.com,sulekha.com,vikings.com#@#.ad-top
 etonline.com,fool.com,interscope.com#@#.ad-unit
 billboard.com#@#.ad-unit-300-wrapper


### PR DESCRIPTION
URL:
```
https://www.isewanferry.co.jp/
http://jreu-h.jp/
https://www.nexco-hoken.co.jp/
```

Issue: isewanferry and jreu-h: contact info hidden
nexco-hoken: Privacy-mark which is a Japanese certification seal for privacy is hidden.

<details>

  <summary>Screenshots</summary>

![isewanferry1](https://user-images.githubusercontent.com/58900598/91425857-ab9aaa80-e896-11ea-9d7b-52710b689a26.png)

![isewanferry2](https://user-images.githubusercontent.com/58900598/91425870-adfd0480-e896-11ea-85ec-63e7fbe9e045.png)

![jreu-h1](https://user-images.githubusercontent.com/58900598/91425962-cd942d00-e896-11ea-9b2d-680cddb8aaec.png)

![jreu-h2](https://user-images.githubusercontent.com/58900598/91425968-cf5df080-e896-11ea-8f26-9294e66f8f72.png)

![nexco-hoken1](https://user-images.githubusercontent.com/58900598/91425983-d5ec6800-e896-11ea-8a2c-82a53d5126b4.png)

![nexco-hoken2](https://user-images.githubusercontent.com/58900598/91425985-d71d9500-e896-11ea-8549-4af45976793d.png)

</details>

Env: Firefox 79.0 + uBO 1.29.2 default lists and AGJPN