### PR TITLE
M: redundant filter

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -601,7 +601,6 @@ matkahuolto.fi##.css-jlvvqa
 ifolor.fi##.dialogBanner--align-bottom
 vr.fi##.headerContents > .infoMessages
 lidl.fi,pelit.fi,telia.fi##.notification
-helmet.fi##.notifier_warning
 suomi24.fi##.s24_cc_banner-wrapper
 terveystalo.com##.st-consent-banner
 lehtodigital.fi##[class^="__ld_cookie_"]


### PR DESCRIPTION
https://www.helmet.fi/ - no sign of cookie banner. I loaded the page in incognito mode, disabled Ubo and still no banner.