### PR TITLE
P: fix https://pyfunceble.readthedocs.io/en/master/configuration/inde…

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -70,7 +70,7 @@ livestrong.com#@##adaptv_ad_player_div
 analogplanet.com,audiostream.com,hometheater.com,innerfidelity.com,shutterbug.com,stereophile.com#@##adbackground
 homeclick.com#@##adbanner
 bplaced.net,explosm.net,pocket-lint.com,tweakguides.com#@##adbar
-adblockplus.org#@##adblock
+adblockplus.org,pyfunceble.readthedocs.io#@##adblock
 amfiindia.com#@##adbody
 2leep.com,landwirt.com,quaintmere.de#@##adbox
 games.com#@##adcode


### PR DESCRIPTION
…x.html description

URL: `https://pyfunceble.readthedocs.io/en/master/configuration/index.html#adblock`
Issue: description of adblock option hidden:

<details>
<summary>Screenshots</summary>

![pyfunceble1](https://user-images.githubusercontent.com/58900598/99062418-542eef80-25e6-11eb-9525-1323d860d389.png)

![pyfunceble2](https://user-images.githubusercontent.com/58900598/99062429-57c27680-25e6-11eb-8059-004d4a950b96.png)


</details>