### PR TITLE
P: purr.nytimes.com/v1

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -333,6 +333,7 @@
 @@||ps.w.org/google-analytics-dashboard-for-wp/assets/
 @@||ps.w.org/wp-slimstat/$domain=wordpress.org
 @@||puch-ersatzteile.at^*/google-analytics.min.js
+@@||purr.nytimes.com/v1
 @@||px-cdn.net/api/v2/collector/ocaptcha$xmlhttprequest
 @@||q-examiner.online/api/Ping?
 @@||quantcast.com/wp-content/themes/quantcast/$domain=quantcast.com


### PR DESCRIPTION
Used to speed up article fetching on nytimes.com, takes longer to load otherwise.