### PR TITLE
unblock hubspot.com widget

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1139,7 +1139,6 @@
 ||hotjar.io^$third-party
 ||hotlog.ru^$third-party
 ||hs-analytics.net^$third-party
-||hs-scripts.com^$third-party
 ||hsadspixel.net^$third-party
 ||hscta.net^$third-party
 ||htlbid.com^$third-party


### PR DESCRIPTION
according to https://forums.lanik.us/viewtopic.php?p=129155 and https://knowledge.hubspot.com/reports/what-is-the-hs-scripts-embed-code-loading-on-my-website the domain `hs-scripts.com` is OK in terms of privacy. 

It seems that f70f0a77afb598ec5d5584b6b57fa3ae8d30855d was done without too much concern for that even though it even links pastebin with this exact information that this domain/script is OK :)

it's the first line here https://pastebin.com/aFiXQEq1

p.s. I have no affiliation with hubspot I was just trying to include its widget on my website and it was blocked by uBlock