### PR TITLE
Removed incorrectly added Granify

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1054,7 +1054,6 @@
 ||gostats.ro^$third-party
 ||gotrk.net^$third-party
 ||govmetric.com^$third-party
-||granify.com^$third-party
 ||grapheffect.com^$third-party
 ||gravity4.com^$third-party
 ||grepdata.com^$third-party


### PR DESCRIPTION
Originally added in #3462

<!-- Which filter(s) are causing the issue -->
### Filter affected: 
Privacy Filter

<!-- Example of Broken site -->
### 1st Party sites affected: 
[www.hsn.com](www.hsn.com), plus many other clients

<!-- How is broken? If we visit the site directly whats broken? --> 
### How is it broken? 
Our integrated solution is now blocked from loading. The our initial script is blocked.

<!-- Why should we remove this filter? -->
### Description why it should be removed: 
We run a 1st Party integrated system with our clients. Granify provides valuable site functionality above and beyond "ads". We're internal messaging for the client itself, and being on this ad blocking list is harming the legitimate customer user experience.

Secondly the original site referenced above in #3462 is no longer a client and we are not running on the mentioned site: https://shop.islandcreekoysters.com/

Thanks







