### PR TITLE
Update easyprivacy_general.txt - removed an entry

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -4285,7 +4285,6 @@
 /tide_stat.js
 /timeslog.
 /timestrend_
-/timingcg.
 /tiwik.
 /tjp_beacon.
 /tjx-tracking-


### PR DESCRIPTION
Removed `/timingcg.` because that's the filename we use at RapidSpike for our Real User Monitoring detection. We don't serve ads from it and we don't record any PII data. The script is purely for recording timing metrics, browser, device and estimated location of the user and is installed by the website owner. We also use it for identifying data being sent to untrusted hosts in order to help protect the website's owners and its users from Magecart attacks.