### PR TITLE
P: kauppalehti.fi (videos won't work)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -18,6 +18,7 @@
 @@||bolha.com/js/obj.cookiesPolicy.js
 @@||businessinsider.in/gdpr_js/version-12,minify-1.cms$script,~third-party
 @@||c.evidon.com/sitenotice/evidon-sitenotice-tag.js$script,domain=southpark.de|southparkstudios.nu
+@@||cdn.almamedia.fi/almacmp/*.js$script,domain=kauppalehti.fi
 @@||cdn.cookielaw.org^$script,stylesheet,xmlhttprequest,domain=cnn.com|crfashionbook.com|doctoroz.com|eurogamer.net|gmx.com|mail.com|reuters.com|rockpapershotgun.com|rte.ie|trustpilot.com|tvn24.pl
 @@||chasecdn.com^*/cookie.js$script,domain=chase.com
 @@||civiccomputing.com^*/cookieControl-$script,domain=amplitude.com|msi.com


### PR DESCRIPTION
On kauppalehti.fi videos won't work because cookies have to be accepted first. If not, videos won't load.

Sample link: https://www.kauppalehti.fi/uutiset/kl/5633eb79-0cd4-4f75-8986-50a426517b44

Without whitelisting:
![kuva](https://user-images.githubusercontent.com/17256841/104848409-86faaa00-58ed-11eb-8632-68a18cb6ebc9.png)

Whitelisting applied:
![kuva](https://user-images.githubusercontent.com/17256841/104848443-a85b9600-58ed-11eb-8c52-39a836a6cbe5.png)
