### PR TITLE
Hide cookie banner background overlay on buecher.de

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -270,6 +270,7 @@ oebv.net##form > div
 kalenderpedia.de##p
 fc-hansa.de##p[style="display: block; margin: 0px; padding: 10px 30px 10px 10px; color: rgb(255, 255, 255); font-size: 13px; line-height: 1.5;"]
 hl-live.de##table[width="1000"]
+buecher.de###klaro
 !
 ! ---------- French ----------
 !


### PR DESCRIPTION
Cookie Banner was already blocked, but a background overlay still remained.

https://imgur.com/a/NY8vFEq