### PR TITLE
P: https://www.japantimes.co.jp/ads/the-best-of-japan/special_edition…

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -685,7 +685,7 @@
 .internads.
 .io/ads/
 .is/ads/
-.jp/ads/$domain=~hs-exp.jp
+.jp/ads/$third-party,domain=~hs-exp.jp
 .js?dfp=
 .jsp?adcode=
 .ke/ads/


### PR DESCRIPTION
…/ (partly fixes https://github.com/AdguardTeam/AdguardFilters/issues/86281)
https://github.com/AdguardTeam/AdguardFilters/issues/86281

Many more examples: 
```
https://alhoiku.jp/ads/
https://www.nishinippon-adv.jp/ads/
http://www.synapse.ne.jp/ads/
http://cs9.co.jp/ads/
```

If any 1p `.jp/ads/` needs to be blocked, it'll be done by Japanese filters. Note `hs-exp.jp` still needs to be excluded.