### PR TITLE
P: fix https://gotoeat.maff.go.jp/ contact info hidden

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -482,7 +482,7 @@ thestudentroom.co.uk#@#.fixed_ad
 webphunu.net#@#.flash-advertisement
 songlyrics.com#@#.footer-ad
 employmentguide.com#@#.footer-ads
-selectparkhomes.com#@#.footer_ad
+gotoeat.maff.go.jp,selectparkhomes.com#@#.footer_ad
 koopik.com#@#.footerad
 ebayclassifieds.com,guloggratis.dk#@#.gallery-ad
 time.com#@#.google-sponsored


### PR DESCRIPTION
URL: `https://gotoeat.maff.go.jp/`
Issue: Contact info wrongly hidden:

<details>
<summary>Screenshots</summary>

![maff1](https://user-images.githubusercontent.com/58900598/98667119-564c4080-2391-11eb-81d7-e670f6de54c8.png)

![maff2](https://user-images.githubusercontent.com/58900598/98667122-58160400-2391-11eb-93fa-cf72b0348e3c.png)

</details>

Env: Firefox 82.0.3 + uBO 1.30.6 default + AGJPN