### PR TITLE
P: fix www.lacoste.com size selection

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -219,6 +219,7 @@
 @@||kbb.com/static/js/global/app-measurement$script
 @@||kentucky.com/mistats/finalizestats.js
 @@||kohls.com/ecustservice/js/sitecatalyst.js$script,~third-party
+@@||lacoste.com/on/demandware.static/*/click-analytics.js$~third-party
 @@||legendstracking.com/js/legends-tracking.js
 @@||lenovo.com/_ui/desktop/common/js/AdobeAnalyticsEvent.js$script,~third-party
 @@||lexus.com/lexus-share/js/tracking_omn/$xmlhttprequest


### PR DESCRIPTION
URL: `https://www.lacoste.com/us/lacoste/men/clothing/jackets-coats/men-s-motion-water-resistant-colorblock-zip-jacket-/BH5316-51.html?color=WBE`
Issue: size selection for wear doesn't work due to `/click-analytics.`:
<details>

![lacoste1](https://user-images.githubusercontent.com/58900598/98387561-e7bb6a00-2094-11eb-9417-8fcee537a045.png)

</details>

Env: Firefox 82.0.2 + uBO 1.30.6 default + AGJPN