### PR TITLE
P: https://ascii.jp/

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -357,6 +357,7 @@ insomnia.gr,kingsinteriors.co.uk,superbikeplanet.com#@#.adlink
 bmwoglasnik.si,clickindia.com#@#.adlist
 find-your-horse.com#@#.admain
 smilelocal.com#@#.admiddle
+ascii.jp#@#.adrect
 tomwans.com#@#.adright
 skatteverket.se#@#.adrow1
 skatteverket.se#@#.adrow2


### PR DESCRIPTION
`##.adrect` hides too many on the page, hiding e.g. Twitter widget.

<details>
<summary>Screenshot</summary>

![ascii](https://user-images.githubusercontent.com/58900598/100335986-f4d6d380-3018-11eb-95d3-20079543e10c.png)

</details>