### PR TITLE
P: hatenacorp.jp

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -439,6 +439,7 @@
 @@||googlesyndication.com/simgad/$image,domain=pccomponentes.com
 @@||googletagservices.com/tag/js/gpt.js$domain=farfeshplus.com|gentside.com|pccomponentes.com|tv-asahi.co.jp|vlive.tv|voici.fr
 @@||gunosy.co.jp/img/ad/$image,~third-party
+@@||hatenacorp.jp/_next/static/chunks/pages/ads-$script,~third-party
 @@||iejima.org/ad-banner/$image,~third-party
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=bloomberg.co.jp|farfeshplus.com|filmweb.pl|gamepix.com|klix.ba|locipo.jp|maharashtratimes.com|minigame.aeriagames.jp|nettavisen.no|niusdiario.es|rtlnieuws.nl|sportsport.ba|success-games.net|synk-casualgames.com|tbs.co.jp|tv-asahi.co.jp|tv.rakuten.co.jp|tver.jp|video.tv-tokyo.co.jp|vlive.tv|webdunia.com|wtk.pl
 @@||ingrossoprofumitester.it/img/ad-profumeria-$image,~third-party

--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -383,6 +383,7 @@ members.portalbuzz.com#@#.ads-holder
 gratisaftehalen.nl#@#.ads-image
 t3.com#@#.ads-inline
 celogeek.com,checkrom.com#@#.ads-item
+hatenacorp.jp#@#.ads-link
 circus-dev.com#@#.ads-list
 bannerist.com#@#.ads-right
 apple.com#@#.ads-section

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -244,7 +244,7 @@
 @@||e-stat.go.jp/modules/custom/retrieve/src/js/stat.js?$script,~third-party
 @@||flipdesk.jp/wp/wp-content/themes/flipdesk/images/analytics3.png$image
 @@||googleadservices.com/pagead/conversion_async.js$script,domain=jp.square-enix.com
-@@||googletagmanager.com/gtm.js$script,domain=anond.hatelabo.jp|book.impress.co.jp|cyclestyle.net|kakuyomu.jp|sankei.com|ymobile.jp
+@@||googletagmanager.com/gtm.js$script,domain=anond.hatelabo.jp|book.impress.co.jp|cyclestyle.net|hatenacorp.jp|kakuyomu.jp|sankei.com|ymobile.jp
 @@||in.treasuredata.com/js/*api_key$script,domain=retty.me
 @@||k-img.com/javascripts/modules/rst/analytics.js?$domain=tabelog.com
 @@||k-img.com/script/analytics/s_code.js$script,domain=kakaku.com


### PR DESCRIPTION
### List the website(s) you're having issues:
`https://hatenacorp.jp/`
`https://hatenacorp.jp/ads`

### What happens?
See screenshots below.
Screenshot 1: `hatenacorp.jp#@#.ads-link` (EasyList)
Screenshot 2-1: `@@||googletagmanager.com/gtm.js$script,domain=hatenacorp.jp` (EasyPrivasy)
Screenshot 2-2: `@@||hatenacorp.jp/_next/static/chunks/pages/ads-$script,~third-party` (EasyList)

### Screenshots
<details>
<summary>Screenshot 1</summary>

![Screenshot 1](https://user-images.githubusercontent.com/82331005/123503203-77497380-d68c-11eb-96b0-41f73625de11.png)
</details>

<details>
<summary>Screenshot 2</summary>

![Screenshot 2](https://user-images.githubusercontent.com/82331005/123503201-744e8300-d68c-11eb-8f0b-ac66c34ec059.png)
</details>
