### PR TITLE
P: https://live.nicovideo.jp/watch/lv330945055

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -286,7 +286,7 @@
 ||naukri.com/banners
 ||newsnow.co.uk/pharos.js
 ||newstrackindia.com/images/hairfallguru728x90.jpg
-||nicoad.nicovideo.jp^$domain=~blog.nicovideo.jp|~live2.nicovideo.jp|~nicoad.nicovideo.jp
+||nicoad.nicovideo.jp^$domain=~blog.nicovideo.jp|~live.nicovideo.jp|~live2.nicovideo.jp|~nicoad.nicovideo.jp
 ||nigerianbulletin.com/data/siropu/
 ||ninemanga.com/files/js/ninemanga_300.js
 ||norwaypost.no/images/banners/


### PR DESCRIPTION
Reproducing issue doesn't require account, but fix confirmation does.
Another request `https://api.nicoad.nicovideo.jp/v1/live/statusarea/lv330945055` is also not for ads, it's kinda notification and no need to block.

<details>
<summary>Screenshots</summary>

![nico1](https://user-images.githubusercontent.com/58900598/111485793-46e36680-877a-11eb-9138-50ab45ad4357.png)

![nico2](https://user-images.githubusercontent.com/58900598/111485804-4945c080-877a-11eb-9a67-1292d272153c.png)

</details>
