### PR TITLE
M: Blocking Rakuten Automate scripts causes breakages of images or embed social media posts.

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -185,6 +185,7 @@
 @@||lacoste.com/on/demandware.static/*/click-analytics.js$~third-party
 @@||legendstracking.com/js/legends-tracking.js$~third-party
 @@||lenovo.com/_ui/desktop/common/js/AdobeAnalyticsEvent.js$script,~third-party
+@@||linksynergy.com/minified_logic.js$xmlhttprequest,third-party
 @@||listrakbi.com^$image,script,stylesheet,domain=sks-bottle.com
 @@||live.bbc.co.uk^*/comscore.js$script,~third-party
 @@||logging.apache.org^$domain=apache.org


### PR DESCRIPTION
`https://automate-frontend.linksynergy.com/minified_logic.js`
According to my observation, blocking this script occasionally prevents with image loading and always breaks embedded tweets and instagrams.
It is often used on Japanese sites, but is also used on English sites.
It can also be fixed with a scriptlet such as `4meee.com##+js(aopw, _rakuten_automate)`, which is the best solution, but cannot makes generic.

**Example**
Broken images
 `https://4meee.com/articles/view/30008569`
 `https://jamalouki.net/`
 `https://www.winecompanion.com.au/`
 
Broken embed tweets and/or instagram
 `https://www.gamespark.jp/article/2017/12/14/77430.html`
 `https://petpedia.net/article/894/neko_hetakuso`
 `https://www.sassyhongkong.com/lifestyle-culture-instagram-apps-insta-story-tips/`