### PR TITLE
P: (nsfw) https://javynow.com/

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -637,6 +637,7 @@ express.de,focus.de#@#.trc_related_container div[data-item-syndicated="true"]
 yahoo.com#@#.type_ads_default
 wingsbirdpro.com#@#.vertical-ads
 youtube.com#@#.video-ads
+javynow.com#@#.videos-ad
 vinden.se#@#.view_ad
 nytimes.com,nytimes3xbfgragh.onion#@#.wideAd
 britannica.com,cam4.com#@#.withAds

--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -550,6 +550,7 @@ clip16.com##.video-spots
 pornhub.com,pornhubthbh7ap3u.onion##.video-wrapper > #player + [class]
 h2porn.com##.video_banner
 indianpornvideos.com##.videoads
+javynow.com##.videos-ad__ad
 porndoo.com##.videosite
 sexyshare.net##.videosz_banner
 lubetube.com##.viewvideobanner


### PR DESCRIPTION
`https://javynow.com/`
Issue: Hot Videos (not ads but links to actual videos) hidden:

<details>
<summary>Screenshots</summary>

![javynow1](https://user-images.githubusercontent.com/58900598/106380725-9272c880-63f7-11eb-96e7-9821de67d409.png)

![javynow2](https://user-images.githubusercontent.com/58900598/106380731-97377c80-63f7-11eb-8cd5-58c6aaaaee0c.png)

</details>

Addressing the right black space requires CSS injection but already done on uBO and on AG:
https://github.com/uBlockOrigin/uAssets/commit/f4428524b19e7ecf0dccf47cab817533fc7d5997
https://github.com/AdguardTeam/AdguardFilters/commit/6675c6a80cceb5a67c6748323af47f98721634d8
 