### PR TITLE
P: fix https://ascii.jp/elem/000/004/030/4030245/ ranking numbers

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -564,6 +564,7 @@
 @@||amebame.com/pub/ads/$image,domain=ameba.jp
 @@||anandabazar.com/js/anandabazar-bootstrap/$script
 @@||api.friends.ponta.jp/api/$~third-party
+@@||ascii.jp/img/ad/yayoi/rank_$image,~third-party
 @@||astatic.ccmbg.com^*/prebid$script,domain=linternaute.com
 @@||bancodevenezuela.com/imagenes/publicidad/$~third-party
 @@||banki.ru/bitrix/*/advertising.block/$stylesheet


### PR DESCRIPTION
URL: `https://ascii.jp/elem/000/004/030/4030245/`
Issue: A minor FP, the number indicator on a ranking widget is blocked by EL:

<details>
<summary>Screenshots</summary>

![ascii1](https://user-images.githubusercontent.com/58900598/96147125-facd9500-0f41-11eb-836f-d2ccfb81f404.png)

![ascii2](https://user-images.githubusercontent.com/58900598/96147133-fbfec200-0f41-11eb-8fd8-af7869ec257c.png)

![ascii3](https://user-images.githubusercontent.com/58900598/96147140-fd2fef00-0f41-11eb-970b-57234d0dff39.png)

</details>

Env: Firefox 81.0.2/uBO 1.30.4 default + AGJPN

Note: originally PRed to regional list: https://github.com/AdguardTeam/AdguardFilters/pull/65635