### PR TITLE
sfanytime.com (specific cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -536,6 +536,7 @@ devhut.net##.ht-notification-section
 huawei.com##.huawei-bootom-cookie
 zeroturnaround.com##.hud
 ibm.com##.ibm-show
+sfanytime.com##.iCWLQN.sc-hGwdws
 wccftech.com##.iframe-wrapper
 doff.co.uk##.ig_action_bar
 subscribercounter.com##.index__ModalContainer--mPjzx


### PR DESCRIPTION
https://www.sfanytime.com/

Note: this site is multilingual site (4 languages) but doesn't have English. Hopefully this list is still the correct one.

Language selector is located at the bottom right of the page:

![kuva](https://user-images.githubusercontent.com/17256841/109388930-b94aee80-7912-11eb-8b8e-aa53bec7b6eb.png)
