### PR TITLE
M: expansion of 3rd party cookie filter

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -28,7 +28,7 @@
 ||cookieconsent.silktide.com^$third-party
 ||cookiefirst.com^$third-party
 ||cookiehub.net^$third-party
-||cookieinformation.com/*/*.js
+||cookieinformation.com^$script
 ||cookieinformation.com^$subdocument,third-party
 ||cookieinfoscript.com^$third-party
 ||cookielaw.org^$third-party


### PR DESCRIPTION
I think that this filter could be expanded so that it completely covers sites like this: https://www.fazer.fi/ There is now one unblocked cookie script:

![kuva](https://user-images.githubusercontent.com/17256841/105071416-3d48c580-5a8d-11eb-9544-0698d1479618.png)

