### PR TITLE
fix https://wikiwiki.jp/dota2/%E5%88%9D%E5%BF%83%E8%80%85%E3%82%AC%E3…

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -629,6 +629,7 @@
 @@||velet.jp/images/adv/$image,~third-party
 @@||vidgyor.com/live/dai/js/videojs.ads.min.js$script,domain=zeebiz.com
 @@||vitalia.pl/gfx/*reklama$image,domain=diety.wp.pl
+@@||wikiwiki.jp^*/plus/adv.png$~third-party
 ! Used as an Anti-adblock check
 @@||fastly.net/ad/$image,script,xmlhttprequest
 @@||fastly.net/ad2/$image,script,xmlhttprequest


### PR DESCRIPTION
…%82%A4%E3%83%89 advanced-mode button

URL: `https://wikiwiki.jp/dota2/%E5%88%9D%E5%BF%83%E8%80%85%E3%82%AC%E3%82%A4%E3%83%89`
Issue: a button to enter "advanced mode" is blocked by EL.

<details>

![wikiwiki1](https://user-images.githubusercontent.com/58900598/95849448-74228780-0d8a-11eb-8829-f3a00242d818.png)

![wikiwiki2](https://user-images.githubusercontent.com/58900598/95849453-75ec4b00-0d8a-11eb-9de2-502e56484500.png)

![wikiwiki3](https://user-images.githubusercontent.com/58900598/95849459-78e73b80-0d8a-11eb-8219-ff2e44622fae.png)

</details>

Env: Firefox 81.0.1 + uBO 1.30.2 default + AGJPN