### PR TITLE
clapper.com.br

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -1512,7 +1512,6 @@
 ||widget.engageya.com/engageya_loader.js
 ||widget.imshopping.com^$third-party
 ||widget.jobberman.com^$third-party
-||widget.justwatch.com^$third-party
 ||widget.searchschoolsnetwork.com^
 ||widget.sellwild.com^
 ||widget.shopstyle.com.au^


### PR DESCRIPTION
Hello,

I noticed that on a site I'm using one of the main functionalities is blocked by the following rule:

```
 ||widget.justwatch.com^$third-party
```

 Is there a way this can be made more fine grained?

Site: https://www.clapper.com.br/titulo/it-a-coisa

Screenshot:

<img width="885" alt="Screen Shot 2021-04-14 at 12 36 22" src="https://user-images.githubusercontent.com/81977632/114697295-0695ea80-9d1e-11eb-878e-4537a11d298f.png">
