### PR TITLE
M: generic cookie filter modified to avoid unwanted blockings

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -5487,7 +5487,7 @@
 ###os_app_cookiewarn
 ###osomcookie
 ###ost-cookiewall-container
-###ot-sdk-btn
+###ot-sdk-btn:not(button)
 ###otp-privacy
 ###otrcookiecompliancediv
 ###oupcookiepolicy_message


### PR DESCRIPTION
Rule `###ot-sdk-btn` might in some cases remove legit buttons, like it does on https://www.maaseuduntulevaisuus.fi/ it removes a button where you can access website's cookie settings. That should not in my opinion be blocked.

Modifying the rule to be like this `###ot-sdk-btn:not(button)` fixes the issue.

Sample picture: 
![kuva](https://user-images.githubusercontent.com/17256841/122582785-384e6900-d061-11eb-907f-2bc69ff8e477.png)

(Scroll to the bottom of the page. _Evästeasetukset_ means "Cookie settings" in English.