### PR TITLE
remove "bugsnag" from easyprivacy_trackingservers

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -421,7 +421,6 @@
 ||btttag.com^$third-party
 ||bubblestat.com^$third-party
 ||bugherd.com^$third-party
-||bugsnag.com^$third-party
 ||bunchbox.co^$third-party
 ||burstbeacon.com^$third-party
 ||burt.io^$third-party


### PR DESCRIPTION
Reverts 60204319a93cbfce572f99613d562e54e6a767d5.

This is causing our web application (https://app.bugsnag.com) not to work as has been reported by several of our users who use the Opera browser.

<img width="976" alt="Screenshot 2020-12-17 at 17 52 42" src="https://user-images.githubusercontent.com/2514172/102524287-af924880-4090-11eb-98a4-4ed44d640a50.png">

I defer to https://github.com/easylist/easylist/pull/719 for further context and rationale for reverting this entry.

Thanks for maintaining easylist and considering this change.