### PR TITLE
M: sourceforge.net (removing a cookie whitelist rule)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -34,7 +34,7 @@
 @@||consent.trustarc.com/asset/$script
 @@||consent.trustarc.com^$image
 @@||consent.truste.com/notice$script
-@@||consentmanager.mgr.consensu.org/delivery/$script,stylesheet,xmlhttprequest,domain=sourceforge.net
+@@||consentmanager.mgr.consensu.org/delivery/$stylesheet,xmlhttprequest,domain=sourceforge.net
 @@||cookie-cdn.cookiepro.com^$script,stylesheet,xmlhttprequest,domain=api.newsguardtech.com|giochi.it
 @@||cookielaw.org/consent/$other,xmlhttprequest
 @@||cookielaw.org/consent/cmp.stub.js$domain=reuters.com


### PR DESCRIPTION
Due to this https://github.com/easylist/easylist/issues/4629 issue report, this whitelist rule was added. I tested and now downloading counter starts and I can download normally even if I block that address.

Sample link to test with: https://sourceforge.net/projects/megui/