### PR TITLE
A: ubuntu.com (cookie block, ubo)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -20,6 +20,8 @@ interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
 ! dnb.no (Cookie message)
 ||adobedtm.com^$important,domain=dnb.no
+! scripts
+ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 ! Generichide fixes
 dogemate.com###cconsent-bar
 analog.com###cookie-consent-container.modal


### PR DESCRIPTION
https://ubuntu.com/

Added a filter to block cookie notification. Hiding the cookie banner does not always work fast enough, I occasionally see a blink.