### PR TITLE
P: https://www.sankei.com/politics/news/210127/plt2101270043-n1.html …

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -539,6 +539,7 @@ driverscollection.com#@#.mid_ad
 donga.com#@#.middle_AD
 austurfrett.is#@#.middlead
 thenewamerican.com#@#.module-ad
+sankei.com#@#.module_ad
 nationalpost.com,seura.fi,www.msn.com#@#.nativead
 eatthis.com#@#.nav-ad
 ziehl-abegg.com#@#.newsAd


### PR DESCRIPTION
…(fixes subscription links)
`https://www.sankei.com/politics/news/210127/plt2101270043-n1.html`
`##.module_ad` hides bit too much on the page, hidding links to subscribe their newspaper:

<details>
<summary>Screenshot</summary>

![sankei](https://user-images.githubusercontent.com/58900598/106007223-699dbb00-60f9-11eb-9b52-029bb7831c52.png)

</details>