### PR TITLE
More accurately block arc.io's Sentry, sentry.arc.io, instead of Arc's entire widget.

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -256,7 +256,6 @@
 ||appspot.com/api/track/
 ||appspot.com/collect
 ||appspot.com/stats?
-||arc.io/widget.min.js
 ||arclk.net/trax?
 ||areyouahuman.com/kitten?
 ||argos.citruserve.com^
@@ -1702,6 +1701,7 @@
 ||sendibm4.com^*/op/$third-party
 ||sendtonews.com/player/loggingajax.php?
 ||sendtonews.com^*/data_logging.php
+||sentry.arc.io^
 ||session.timecommerce.net^
 ||sftrack.searchforce.net^
 ||share-online.biz/affiliate/$third-party


### PR DESCRIPTION
Hi guys! :wave:

I'm Ansgar. We (`https://arc.io/team`) build Arc (`https://arc.io/`), a
peer-to-peer content delivery network (CDN) that runs in the browser.

Like many, we use Sentry (`https://sentry.io/`) to monitor and improve
our software. It was for this use of Sentry that Arc was added to
`easyprivacy_thirdparty.txt` in https://github.com/easylist/easylist/commit/76167fc006588056a05cef3c1eaf415591a2115d.

See here for prior discussion on Sentry:

  * https://github.com/easylist/easylist/pull/7207

  * https://github.com/easylist/easylist/issues/6963

Since we self host Sentry, I created this PR to more accurately block
Arc's Sentry, at `sentry.arc.io`, and not Arc's entire widget.

Thank you!
