### PR TITLE
P: https://nba.rakuten.co.jp/videos/3683

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -601,12 +601,13 @@
 @@||fwmrm.net/ad/g/$script,domain=viafree.se
 @@||fwmrm.net^*/LinkTag2.js$domain=viafree.se
 @@||g.doubleclick.net/gampad/ads?$domain=pccomponentes.com
+@@||g.doubleclick.net/gampad/ads?sz=*nba.rakuten.co.jp$xhr,domain=imasdk.googleapis.com
 @@||g.doubleclick.net/gpt/pubads_impl_$script,domain=pccomponentes.com
 @@||gakushuin.ac.jp/ad/common/$~third-party
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|vlive.tv
 @@||iejima.org/ad-banner/$image,~third-party
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nettavisen.no|niusdiario.es|rtlnieuws.nl|sportsport.ba|tbs.co.jp|tv.rakuten.co.jp|tver.jp|vlive.tv|wtk.pl
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|klix.ba|locipo.jp|nba.rakuten.co.jp|nettavisen.no|niusdiario.es|rtlnieuws.nl|sportsport.ba|tbs.co.jp|tv.rakuten.co.jp|tver.jp|vlive.tv|wtk.pl
 @@||ingrossoprofumitester.it/img/ad-profumeria-$image,~third-party
 @@||jmedj.co.jp/files/$image,~third-party
 @@||kanalfrederikshavn.dk^*/jquery.openx.js?

--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -601,7 +601,7 @@
 @@||fwmrm.net/ad/g/$script,domain=viafree.se
 @@||fwmrm.net^*/LinkTag2.js$domain=viafree.se
 @@||g.doubleclick.net/gampad/ads?$domain=pccomponentes.com
-@@||g.doubleclick.net/gampad/ads?sz=*nba.rakuten.co.jp$xhr,domain=imasdk.googleapis.com
+@@||g.doubleclick.net/gampad/ads?sz=*nba.rakuten.co.jp$xmlhttprequest,domain=imasdk.googleapis.com
 @@||g.doubleclick.net/gpt/pubads_impl_$script,domain=pccomponentes.com
 @@||gakushuin.ac.jp/ad/common/$~third-party
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com


### PR DESCRIPTION
URL: `https://nba.rakuten.co.jp/videos/3683`

Issue 1: The page never loads (fixed by `@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=nba.rakuten.co.jp`)

<details>
<summary>Screenshot 1</summary>

![nba1](https://user-images.githubusercontent.com/58900598/102687872-b3ab9b00-4235-11eb-9239-9237fc58c347.png)

</details>

Issue 2: Entering into full screen mode breaks the player (fixed by `@@||g.doubleclick.net/gampad/ads?sz=*nba.rakuten.co.jp$xhr,domain=imasdk.googleapis.com`)

<details>
<summary>Screenshot 2</summary>

![nba2](https://user-images.githubusercontent.com/58900598/102687880-c625d480-4235-11eb-8ed1-80141e068c7b.png)

</details>

Env: Firefox 84.0 / Chrome 87.0.4280.88 + uBO 1.31.0 default + AGJPN

Note: `@@||g.doubleclick.net/gampad/ads?sz=*nba.rakuten.co.jp$xhr,domain=imasdk.googleapis.com` needs to be as specific as this, if you allow `g.doubleclick.net/gampad/ads?slotname=*nba.rakuten.co.jp` it plays streaming ads.