### PR TITLE
M: healthline.com (fixes #7179)

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1301,7 +1301,7 @@ cgsociety.org##.creditcardAD
 thesimsresource.com##.crtv-bottom-wrapper
 thesimsresource.com##.crtv-top-wrapper
 healthline.com##.css-0 + div:not([class]):last-of-type
-healthline.com##.css-0 > div[class]
+healthline.com##div[class="css-0"]:has(> div[class]:not(:has(> p)))
 stylist.co.uk##.css-1fz837r
 infowars.com##.css-1upmbem
 infowars.com##.css-1vj1npn


### PR DESCRIPTION
Fixes contents of articles other than section headers (i.e. paragraphs of sections) being filtered out erroneously (#7179) 

Before:
![2021-02-07-131725_1076x1232_scrot](https://user-images.githubusercontent.com/4268966/107160267-2558b900-694a-11eb-91a0-61306219e0c3.png)

After:
![2021-02-08-112758_786x1034_scrot](https://user-images.githubusercontent.com/4268966/107271174-b722fd80-6a00-11eb-988a-22273cd6b5bd.png)
