### PR TITLE
P: https://gunosy.co.jp/ad/

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -138,7 +138,6 @@
 @@||googletagservices.com/tag/js/gpt.js$domain=epaper.timesgroup.com|nbcsports.com|vimeo.com|windalert.com
 @@||gpt-worldwide.com/js/gpt.js$~third-party
 @@||guim.co.uk/uploader/$image,~third-party
-@@||gunosy.co.jp/img/ad/$image,~third-party
 @@||hotstar.com/vs/getad.php$domain=hotstar.com
 @@||hulu.com/published/*.flv
 @@||hulu.com/published/*.mp4
@@ -413,6 +412,7 @@
 @@||gamestar.de/gs_cb/assets/core/js/libs/dfp/prebid.$script,domain=gamestar.de
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|pccomponentes.com|tv-asahi.co.jp|vlive.tv|voici.fr
+@@||gunosy.co.jp/img/ad/$image,~third-party
 @@||iejima.org/ad-banner/$image,~third-party
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|filmweb.pl|klix.ba|locipo.jp|maharashtratimes.com|nettavisen.no|niusdiario.es|rtlnieuws.nl|sportsport.ba|tbs.co.jp|tv-asahi.co.jp|tv.rakuten.co.jp|tver.jp|video.tv-tokyo.co.jp|vlive.tv|webdunia.com|wtk.pl
 @@||ingrossoprofumitester.it/img/ad-profumeria-$image,~third-party

--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -138,6 +138,7 @@
 @@||googletagservices.com/tag/js/gpt.js$domain=epaper.timesgroup.com|nbcsports.com|vimeo.com|windalert.com
 @@||gpt-worldwide.com/js/gpt.js$~third-party
 @@||guim.co.uk/uploader/$image,~third-party
+@@||gunosy.co.jp/img/ad/$image,~third-party
 @@||hotstar.com/vs/getad.php$domain=hotstar.com
 @@||hulu.com/published/*.flv
 @@||hulu.com/published/*.mp4

--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -179,6 +179,7 @@ cyclingnews.com#@##mpu_container
 tei-c.org#@##msad
 www.yahoo.com#@##my-adsFPAD
 4kidstv.com#@##myAd
+gunosy.co.jp#@##page_ad
 lemuploads.com,megarelease.org#@##player_ads
 govolsxtra.com#@##pre_advertising_wrapper
 box10.com,chicagotribune.com,enemy.com,flashgames247.com,hackedarcadegames.com,puzzles.usatoday.com#@##prerollAd


### PR DESCRIPTION
The whole page is hidden by generic cosmetic `#page_ad` and `/img/ad/*` blocks non-ads images.

<details><summary>Screenshot:</summary>

![Screenshot from 2021-05-07 19-11-36](https://user-images.githubusercontent.com/82331005/117435154-7dfb1a80-af68-11eb-96e8-09503639c0e4.png)
</details><br/>
