### PR TITLE
A: dcraddock.uk

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -9064,6 +9064,7 @@
 ||tebyj99zkdyb.com^
 ||tec-tec-boom.com^
 ||technicallylunaticgarbage.com^
+||tecuil.com^
 ||tedathedo.club^
 ||teddeparati.top^
 ||tedruptcyfal.info^


### PR DESCRIPTION
Overlay causing popup:

![dcraddock](https://user-images.githubusercontent.com/58900598/116989648-f9f92680-ad0c-11eb-98cf-c3828238419f.png)

IDK if the DOWNLOAD and PLAY NOW buttons should be addressed. Maybe in Annoyance?