### PR TITLE
M: https://app.datadoghq.eu/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1165,7 +1165,7 @@
 ||loglady.skypicker.com^
 ||logs-api.shoprunner.com^
 ||logs.datadoghq.com^$domain=~app.datadoghq.com
-||logs.datadoghq.eu^
+||logs.datadoghq.eu^$domain=~app.datadoghq.eu
 ||logs.spilgames.com^
 ||logs.thebloggernetwork.com^
 ||logs.vmixcore.com^


### PR DESCRIPTION
### List the website(s) you're having issues:

https://app.datadoghq.eu/logs/livetail

### What happened?

Since [this commit](https://github.com/easylist/easylist/commit/dc6029beea066465a09f76aa6e61945cbb375430), domain `logs.datadoghq.eu` is blocked. But the Datadog website is using the domain `live.logs.datadoghq.eu` as an API, so it breaks legitimate user usages.

### List Subscriptions you're using:

easyprivacy

### Suggested change

Block the `logs.datadoghq.eu` domain only for third party usages, same as `logs.datadoghq.com`.

Related PR: https://github.com/easylist/easylist/pull/5107