### PR TITLE
P: fix howtonote.jp broken images

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -200,6 +200,7 @@
 @@||disneyplus.disney.co.jp/view/vendor/analytics/$~third-party
 @@||flipdesk.jp/wp/wp-content/themes/flipdesk/images/analytics3.png$image
 @@||googletagmanager.com/gtm.js$script,domain=book.impress.co.jp|sankei.com
+@@||howtonote.jp/google-analytics/$image,~third-party
 @@||in.treasuredata.com/js/*api_key$script,domain=retty.me
 @@||k-img.com/script/analytics/s_code.js$script,domain=kakaku.com
 @@||mediaweaver.jp^$image,domain=ismedia.jp


### PR DESCRIPTION
URL: `https://www.howtonote.jp/google-analytics/setup/index2.html`
Issue: images blocked

<details>
<summary>Screenshots</summary>

![howtonote1](https://user-images.githubusercontent.com/58900598/97809641-6ab57c80-1cb1-11eb-9232-ae12a838ce9d.png)

![howtonote2](https://user-images.githubusercontent.com/58900598/97809644-6c7f4000-1cb1-11eb-9f13-9d65a5014a88.png)

</details>