### PR TITLE
A: https://www.spongepowered.org/

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -401,7 +401,7 @@
 ||speedcafe.com^*-banner-
 ||speedcafe.com^*/partners/
 ||speedvideo.net/img/pla_
-||spongepowered.org^*/assets/img/sponsors/
+||spongepowered.org^*/img/sponsors/
 ||sportpesanews.com/images/promo/
 ||static.tellerium.com^$subdocument
 ||steamanalyst.com/www

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1278,7 +1278,7 @@ dailyhaha.com###spon300
 krillion.com###sponCol
 foreignpolicy.com###spon_reports
 phonescoop.com###sponboxb
-breakingtravelnews.com,compfight.com,europages.co.uk,japanvisitor.com,jewishva.org,mothering.com,progressillinois.com,submarinecablemap.com,telegeography.com,tsn.ca,tvnz.co.nz,wallpapercropper.com,walyou.com,wgr550.com,wsjs.com###sponsor
+breakingtravelnews.com,compfight.com,europages.co.uk,japanvisitor.com,jewishva.org,mothering.com,progressillinois.com,spongepowered.org,submarinecablemap.com,telegeography.com,tsn.ca,tvnz.co.nz,wallpapercropper.com,walyou.com,wgr550.com,wsjs.com###sponsor
 leedsunited.com###sponsor-bar
 opb.org###sponsor-big-default-location
 angloinfo.com###sponsor-box-widget


### PR DESCRIPTION
This amends my changes made in GH-6098 which, while resolving (part)
of the page itself targetted, mistakenly undid other blocks.

Changing
   ||spongepowered.org/assets/img/sponsors/
to
   ||spongepowered.org^*/assets/img/sponsors/
has the unintended consequence of no longer actually blocking the
former.

I also left out blocking `###sponsor`, which blocks the tagline on
the downloads page (I had meant to put this into the previous pr, as
I had it on my uBlock list - I just forgot).

Effectively, the following 3 blocks are now in place for Sponge:
- `||spongepowered.org^*/img/sponsors/` which blocks sponsor images
  on both the homepage and the downloads page
- `spongepowered.org###sponsor` which blocks the sponsor tagline in
  the downloads page.
- `spongepowered.org##.sponsor` which blocks the sponsor advertisement
  on the Ore plugin repository.