### PR TITLE
P: fix iejima.org banner links

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -595,6 +595,7 @@
 @@||gakushuin.ac.jp/ad/common/$~third-party
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
+@@||iejima.org/ad-banner/$image,~third-party
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nettavisen.no|rtlnieuws.nl|sportsport.ba|tbs.co.jp|tv.rakuten.co.jp|tver.jp|vlive.tv|wtk.pl
 @@||ingrossoprofumitester.it/img/ad-profumeria-$image,~third-party
 @@||jmedj.co.jp/files/$image,~third-party

--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -313,6 +313,7 @@ sanmarcosrecord.com#@#.ad_3
 elledecor.com,nydailynews.com,tvland.com#@#.ad_728x90
 globest.com#@#.ad_960
 nirmaltv.com#@#.ad_Right
+iejima.org#@#.ad_banner
 focustaiwan.tw,lavozdegalicia.es#@#.ad_block
 panarmenian.net#@#.ad_body
 joins.com#@#.ad_bottom


### PR DESCRIPTION
URL: `https://www.iejima.org/`
Issue: This is an official home page of a village but banner links to sub pages are blocked by `.org/ad-` in EL.

<details>
<summary>Screenshots</summary>

![iejima1](https://user-images.githubusercontent.com/58900598/96008173-3e5ccc00-0e7a-11eb-8721-d4e81d327ecc.png)

![iejima2](https://user-images.githubusercontent.com/58900598/96008184-41f05300-0e7a-11eb-9605-3e036acf0dc8.png)

![iejima3](https://user-images.githubusercontent.com/58900598/96008193-4452ad00-0e7a-11eb-811a-515a13556847.png)

![iejima4](https://user-images.githubusercontent.com/58900598/96008198-474d9d80-0e7a-11eb-976c-da7626305bd2.png)

</details>

Tested on Firefox 81.0.2 + uBO 1.30.4 default + AGJPN