### PR TITLE
M: Remove unnecessary filters

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -444,10 +444,8 @@
 @@||minigame.aeriagames.jp/css/videoad.css
 @@||mjhobbymassan.se/r/annonser/$image,~third-party
 @@||netmile.co.jp/ad/images/$image
-@@||news24.jp/ad-navi/$domain=search.news24.jp
 @@||nintendo.co.jp/ring/*/adv$~third-party
 @@||nnmclub.to/forum/misc/html/advert.html$~third-party
-@@||ntv.co.jp/ad-navi/$domain=search.news24.jp
 @@||pia.jp/feature/rss/ad.xml|$~third-party,xmlhttprequest
 @@||player-feedback.p7s1video.net^$script,domain=kabeleins.de|sat1.de
 @@||player.vodgc.net^*/videojs-contrib-ads/dist/videojs.ads.min.js$script

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -157,7 +157,6 @@
 -ad-strip.
 -ad-switcher.
 -ad-tags.
--ad-text_
 -ad-tile.
 -ad-top.
 -ad-unit.
@@ -1020,7 +1019,6 @@
 /ad-minister.$domain=~ad-minister.app
 /ad-minister/*$domain=~ad-minister.app
 /ad-modules/*
-/ad-navi/*
 /ad-nytimes.
 /ad-offer1.
 /ad-openx.
@@ -4275,7 +4273,6 @@
 /collections/ads-
 /collisionadmarker.
 /colorscheme/ads/*
-/column-ad-
 /columnadcounter.
 /columnads/*
 /com/ads/*


### PR DESCRIPTION
https://github.com/easylist/easylist/commit/9bd4f0d5db20aa914f2201bf0c16ad661f4bc3e9

`https://web.archive.org/web/20160518165428/http://www.ntv.co.jp/`

I used the Internet Archive to check this commit and found that all the added general_block filters blocked non-advertising stuff.
In particular, `/ad-navi /*` still blocks non-ads and some of them are whitelisted.