### PR TITLE
P: seura.fi

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -531,7 +531,7 @@ driverscollection.com#@#.mid_ad
 donga.com#@#.middle_AD
 austurfrett.is#@#.middlead
 thenewamerican.com#@#.module-ad
-nationalpost.com,www.msn.com#@#.nativead
+nationalpost.com,seura.fi,www.msn.com#@#.nativead
 eatthis.com#@#.nav-ad
 ziehl-abegg.com#@#.newsAd
 dogva.com#@#.node-ad

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4019,6 +4019,7 @@ mail.google.com##.nH.PS
 laradiofm.com##.narrow_banner
 scroll.in##.native
 bbc.com##.native-promo-button
+seura.fi##.nativead:not(.list)
 animenfo.com##.nav2
 thetechpoint.org##.navigation-banner
 typo3.org##.navigationbanners

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -114,7 +114,7 @@
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
-@@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|soundi.fi|tilt.fi
+@@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|seura.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 @@||nettix.fi^*_analytics.js$domain=nettiauto.com|nettikaravaani.com|nettikone.com|nettimokki.com|nettimoto.com|nettivaraosa.com
 @@||scdn.cxense.com/cx.js$script,domain=ksml.fi|savonsanomat.fi


### PR DESCRIPTION
https://seura.fi/hyvinvointi/vaarantaako-maito-terveyden-laillistettu-ravitsemusterapeutti-vastaa/

Easylist hides articles under "Lisää aiheesta" (More on this topic) section. Those should not be hid.

![kuva](https://user-images.githubusercontent.com/17256841/95661604-4c88b080-0b39-11eb-96d4-35989010f2e8.png)

Also some whitelistings for Easyprivacy are needed as well (added).

Also added a hiding rule to hide nativead elements in a proper way so that non-ads won't be hid.