### PR TITLE
A: facebook.com (cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -817,6 +817,7 @@ orcid.org##app-banners
 bethesda.net#?#visor-alert[name="visor-alert"] > div[class=""] > div > div:last-child:-abp-has( > a[href$="/cookie-policy"])
 myscience.org##body > .block > .center
 openbookpublishers.com##body > .menu-header
+facebook.com##body.fbIndex.UIPage_LoggedOut.hasBanner div[data-testid="cookie-policy-banner"]
 medium.com##div > .branch-journeys-top
 spotify.com##div > div[aria-live="polite"]
 transamerica.com##div.bannerAlert--isHidden

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -817,7 +817,7 @@ orcid.org##app-banners
 bethesda.net#?#visor-alert[name="visor-alert"] > div[class=""] > div > div:last-child:-abp-has( > a[href$="/cookie-policy"])
 myscience.org##body > .block > .center
 openbookpublishers.com##body > .menu-header
-facebook.com##body.fbIndex.UIPage_LoggedOut.hasBanner div[data-testid="cookie-policy-banner"]
+facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]
 medium.com##div > .branch-journeys-top
 spotify.com##div > div[aria-live="polite"]
 transamerica.com##div.bannerAlert--isHidden


### PR DESCRIPTION
A rule to hide cookie banner on the login page and on the "checkpoint" page only. Doesn't hide cookie banner on fan pages, which causes scrolling issues.

Samples:
https://www.facebook.com/ - banner hid
https://www.facebook.com/Motorhead-Fan-Page-188921241129818/ - banner not hid

https://github.com/easylist/easylist/issues/6129