### PR TITLE
A: warkaudenlehti.fi (generic Easylist hide)

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -21040,6 +21040,7 @@
 ##div[class^="local-feed-banner-ads"]
 ##div[class^="pane-google-admanager-"]
 ##div[class^="proadszone-"]
+##div[class~="card--native"]
 ##div[data-ad-underplayer]
 ##div[data-adunit-path]
 ##div[data-adunit]


### PR DESCRIPTION
I think this would do as a general rule. 

Sample link: https://www.warkaudenlehti.fi/uutissuomalainen/3106612

![kuva](https://user-images.githubusercontent.com/17256841/93348217-9b933c80-f83e-11ea-9566-553fe32460bd.png)
