### PR TITLE
P: www.sony.jp can't switch tabs

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -183,8 +183,8 @@
 !---------- Japanese ----------
 !
 @@||a8.net/svt/$image,domain=samplefan.com
-@@||adobedtm.com^*/mbox-contents-$script,domain=fcbarcelona.jp|www.sony.jp
-@@||adobedtm.com^*/satelliteLib-$script,domain=fcbarcelona.jp|radiko.jp|www.sony.jp
+@@||adobedtm.com^*/mbox-contents-$script,domain=fcbarcelona.jp|sony.jp
+@@||adobedtm.com^*/satelliteLib-$script,domain=fcbarcelona.jp|radiko.jp|sony.jp
 @@||allabout.co.jp/mtx_cnt.js$script,~third-party
 @@||analytics.edgekey.net/config/$xmlhttprequest,domain=nhk.or.jp
 @@||analytics.edgekey.net/html5/akamaihtml5-min.js$domain=nhk.or.jp

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -183,8 +183,8 @@
 !---------- Japanese ----------
 !
 @@||a8.net/svt/$image,domain=samplefan.com
-@@||adobedtm.com^*/mbox-contents-$script,domain=fcbarcelona.jp
-@@||adobedtm.com^*/satelliteLib-$script,domain=fcbarcelona.jp|radiko.jp
+@@||adobedtm.com^*/mbox-contents-$script,domain=fcbarcelona.jp|www.sony.jp
+@@||adobedtm.com^*/satelliteLib-$script,domain=fcbarcelona.jp|radiko.jp|www.sony.jp
 @@||allabout.co.jp/mtx_cnt.js$script,~third-party
 @@||analytics.edgekey.net/config/$xmlhttprequest,domain=nhk.or.jp
 @@||analytics.edgekey.net/html5/akamaihtml5-min.js$domain=nhk.or.jp


### PR DESCRIPTION
URL: `https://www.sony.jp/`
Issue: You can't switch tabs on the page:

![sony](https://user-images.githubusercontent.com/58900598/93232987-7c040180-f7b5-11ea-9a4f-7f5e6d13495e.png)

Env: Firefox 80.0.1 + uBO 1.29.2 default lists

Note: another fix is needed on uBlock Unbreak to allow tiqcdn.