### PR TITLE
P: https://www.e-stat.go.jp/stat-search

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3995,7 +3995,7 @@
 /stat.cgi?
 /stat.gif?
 /stat.htm?
-/stat.js?
+/stat.js?$domain=~e-stat.go.jp
 /stat.php?
 /stat.png?
 /stat.tag.


### PR DESCRIPTION
The left-side accordion menu does not expand.
e-Stat is a portal site for Japanese Government Statistics, so blocking `stat.js` is probably false-positive.

<details><summary>Screenshot:</summary>

![screenshot](https://user-images.githubusercontent.com/82331005/115712883-4f017800-a3b0-11eb-845a-0a9c6d40506d.png)
</details>