### PR TITLE
P: https://soccer.yahoo.co.jp/jleague/

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -657,7 +657,7 @@
 @@||politiken.dk/static/$script
 @@||portalbici.es^*-advertisement.$~third-party,xmlhttprequest
 @@||przegladpiaseczynski.pl/wp-content/plugins/wppas/$~third-party
-@@||s.yimg.jp/images/listing/tool/yads/yads-timeline-ex.$script,domain=chiebukuro.yahoo.co.jp|sports.yahoo.co.jp
+@@||s.yimg.jp/images/listing/tool/yads/yads-timeline-ex.js$domain=yahoo.co.jp
 @@||s0.2mdn.net/instream/html5/ima3.js$script,domain=tilt.fi
 @@||samplefan.com/img/ad/$image
 @@||sascdn.com/diff/templates/ts/dist/banner/sas-banner-$script,domain=dr.dk


### PR DESCRIPTION
New entries never load:

<details>

![soccor](https://user-images.githubusercontent.com/58900598/111891493-d7e66600-8a36-11eb-9491-a6190a50475e.png)

</details>

The same happens at `https://baseball.yahoo.co.jp/npb/`. There's also mobile-only issue by the same script at `https://creators.yahoo.co.jp/nikunokoujinikuyo/0300078364` I forgot to report. At this point it will be better to exclude the whole `yahoo.co.jp` but `/yads/*$domain=~yahoo.co.jp` is not viable as there are other patterns of `/yads/*` such as `||yimg.jp/images/listing/tool/yads/yads-iframe.html?` and `yads-` brings other issues. 