### PR TITLE
P: parturikampaamodiva.fi (broken cookie blocking)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -620,6 +620,7 @@ blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
 matkahuolto.fi##.css-jlvvqa
 ifolor.fi##.dialogBanner--align-bottom
 vr.fi##.headerContents > .infoMessages
+parturikampaamodiva.fi##.modal-backdrop.in
 lidl.fi,pelit.fi,telia.fi##.notification
 helmet.fi##.notifier_warning
 suomi24.fi##.s24_cc_banner-wrapper

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -620,7 +620,7 @@ blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
 matkahuolto.fi##.css-jlvvqa
 ifolor.fi##.dialogBanner--align-bottom
 vr.fi##.headerContents > .infoMessages
-parturikampaamodiva.fi##.modal-backdrop.in
+timma.fi##.modal-backdrop.in
 lidl.fi,pelit.fi,telia.fi##.notification
 helmet.fi##.notifier_warning
 suomi24.fi##.s24_cc_banner-wrapper


### PR DESCRIPTION
Currently, Easylist breaks time appointment:

https://www.parturikampaamodiva.fi/ajanvaraus

![kuva](https://user-images.githubusercontent.com/17256841/116910738-b0e29d00-ac4e-11eb-81cc-9a8b0ab87041.png)

I added a fix to block cookie banner properly without breakages.

Note, that appointment function is loaded through an iframe which is why it needs a different url for the actual filter.