### PR TITLE
Allow entry for expedia site breakage

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -363,3 +363,5 @@
 @@||heatmap.it^$domain=heatmap.com|heatmap.it|heatmap.me|heatmap.org
 ! Google
 @@||google.com/analytics/$domain=analytics.google.com
+! Expedia search breakage
+@@||travel-assets.com/platform-analytics-prime/$script


### PR DESCRIPTION
Allow entry for expedia site breakage

Causes prices to not display on details page. This library is a first party data collection tool used to monitor the site.