### PR TITLE
A: https://thegay.com/ NSFW

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -16418,6 +16418,7 @@
 ##.hype_adrotate_widget
 ##.i360ad
 ##.iAdserver
+##.iRx9_wrt
 ##.i_ad
 ##.iab300x250
 ##.iab728x90

--- a/easylist_adult/adult_specific_block.txt
+++ b/easylist_adult/adult_specific_block.txt
@@ -802,6 +802,7 @@
 ||thefappening.wiki^*/promo/
 ||thefappeningblog.com/icloud9.html
 ||thefappeningblog.com/sproject/
+||thegay.com/gagra/
 ||thegay.porn/poppy/
 ||thehun.net^*/banners/
 ||thenewporn.com/js/adpthenewporn

--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -349,7 +349,7 @@ porn555.com##.fel-foot-m
 sss.xxx##.fel-item
 tuberel.com##.fel-list
 tubepornclassic.com##.fel-side
-txxx.com##.fiioed
+thegay.com,txxx.com##.fiioed
 wankerhut.com##.float-right
 gotporn.com##.floater-banner
 xcafe.com##.fluid-b
@@ -575,6 +575,7 @@ h2porn.com##.video-banner
 pornoxo.com##.video-extra-overlay
 boyfriendtv.com##.video-extra-wrapper
 hdporntube.xxx,pornhat.com##.video-link
+thegay.com##.video-page__content > .right
 hardsextube.com,pornhd.com##.video-player-overlay
 japan-whores.com##.video-provider
 alphaporno.com,tubewolf.com##.video-sponsor


### PR DESCRIPTION
Popunder and some placeholder
`##.iRx9_wrt` is very common (e.g. `hclips.com,hdzog.com,tubepornclassic.com,vjav.com` NSFW) so made generic.

<details>
<summary>Screenshots</summary>

![thegay](https://user-images.githubusercontent.com/58900598/100395962-787ad980-3086-11eb-8a4a-6aca18a2344c.png)

![thegay1](https://user-images.githubusercontent.com/58900598/100395963-7a449d00-3086-11eb-833a-7bb4f25aab0e.png)

![thegay2](https://user-images.githubusercontent.com/58900598/100395965-7c0e6080-3086-11eb-81a2-61a6364a4fe8.png)

![thegay3](https://user-images.githubusercontent.com/58900598/100395967-7e70ba80-3086-11eb-97e8-290622761e74.png)

</details>

Env: Firefox 83.0 + uBO 1.31.0 default lists