### PR TITLE
P: http://kshow123.net/show/the-return-of-superman/episode-357.html p…

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2666,6 +2666,7 @@
 ||fktrlckpmsxx.com^
 ||fkymvojkpdx.com^
 ||flac2flac.xyz^
+||flatepicbats.com^
 ||flatlyforensics.com^
 ||flexknfp.com^
 ||flipy6sudy.com^


### PR DESCRIPTION
…opup ads

URL: `http://kshow123.net/show/the-return-of-superman/episode-357.html`

Issue: popup ads

<details>

![kshow123](https://user-images.githubusercontent.com/58900598/94030258-92830c00-fdf8-11ea-99dc-f2a3fcaee244.png)

</details>

Env: Firefox 80.0.1 + uBO 1.29.2 default + AGJPN + YousList (IDK if it's really a Korean site tho.)