### PR TITLE
P: (prismaconnect.fr) https://www.programme-tv.net/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1927,7 +1927,6 @@
 ||tr.marsflag.com^
 ||tr.webantenna.info^
 ||tr1.mailperformance.com^
-||tra.scds.pmdstatic.net/pmc-starter/$script
 ||tra.scds.pmdstatic.net/sourcepoint/
 ||traccoon.intellectsoft.net^
 ||trace.qq.com^$third-party


### PR DESCRIPTION
filter 
```
||tra.scds.pmdstatic.net/pmc-starter/$script
```

problem

* Prevent authentication to private space on : programme-tv.net, programme.tv, cesoirtv.com, voici.fr, gala.fr ...

source : 

* https://forums.lanik.us/viewtopic.php?p=158583#p158583

