### PR TITLE
P: https://www.velet.jp/ breakage

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -634,6 +634,7 @@
 @@||strangermeetup.com/socket.io/$~third-party
 @@||tabiat.gov.tr/KACMS/Files/ad-$image,~third-party
 @@||valuecommerce.com^$image,domain=pointtown.com
+@@||velet.jp/images/adv/$image,~third-party
 @@||vidgyor.com/live/dai/js/videojs.ads.min.js$script,domain=zeebiz.com
 @@||vitalia.pl/gfx/*reklama$image,domain=diety.wp.pl
 ! Used as an Anti-adblock check


### PR DESCRIPTION
Banners showing suppliers are blocked by an EL rule `/images/adv/*`.

<details>
<summary>Screenshots</summary>

![velet1](https://user-images.githubusercontent.com/58900598/93022991-0c600c00-f627-11ea-840d-a6288bda9f26.png)

![velet2](https://user-images.githubusercontent.com/58900598/93022993-0e29cf80-f627-11ea-93f1-1ea8ed288bfd.png)

</details>