### PR TITLE
P: https://this.kiji.is/-/units/39166665832988672 (fixes https://gith…

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -531,7 +531,7 @@
 ||log.codemarketing.cloud^
 ||log.f-tra.com^
 ||log.gs3.goo.ne.jp^
-||log.nordot.jp^
+||log.nordot.jp^$~script
 ||log.popin.cc^
 ||log000.goo.ne.jp^
 ||macromill.com/imp/


### PR DESCRIPTION
…ub.com/AdguardTeam/AdguardFilters/issues/80265#issuecomment-818787175)
https://github.com/AdguardTeam/AdguardFilters/issues/80265#issuecomment-818787175
https://github.com/AdguardTeam/AdguardFilters/commit/acbb252b847b8bfbe63a21a5c16206319e595d66
`log.nordot.jp` is used almost only on `kiji.is` and excluding `$script` is enough to fix the reported issue.