### PR TITLE
M: `/RequestVideoTag` is useless and breaks the uliza's video player.

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -259,7 +259,6 @@
 @@||support-widget.nakanohito.jp/chatbot$script,stylesheet
 @@||suumo.jp/sp/js/beacon.js$script,~third-party
 @@||twitter.com/oct.js$domain=jp.square-enix.com
-@@||uliza.jp/IF/RequestVideoTag.aspx$script,domain=jsports.co.jp|kobe-np.co.jp|toonippo.co.jp
 @@||useinsider.com/ins.js$domain=pizzahut.jp
 @@||webcdn.stream.ne.jp^*/referrer.js$domain=stream.ne.jp
 @@||yu.xyz.mn/images/event.gif?$image,~third-party

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3675,7 +3675,6 @@
 /reporting/campaignresolution/?
 /request_tracker+
 /RequestTrackerServlet?
-/RequestVideoTag.
 /res/x.gif?
 /resmeter.js
 /resonance.js


### PR DESCRIPTION
EasyPrivasy already has three exceptions in allowlist, `kobe-np.co.jp` : https://github.com/easylist/easylist/commit/85053012d5194f3cf04fdc65a977baf7cc93d568 `toonippo.co.jp`: https://github.com/easylist/easylist/pull/5452 `jsports.co.jp`: https://github.com/easylist/easylist/pull/7131.

I found three more similar examples  `https://theatrelive.mu-mo.net/plus-a/audition`, `http://pc.jtta-shidou.jp/`, and `https://kbc.co.jp/movie/`.

The problematic filter was added by easylist/easylist@b4fad44, which is associated with `http://www.fnn-news.com/`, Japanese TV news websites. 
I don't know what @Khrin blocked, but the website used uliza's video player at that time according to  [Internet Archive](https://web.archive.org/web/20180617053135mp_/http://www.fnn-news.com/news/headlines/articles/CONN00392927.html), so I strongly suspect that it was a mistake.

You can add more allowlist filters like `@@||uliza.jp/IF/RequestVideoTag.aspx$script,domain=jsports.co.jp|jtta-shidou.jp|kbc.co.jp|kobe-np.co.jp|theatrelive.mu-mo.net|toonippo.co.jp` to solve this issue, but removing problematic and probably unwanted filters is the right way.