### PR TITLE
M: remove sentry.io

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2098,7 +2098,6 @@
 ||semasio.net^$third-party
 ||sematext.com^$third-party
 ||sendtraffic.com^$third-party
-||sentry.io^$third-party
 ||seomonitor.ro^$third-party
 ||seomoz.org^$third-party
 ||seoparts.net^$third-party


### PR DESCRIPTION
This removes `sentry.io` as it's not a tracker. See discussion here: https://github.com/easylist/easylist/issues/6963

Sentry is a crash reporting tool and does not perform any tracking. Happy to provide more context if needed but I believe the prior discussions give quite a bit of context:

* https://github.com/easylist/easylist/issues/6963
* https://github.com/uBlockOrigin/uAssets/pull/7924