### PR TITLE
P: accounts.google.com (third-party)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -6,6 +6,7 @@
 @@||1trackapp.com/static/tracking/$script,stylesheet,~third-party
 @@||9cdn.net^*/js/tracking/$script,domain=nine.com.au
 @@||accounts.nintendo.com/account/js/pages/$script,~third-party
+@@||accounts.google.com$~third-party
 @@||ad.crwdcntrl.net^$script,domain=investopedia.com
 @@||adblockanalytics.com/ads.js|
 @@||addgene.org/headers/blat/js/analyze.js


### PR DESCRIPTION
On some non-google websites the account login banner is broken. This is what it should look like for refrence.

<img width="506" alt="Screen Shot 2021-03-08 at 11 55 37 PM" src="https://user-images.githubusercontent.com/69411255/110420750-f5e0bd80-8069-11eb-94fc-a387674fbf97.png">