### PR TITLE
P: https://www.pizzahut.jp/ (fix address search)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -221,6 +221,7 @@
 @@||sanspo.com/parts/chartbeat/$xmlhttprequest
 @@||suumo.jp/sp/js/beacon.js$script,~third-party
 @@||uliza.jp/IF/RequestVideoTag.aspx$script,domain=kobe-np.co.jp|toonippo.co.jp
+@@||useinsider.com/ins.js$domain=pizzahut.jp
 @@||webcdn.stream.ne.jp^*/referrer.js$domain=stream.ne.jp
 @@||yu.xyz.mn/images/event.gif?$image,~third-party
 !


### PR DESCRIPTION
URL: `https://www.pizzahut.jp/`
Issue: address search doesn't properly work.

<details>
<summary>Screenshots</summary>

![pizzahut1](https://user-images.githubusercontent.com/58900598/103410393-59ec8e80-4bae-11eb-8ad8-7edc15d4d2e0.png)

![pizzahut2](https://user-images.githubusercontent.com/58900598/103410399-5fe26f80-4bae-11eb-8e0a-b9d44e38b7b0.png)

</details>

Env: Firefox 84.0.1 + uBO 1.32.5b0 default lists + AGJPN