### PR TITLE
Extra ajXXXX.online ad domain.

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -785,6 +785,7 @@
 ||aj1907.online^
 ||aj2073.online^
 ||aj2208.online^
+||aj2234.online^
 ||ajcsjktzlqh.com^
 ||ajjsffefpooknd.com^
 ||ajszcymkv.com^


### PR DESCRIPTION
added aj2234.online, as found serving ads on parianostypos.gr