### PR TITLE
M: generic cookie hide filter expansion

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -4407,8 +4407,6 @@
 ###gdpr-cookie-banner
 ###gdpr-cookie-banner-container
 ###gdpr-cookie-block
-###gdpr-cookie-consent
-###gdpr-cookie-consent-popup
 ###gdpr-cookie-footer
 ###gdpr-cookie-info
 ###gdpr-cookie-law
@@ -12068,6 +12066,7 @@
 ##[data-type="cookie-addsense"]
 ##[data-unique-cookie-name]
 ##[data-veci="cookies-policy"]
+##[id*="gdpr-cookie-consent"]
 ##[name="cookie-info"]
 ##[ng-show^="cookiePolicyCtrl"]
 ##[type="cookie-notification"]


### PR DESCRIPTION
Reason: "_gdpr-cookie-consent_" can be used as part of another cookie banner's name.

Sample link: https://www.finlandiatalo.fi/

Name of the cookie banner element on that site:
_##[id="db-gdpr-cookie-consent"]_

I don't know what "db" stands for and I don't think that it's necessary to make a separate filter for it. I think it's better to expand an existing filter. I think that  _##[id*="gdpr-cookie-consent"]_ is safe enough and doesn't produce false positives.