### PR TITLE
P: tori.fi (cookie hiding rule removes a checkbox)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -5777,7 +5777,7 @@
 ###privacy_law
 ###privacy_modal
 ###privacy_notice
-###privacy_policy
+###privacy_policy:not(input)
 ###privacy_policy_banner
 ###privacy_policy_bar
 ###privacy_policy_link_window


### PR DESCRIPTION
Creating a new account cannot be done on https://www.tori.fi/tili because a necessary checkbox is being removed. Added a fix. I have seen this issue before so I made a modification to the generic rule instead of creating a whitelist rule for this site.

Before:

![kuva](https://user-images.githubusercontent.com/17256841/109425733-6b0d1c80-79f2-11eb-9e71-0f7f1873f8b3.png)

After:

![kuva](https://user-images.githubusercontent.com/17256841/109425754-95f77080-79f2-11eb-9d13-18fc04a531c8.png)
