### PR TITLE
Tumblr: "takeover" ad

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -836,6 +836,7 @@ this.org##.Wrap-leaderboard
 xbox.com##.XbcSponsorshipText
 rxlist.com##.Yahoo
 tumblr.com##._1aQrn
+tumblr.com##._18O6M
 thequint.com##._1v3nU
 coderwall.com##._300x250
 thequint.com##._4xQrn


### PR DESCRIPTION
Cosmetically filters the "Takeover" style ads (a custom graphic at the top of the tumblr dashboard).

`_18O6M` is `takeoverBanner` in Tumblr's css map.

Resolves #7612.

(I couldn't figure out if these should be titled P/M/A, sorry!)