### PR TITLE
M: /entry.count.image? & /entry.count? is not a tracker

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1777,8 +1777,6 @@
 /EndpointTracker/*
 /engine/ping?
 /ent_counter?
-/entry.count.image?
-/entry.count?
 /entry_stats?
 /envoy.sb?sbaid
 /epf_v1_95.js


### PR DESCRIPTION
`/entry.count.image?` is added by https://github.com/easylist/easylist/commit/12fa20426b014f4d733400778147ffb84ca6e5a3
The commit is associated with a 404 URL, but since it's a hatenablog article, I think `/entry.count.image?` was introduced to block 
 `s.st-hatena.com/entry.count.image?uri=`
This is used to get the number of likes pressed to quoted hatenablogs.

URL: `https://honeshabri.hatenablog.com/entry/hatebu_pv`
<details><summary>Screenshot:</summary>

![`/entry.count.image?`](https://user-images.githubusercontent.com/82331005/118345979-43e6d580-b573-11eb-9714-e751396c4041.png)
</details><br/>

`/entry.count?` is added by https://github.com/easylist/easylist/commit/b9ab14237d7814b1e2cfbab6aaa07dd8a7c1431f

The commit is associated with `http://jisakutech.com/archives/2017/04/33003` and the added filter blocks
`b.hatena.ne.jp/entry.count?`.
This is used to get the number of people who have socially bookmarked the article.
<details><summary>Screenshot:</summary>

![`/entry.count?`](https://user-images.githubusercontent.com/82331005/118345925-e05ca800-b572-11eb-953a-f3a5de049caa.png)
</details><br/>

It can blocked on Social filters, but fanboy social already has `||b.hatena.ne.jp^$third-party`.
`api.b.st-hatena.com/entry.count?` might be worth blocking on fanboy social.

ex. `http://hankodeasobu.com/`