### PR TITLE
P: https://t.pia.jp/pia/ticketInformation.do?eventCd=2033857&rlsCd=001

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -220,6 +220,7 @@
 @@||mediaweaver.jp^$image,domain=ismedia.jp
 @@||nihongo.alc.co.jp/theme/Japanese/img/home/nf/us.gif$image,~third-party
 @@||ovp.piksel.com/ipLookup.php$xmlhttprequest,domain=nhk.or.jp
+@@||probance.jp/webtrax/public/probance_tracker.js$domain=t.pia.jp
 @@||sankei.co.jp/js/analytics/skd.Analysis.js$script
 @@||sanspo.com/parts/chartbeat/$xmlhttprequest
 @@||suumo.jp/sp/js/beacon.js$script,~third-party


### PR DESCRIPTION
`https://t.pia.jp/pia/ticketInformation.do?eventCd=2033857&rlsCd=001`
Issue: button to buy tickets not shown due to `/probance_tracker.`:

<details>
<summary>Screenshots</summary>

![pia1](https://user-images.githubusercontent.com/58900598/106266764-2e6fc900-626c-11eb-84eb-662afd07c764.png)

![pia2](https://user-images.githubusercontent.com/58900598/106266768-2fa0f600-626c-11eb-8d4e-e3274f942724.png)

</details>