### PR TITLE
M: fix blocking of Matomo docker images

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2813,7 +2813,7 @@
 /matomo-tracking.
 /matomo.js$domain=~github.com
 /matomo.php
-/matomo/*$domain=~github.com|~matomo.org|~wordpress.org
+/matomo/*$third-party,domain=~github.com|~matomo.org|~wordpress.org
 /maxymiser.
 /Maxymiser/*
 /mbcom.tracking.


### PR DESCRIPTION
The current filter rules cause https://hub.docker.com/r/crazymax/matomo/ to show a 404 as the site loads its content from https://hub.docker.com/v2/repositories/crazymax/matomo/ which is blocked by the `/matomo/` rule.