### PR TITLE
M: fix ad-leftover on various NSFW sites

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20770,6 +20770,7 @@
 ##.vjs-ad-iframe
 ##.vjs-ad-overlay
 ##.vjs-ima3-ad-container
+##.vjs-overlay.size-300x250
 ##.vl-ad-item
 ##.vlog-ad
 ##.vmp-ad


### PR DESCRIPTION
Ex.

<details>
<summary>Screenshot</summary>

![nursexfilme](https://user-images.githubusercontent.com/58900598/116557595-88e6f700-a939-11eb-9499-3cadca06c901.png)

</details>

The rest:
```
www.milffabrik.com
www.xhamster-sexvideos.com
www.hdpornos.net
www.gutesexfilme.com
```