### PR TITLE
Update easylist_general_hide.txt

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -21157,6 +21157,7 @@
 ##.widget_evolve_ad_gpt_widget
 ##.widget_fearless_responsive_image_ad
 ##.widget_googleads
+##.widget_html_snippet_ad_widget
 ##.widget_ima_ads
 ##.widget_internationaladserverwidget
 ##.widget_ione-dart-ad


### PR DESCRIPTION
Fix for https://vaccines.procon.org/ & xxx.procon.org types domain which have empty boxes after ad blocking in the list of Pros & cons.