### PR TITLE
M: ###privacypolicy -> ###privacypolicy:not(input)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -84,7 +84,6 @@ theverge.com#@##privacy-consent
 readthedocs.io,sportdiver.com#@##privacy-policy
 account.sonymobile.com#@##privacy-statement
 dcinside.com,totalwar.com#@##privacy_policy
-varusteleka.com,varusteleka.fi#@##privacypolicy
 repostuj.pl#@##rodo-modal
 forgeandfortune.com#@##toasts > #toastsWrapper
 litebit.eu#@#.CookieConsent

--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -5797,7 +5797,7 @@
 ###privacymanager
 ###privacymessage
 ###privacynotice
-###privacypolicy
+###privacypolicy:not(input)
 ###privacypolicycontainer
 ###privacypopup
 ###privatBanner


### PR DESCRIPTION
I think this modification could potentially fix many sites where a checkboxes are being removed because they have an id "privacypolicy".

I also removed filter added by this pull req: https://github.com/easylist/easylist/pull/6597 as it becomes redundant

I got inspiration for this change from here: https://github.com/easylist/easylist/pull/7309