### PR TITLE
Block tracking from gem.com domain

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -924,6 +924,7 @@
 ||gcion.com/gcion.ashx?
 ||geckofoot.com/gfcounterimg.aspx?
 ||geckofoot.com/gfvisitormap.aspx?
+||gem.com/api/o/$image,third-party
 ||gemius.mgr.consensu.org^
 ||geni.us/snippet.js
 ||geni.us/snippet.min.js


### PR DESCRIPTION
gem.com is often used for tracking email access and click throughs by recruiters