### PR TITLE
P: https://b.hatena.ne.jp/entry/s/b.hatena.ne.jp/15th

### DIFF
--- a/fanboy-addon/fanboy_social_thirdparty.txt
+++ b/fanboy-addon/fanboy_social_thirdparty.txt
@@ -27,8 +27,8 @@
 ||assets.tumblr.com/assets/html/iframe/o.html$third-party
 ||assets.tumblr.com/assets/html/iframe/teaser.html?$third-party
 ||b.hatena.ne.jp^$third-party
-||b.st-hatena.com/images/$image,third-party
-||b.st-hatena.com/js/$script,third-party
+||b.st-hatena.com/images/$image,third-party,domain=~b.hatena.ne.jp
+||b.st-hatena.com/js/$script,third-party,domain=~b.hatena.ne.jp
 ||badge.facebook.com^$third-party
 ||badges.instagram.com^$third-party
 ||bit.ly/TweetAndTrack.js


### PR DESCRIPTION
`https://b.hatena.ne.jp/entry/s/b.hatena.ne.jp/15th`
The filters including Fanboy’s Social which block Hatena Bookmark widgets break the social bookmark service itself.

<details><summary>Screenshot:</summary>

![actual image](https://user-images.githubusercontent.com/82331005/114992162-67b3ee80-9ed5-11eb-85a7-6ed3fe9272ff.png)

![expected image](https://user-images.githubusercontent.com/82331005/114992194-70a4c000-9ed5-11eb-938a-641c9d82febc.png)

</details><br/>



