### PR TITLE
A: asmand.wordpress.com (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -1,4 +1,5 @@
 /messaging.js$domain=computerworld.com|digitalartsonline.co.uk|greenbot.com|itworld.com|macworld.com|networkworld.com|pcwelt.de|pcworld.com|tecchannel.de|techadvisor.co.uk|techadvisor.fr|techhive.com|vkmag.com
+/wp-content/blog-plugins/wordads-classes/js/banner.bundle.js
 ||agicssecurity.com/Header/ajax/cookie.php
 ||appconsent.io^
 ||cmp.infopro-digital.com^


### PR DESCRIPTION
https://asmand.wordpress.com/

A generic cookie blocking rule for wordpress-sites.