### PR TITLE
M: digitiminimi.com from tracking to social

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -605,7 +605,6 @@
 ||d-markets.net^$third-party
 ||d2-apps.net^$third-party
 ||deteql.net^$third-party
-||digitiminimi.com^$third-party
 ||docodoco.jp^$third-party
 ||e-click.jp^$third-party
 ||e-kaiseki.com^$third-party

--- a/fanboy-addon/fanboy_social_thirdparty.txt
+++ b/fanboy-addon/fanboy_social_thirdparty.txt
@@ -51,6 +51,7 @@
 ||dailymotion.com/badge/user/$third-party
 ||digg.com^$script,subdocument,third-party
 ||diggstatic.com^*/follow_buttons/
+||digitiminimi.com^$third-party 
 ||encrypted-tbn2.gstatic.com/images?$domain=vitorrent.org
 ||facebook.com*/plugins/like.php?$third-party
 ||facebook.com/connect/connect.*connections$third-party,domain=~farmville.com


### PR DESCRIPTION
digitiminimi.com is not a tracking server. It provides a Twitter button and retrieves the number of shares and likes on Twitter.
ex. `https://diamond.jp/articles/-/224881`

![image](https://user-images.githubusercontent.com/82331005/116868035-04ea8300-ac49-11eb-8633-6e534fc4d844.png)