### PR TITLE
A: murha.info (generic cookie hide, Ubo - Firefox)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -96,3 +96,5 @@ viget.com##[class^="gpdr-banner__"]
 fandom.com##[data-tracking-opt-in-overlay="true"]
 macdrop.net,dropgalaxy.*###gdpr-cookie-notice
 stfly.*###cookie-pop
+! Html filters for Firefox
+*##^.pea_cook_wrapper


### PR DESCRIPTION
Hi, is this filter ok? Html filters are Firefox specific only, but they are powerful because they remove the element from the source code of the webpage before the page is rendered -> it's impossible to see a blink of the removed element.

`.pea_cook_wrapper` is being used on many sites, for e.g. here: https://www.murha.info/

Sometimes, when I refresh the page many times, I'll see a blink of that blocked cookie banner element, so I thought it wouldn't hurt to add a filter that never causes blinking. (And as it's already exists as a normal generic filter, why not to add it as a generic html filter as well?)

In order to overcome race-condition issues that are very common on websites...