### PR TITLE
fix https://marshmallow-qa.com/marshmallow Send button

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -193,6 +193,7 @@
 @@||analytics.edgekey.net/ma_library/javascript/javascript_malibrary.js$script,domain=nhk.or.jp
 @@||assets.adobedtm.com^*-librarycode_source.min.js$script,domain=mora.jp
 @@||atwiki.jp/common/_img/spacer.gif?$image,domain=atwiki.jp
+@@||browser.sentry-cdn.com^$domain=marshmallow-qa.com
 @@||carsensor.net/usedcar/modules/clicklog_top_lp_revo.php$xmlhttprequest
 @@||cdn.treasuredata.com/sdk/$script,domain=retty.me
 @@||chancro.jp/assets/lib/googleanalytics-$script


### PR DESCRIPTION
URL: `https://marshmallow-qa.com/marshmallow`
Issue Send (おくる in Japanese) button in comment form doesn't work.

<details>
<summary>Screenshots</summary>

![marshmallow-qa1](https://user-images.githubusercontent.com/58900598/99063126-5fcee600-25e7-11eb-8508-e120167f5a37.png)

![marshmallow-qa2](https://user-images.githubusercontent.com/58900598/99063134-61001300-25e7-11eb-8037-f4ed80a897a2.png)

</details>

Env: Firefox 82.0.3 + uBO 1.30.6 default + AGJPN