### PR TITLE
P: mobiili.fi

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -494,7 +494,7 @@ forums.digitalspy.com,marketwatch.com,waer.org#@#.has-ad
 minecraftforge.net#@#.hasads
 adexchanger.com,assetbar.com,burningangel.com,donthatethegeek.com,drunkenstepfather.com,intomobile.com,minkch.com,poderpda.com,politicususa.com,seattlepi.com,sfgate.com,startingstrongman.com,thenationonlineng.net,thinkcomputers.org,wccftech.com,wholelifestylenutrition.com#@#.header-ad
 greenbayphoenix.com,photobucket.com#@#.headerAd
-dailytimes.com.pk,swns.com#@#.header_ad
+dailytimes.com.pk,mobiili.fi,swns.com#@#.header_ad
 associatedcontent.com#@#.header_ad_center
 kidzworld.com#@#.header_advert
 plugcomputer.org#@#.headerad

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2906,6 +2906,7 @@ onegreenplanet.org##.header728container
 thelakewoodscoop.com##.headerPromo
 bastropenterprise.com##.headerTop
 maxim.com##.headerTopBar
+mobiili.fi##body[class~="category"] > div * .header_ad
 domainnamewire.com,gaijinpot.com,squidoo.com##.header_banner
 kpopstarz.com##.header_bn
 steadyhealth.com##.headerboard


### PR DESCRIPTION
Hiding this element for the front page https://mobiili.fi/, causes image elements to be attached directly to the top bar which looks ugly and looks like a part of the image is missing.

Screenshot:

![kuva](https://user-images.githubusercontent.com/17256841/97107949-f5efaa80-16d2-11eb-9c93-f636ae8d5d0d.png)

My fix applied:

![kuva](https://user-images.githubusercontent.com/17256841/97107942-e5d7cb00-16d2-11eb-9e83-de0c7d72cd13.png)

However, this element can be hid on subpages without any issues.

Sample page: https://mobiili.fi/category/kayttojarjestelmat/windows/