### PR TITLE
A: duunitori.fi (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -617,6 +617,7 @@
 /gdpr-desc
 /gdpr-lfc.
 /gdpr-min.
+/gdpr-popup-
 /gdpr-popup.
 /gdpr-public.
 /gdpr-transparency-


### PR DESCRIPTION
A generic rule to block GDPR banner.

https://duunitori.fi/

![kuva](https://user-images.githubusercontent.com/17256841/109869654-d7e21a00-7c71-11eb-97b4-992a842444b7.png)
