### PR TITLE
Fix Patreon cookie banner filter

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -850,7 +850,7 @@ spotify.com##div > div[aria-live="polite"]
 transamerica.com##div.bannerAlert--isHidden
 yahoo.com##div.js-applet-view-container-main > div.fixed-win[style^="background:"]
 tacobell.co.uk##div[am-cookie]
-patreon.com##div[aria-describedby^="BannerContent"]
+patreon.com##div[data-tag="cookie-disclosure"]
 revolut.com##div[class*="StyledCookiesBanner"]
 quora.com##div[class*="flex_wrapper"][class*="gray_ultralight"]
 inc.com##div[class*="privacyPolicyPopup"]


### PR DESCRIPTION
The current filter blocks all banners used on Patreon, including important parts of the user experience. This fix will block only the cookie disclosure banner.