### PR TITLE
Allow entry for expedia site breakage

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -363,3 +363,5 @@
 @@||heatmap.it^$domain=heatmap.com|heatmap.it|heatmap.me|heatmap.org
 ! Google
 @@||google.com/analytics/$domain=analytics.google.com
+! Expedia search breakage
+@@||travel-assets.com/platform-analytics-prime/$script


### PR DESCRIPTION
Allow entry for expedia site breakage


@Khrin It is on a details page and the session will expire in 11hrs. So either follow these steps or use this link within 11 hours. On the right side of the page you should see prices, but with the ad block list it will not display.

[This URL is valid for 12 hrs](https://www.expedia.com/Details?action=UnifiedDetailsWidget@showDetailsForDeepLink&ptyp=multiitem&langid=1033&isDeeplinkFromFSR=true&crom=1&cadt=R1:2&dcty=L1:SEA%7CL2:LAS&acty=L1:LAS%7CL2:SEA&ddte=L1:2021-04-09%7CL2:2021-04-14&destinationId=178276&c=d82700f9-fa5c-47de-9bd5-31a7f2937bde&misId=Agini5ni-caQ2gsQ6cTN1bfEoKeHASCy4eUh~ARIIGgIIAiDk8AoaNwgBEhsKA1NFQRj6oP6ewJbi1gcqCjIwMjEtMDQtMDkSFgoDTEFTGMyCzQIqCjIwMjEtMDQtMTQ&hotelId=12628&ratePlanCode=244390940&roomTypeCode=201638920&inventoryType=MERCHANT&checkInDate=2021-04-09&checkOutDate=2021-04-14&flightPIID=v5-sos-6580e6f49f914a678933b16095a3b516-26-13-2~2.S~AQoCCAESBwjUBBABGAEgASAHIA0gDCgDUgS5-AEAWAJwAA~AQoiCiAIzpYBEgMyOTIYkgEgi5ABKI636QEwnrjpAThSQABYAQoiCiAIzpYBEgM0ODYYi5ABIJIBKMDs6QEw1e3pAThHQABYARIKCAIQARgCKgJOSxgCIgQIARACKAIoAygEMAE&mipt=AQoDVVNEEi8KBggCEISNBxIGCAIQhI0HGgYIAhCEjQciBggCEKydBioFCAIQ2G8yBggCEOi1ARojCgYIAhCMogMSBggCEIyiAxoGCAIQmLECIgUIAhD0cCoCCAI&packageType=fh&forwardOutTo=UDP)

1. Start at www.expedia.com
2. Select Packages
3. Do a search from New York to Las Vegas 
4. Choose some dates in the near future.
5. Choose any hotel
6. Choose any flights
7. You will now be on a details page where the issue occurs.