### PR TITLE
M: make more specific

### DIFF
--- a/fanboy-addon/fanboy_notifications_allowlist.txt
+++ b/fanboy-addon/fanboy_notifications_allowlist.txt
@@ -1,2 +1,1 @@
-@@||jrepoint.jp/resource/script/jquery.smartbanner.js
 @@||st.mycdn.me/static/*/WebPush.js$script,domain=ok.ru

--- a/fanboy-addon/fanboy_notifications_general_block.txt
+++ b/fanboy-addon/fanboy_notifications_general_block.txt
@@ -96,7 +96,7 @@ _revotas_push.
 ! Mobile notifications
 /app-banner/*$xmlhttprequest
 /jquery.androidbanner.js
-/jquery.smartbanner.js|
-/jquery.smartbanner.min.js|
 /js-mobile-*/header_$script
+/js/jquery.smartbanner.js|
+/js/jquery.smartbanner.min.js|
 /mobile-welcome-overlay/*$script


### PR DESCRIPTION
Another problem by `jquery.smartbanner.js|` at `https://www.levi.jp/home`:

<details>
<summary>Screenshots</summary>

![levi1](https://user-images.githubusercontent.com/58900598/111628095-2b886200-8833-11eb-8005-473f440cb81d.png)

![levi2](https://user-images.githubusercontent.com/58900598/111628099-2d522580-8833-11eb-8a53-2a5590f3ae0c.png)

</details>

Rather than individual fixes I propose to change to `/js/jquery.smartbanner.js|` following AG Annoyances, which also fixes https://github.com/easylist/easylist/pull/7406 and still covers what are blocked by the rule in the original PR: https://github.com/easylist/easylist/pull/5285