### PR TITLE
Fix www.jmp.com search

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -330,6 +330,7 @@
 @@||serve-ts.amagi.tv^*/beacon?$xmlhttprequest,domain=watch.truecrimenetworktv.com
 @@||siteapps.caa.co.uk/scripts/plugins/analytics/ga.min.js$script,~third-party
 @@||smartclient.com/smartclient/isomorphic/system/modules/isc_analytics.js$xmlhttprequest
+@@||solr.sas.com/query/$xmlhttprequest,domain=jmp.com
 @@||songza.com/static/*/songza/systems/$script
 @@||sophos.com^*/tracking/gainjectmin.js$script,domain=community.sophos.com
 @@||speakout7eleven.ca^*/Magento_GoogleTagManager/$~third-party


### PR DESCRIPTION
URL: `https://www.jmp.com/ja_jp/search/jmp.html?q=%E7%B5%B1%E8%A8%88` (same results for en_us)
Issue: search results not shown

![jmp1](https://user-images.githubusercontent.com/58900598/96606021-cab33700-1331-11eb-9176-bf0ca1b7e25c.png)

![jmp2](https://user-images.githubusercontent.com/58900598/96606027-cbe46400-1331-11eb-9f67-66d87c0279d0.png)

Env: Firefox 81.0.2 + uBO 1.30.4 default lists