### PR TITLE
M: Blocking `go.pardot.com` breaks contact/application forms.

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -902,7 +902,6 @@
 ||go.com/globalelements/utils/tracking
 ||go.com/stat/
 ||go.com^*/analytics.js
-||go.pardot.com^
 ||go.theregister.com^$image
 ||gofundme.com/track
 ||golfsmith.com/ci/


### PR DESCRIPTION
### Example URL
`https://wacul.co.jp/pressrelease/5777-2-2/`

### Description
A broken application form.

### Screenshots

<details><summary>Screenshot 1:</summary>

![Screenshot 1](https://user-images.githubusercontent.com/82331005/122443414-89674a00-cfda-11eb-8d88-5b6e0ccfaca5.png)
</details>

<details><summary>Screenshot 2:</summary>

![Screenshot 2](https://user-images.githubusercontent.com/82331005/122443410-88361d00-cfda-11eb-9469-7db1a8861ce7.png)
</details>

### Other example URLs
~~~
https://appian.com/resources/contact-us.html
https://www.questback.com/contact-us/
https://www.walkersands.com/contact-us/
~~~

### Related discussion
`https://forums.lanik.us/viewtopic.php?f=62&t=45671`
https://github.com/AdguardTeam/cname-trackers/issues/8
`https://www.reddit.com/r/uBlockOrigin/comments/mwwvde/how_to_avoid_blocking_pardot_by_ublockorigin/`