### PR TITLE
A: serverfault.com, stackexchange.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1837,6 +1837,7 @@ pedestrian.tv##.popular-jobs-widget
 pirateiro.com##.porndudelink
 gsmarena.com##.post + div[style="margin-left: -10px; margin-top: 30px; height: 145px;"]
 wtop.com##.post--sponsored
+serverfault.com,stackexchange.com##.site-header--sponsored:nth-ancestor(1)
 rare.us##.post-block
 mac-forums.com##.postMREC
 thejournal.ie##.postSponsored


### PR DESCRIPTION
* https://meta.stackexchange.com/questions/307861/site-sponsorships-bringing-resources-back-to-stack-exchange
* https://quantumcomputing.meta.stackexchange.com/questions/1/why-does-the-quantum-computing-site-look-different
* https://meta.serverfault.com/questions/9680/octopus-deploy-will-soon-be-sponsoring-server-fault

Arguably, these are "good ads", but allowing those is not in the mission description.