### PR TITLE
A: Fix Tumblr cosmetic filtering

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -839,7 +839,9 @@ wzzk.com##.Weather_Sponsor_Container
 this.org##.Wrap-leaderboard
 xbox.com##.XbcSponsorshipText
 rxlist.com##.Yahoo
-tumblr.com##._1aQrn
+tumblr.com##._3x1ep
+tumblr.com##.vd2CF
+tumblr.com##.kHo0b
 thequint.com##._1v3nU
 coderwall.com##._300x250
 thequint.com##._4xQrn
@@ -2737,7 +2739,7 @@ scotch.io#?#div.card:-abp-has(a > span:-abp-contains(Sponsor))
 smallseotools.com#?#.col-sm-12 > :-abp-has(p:-abp-contains(Advertisement))
 solarmovie.ink#?#.row:-abp-contains(in HD)
 time.com#?#.article-small-sidebar > .sticky-container:-abp-has(div[id^="ad-"])
-tumblr.com#?#._1DxdS:-abp-has( > div > header[role="banner"])
+tumblr.com#?#._3V0cR ._1s9MS
 twitter.com#?#div[data-testid="UserCell"]:-abp-has(svg + div[dir="auto"] > span:-abp-contains(/Promoted|Gesponsert|Promocionado|Sponsorisé|Sponsorizzato|Promowane|Promovido|Реклама|Uitgelicht|Sponsorlu|Promotert|Promoveret|Sponsrad|Mainostettu|Sponzorováno|Promovat|Ajánlott|Προωθημένο|Dipromosikan|Được quảng bá|推廣|推广|推薦|推荐|プロモーション|프로모션|ประชาสัมพันธ์|प्रचारित|বিজ্ঞাপিত|تشہیر شدہ|مُروَّج|تبلیغی|מקודם/))
 twitter.com#?#div[data-testid="eventHero"]:-abp-contains(/Promoted|Gesponsert|Promocionado|Sponsorisé|Sponsorizzato|Promowane|Promovido|Реклама|Uitgelicht|Sponsorlu|Promotert|Promoveret|Sponsrad|Mainostettu|Sponzorováno|Promovat|Ajánlott|Προωθημένο|Dipromosikan|Được quảng bá|推廣|推广|推薦|推荐|プロモーション|프로모션|ประชาสัมพันธ์|प्रचारित|বিজ্ঞাপিত|تشہیر شدہ|مُروَّج|تبلیغی|מקודם/)
 twitter.com#?#div[data-testid="placementTracking"]:-abp-has(svg + div[dir="auto"] > span:-abp-contains(/Promoted|Gesponsert|Promocionado|Sponsorisé|Sponsorizzato|Promowane|Promovido|Реклама|Uitgelicht|Sponsorlu|Promotert|Promoveret|Sponsrad|Mainostettu|Sponzorováno|Promovat|Ajánlott|Προωθημένο|Dipromosikan|Được quảng bá|推廣|推广|推薦|推荐|プロモーション|프로모션|ประชาสัมพันธ์|प्रचारित|বিজ্ঞাপিত|تشہیر شدہ|مُروَّج|تبلیغی|מקודם/))


### PR DESCRIPTION
An update to Tumblr's CSS map means the current cosmetic filtering rules do not work at all. This fixes them.

`_1aQrn` used to be `instreamAd`, and it has been replaced with updated classes for `instreamAd`, `nativeIponWebAd`, and `takeoverBanner`. This also provides the functionality that the `._1DxdS:-abp-has( > div > header[role="banner"])` was supposed to provide, though it has been broken for a while.

This also hides the sidebar ad via `sidebarContent mrecContainer`, or `._3V0cR ._1s9MS`.

Using CSS map classes is certainly an imperfect solution, as updates like this will sometimes be necessary. It is possible to provide this functionality via human-readable but complex CSS rules, which can be discussed, but this PR fixes the functionality using the current method.

Resolves #7700.