### PR TITLE
P: datakauppa.fi (cookie banner hiding breaks the page)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -12,6 +12,7 @@ epolisbari.com#@##accept_cookie
 aixfoam.com,aixfoam.de,aixfoam.dk,aixfoam.fi,aixfoam.fr,aixfoam.nl,aixfoam.se#@##cc-notification
 aixfoam.com,aixfoam.de,aixfoam.dk,aixfoam.fi,aixfoam.fr,aixfoam.nl,aixfoam.se#@##cc-notification-wrapper
 bing.com#@##cc_container
+datakauppa.fi#@##cliSettingsPopup
 youtube.com#@##consent-bump
 dnb.no#@##consent-modal
 consent.yahoo.com,paypal.com#@##consent.consent
@@ -24,7 +25,7 @@ airam.fi,biotechusa.hu,hscollective.org,litebit.eu#@##cookie-consent
 analog.com#@##cookie-consent-container
 lauritz.com,qxl.de,qxl.dk,qxl.fi,qxl.no,qxl.se#@##cookie-container
 skuola.net#@##cookie-dialog
-calciomercato.napoli.it,clever-zoeger.de,ddz24.eu,lewento.de,theorie-musik.de,wiadomosci-lodz.pl#@##cookie-law-info-bar
+calciomercato.napoli.it,clever-zoeger.de,datakauppa.fi,ddz24.eu,lewento.de,theorie-musik.de,wiadomosci-lodz.pl#@##cookie-law-info-bar
 penny.hu,pennymarket.it#@##cookie-message
 bokadirekt.se,zlm.nl#@##cookie-modal
 makelaarsland.nl#@##cookie-notice


### PR DESCRIPTION
The page cannot be used without a whitelist rule. Both rules are needed - the other for the banner to be visible, other for giving an access to cookie settings ("Evästeasetukset" in Finnish).

Sample link: https://www.datakauppa.fi/tuote/deltaco-uh-408-usb-2-0-hubi/