### PR TITLE
A: autouncle.fi (generic Easylist cookie)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -1406,6 +1406,7 @@
 ###cookie-b
 ###cookie-backdrop
 ###cookie-background
+###cookie-background-overlay
 ###cookie-band
 ###cookie-banner
 ###cookie-banner--popup-wrapper


### PR DESCRIPTION
Generic hiding rule.

https://www.autouncle.fi/

For this specific page, it hides a remnant cookie overlay element.