### PR TITLE
A: puuilo.fi (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -1,4 +1,4 @@
-@@/Amasty_GdprCookie/$script,domain=eckeroline.fi
+@@/Amasty_GdprCookie/*$domain=eckeroline.fi
 @@/cookie*/jquery.cookie.js$script,~third-party,domain=~albeco.com.pl
 @@/cookie_law/plugin.js$script,~third-party
 @@/zig_cookiepolicybar/*/CookieBar.js$script,~third-party

--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -1,3 +1,4 @@
+@@/Amasty_GdprCookie/$script,domain=eckeroline.fi
 @@/cookie*/jquery.cookie.js$script,~third-party,domain=~albeco.com.pl
 @@/cookie_law/plugin.js$script,~third-party
 @@/zig_cookiepolicybar/*/CookieBar.js$script,~third-party

--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -101,7 +101,7 @@
 /alertcookie.
 /alertcookies.
 /am2-gdpr-public.
-/Amasty_GdprCookie/js/
+/Amasty_GdprCookie/
 /amCookieApproval.
 /amgdpr/*
 /amp-consent-

--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -101,7 +101,7 @@
 /alertcookie.
 /alertcookies.
 /am2-gdpr-public.
-/Amasty_GdprCookie/
+/Amasty_GdprCookie/*
 /amCookieApproval.
 /amgdpr/*
 /amp-consent-

--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -101,6 +101,7 @@
 /alertcookie.
 /alertcookies.
 /am2-gdpr-public.
+/Amasty_GdprCookie/js/
 /amCookieApproval.
 /amgdpr/*
 /amp-consent-


### PR DESCRIPTION
A generic cookie blocking rule.

Sample page: https://www.puuilo.fi/

![kuva](https://user-images.githubusercontent.com/17256841/105641683-183dc380-5e8e-11eb-8433-64f1f81a98b2.png)

Used widely:
https://publicwww.com/websites/Amasty_GdprCookie/

Edit, also added whitelisting for `eckeroline.fi` because blocking this script causes some content not load on the home page.