### PR TITLE
lecourrier-du-soir.com (content won't load)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -172,3 +172,4 @@
 @@||x-news.pl/bundles/edgexnews/jquery.cookiebar/jquery.cookiebar.js$script
 !
 @@||cdn.privacy-mgmt.com^$subdocument,xmlhttprequest,domain=ekstrabladet.dk|giga.de|manager-magazin.de|spiegel.de|sport1.de|vtm.begmt.com|welt.de
+@@||lecourrier-du-soir.com/wp-content/plugins/uk-cookie-consent/assets/js/uk-cookie-consent-js.js


### PR DESCRIPTION
On lecourrier-du-soir.com, Images won't load because the script lecourrier-du-soir.com/wp-content/plugins/uk-cookie-consent/assets/js/uk-cookie-consent-js.js does'nt load

Sample link: https://lecourrier-du-soir.com/reforme-des-retraites-adopte-en-plein-confinement-ayons-le-courage-de-le-dire-cest-un-coup-detat-contre-le-peuple/

Without whitelisting:
![20210123_01h49_10s_vivaldi_BAUVZKqmNt](https://user-images.githubusercontent.com/47927025/105563307-e86fae00-5d1d-11eb-9c71-0e8f649efac1.png)

Whitelisting applied:
![image](https://user-images.githubusercontent.com/47927025/105563351-12c16b80-5d1e-11eb-8cea-bb56b2c550e5.png)

