### PR TITLE
P: animeanime.jp and 12 group sites

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -245,7 +245,7 @@
 @@||flipdesk.jp/wp/wp-content/themes/flipdesk/images/analytics3.png$image
 @@||game-tsutaya.tsite.jp/pc/common/scripts/analytics/s_code_ggame.js
 @@||googleadservices.com/pagead/conversion_async.js$script,domain=jp.square-enix.com
-@@||googletagmanager.com/gtm.js$script,domain=animeanime.jp|anond.hatelabo.jp|book.impress.co.jp|carcareplus.jp|cinemacafe.net|cyclestyle.net|gamebusiness.jp|gamespark.jp|hatenacorp.jp|inside-games.jp|kakuyomu.jp|mycar-life.com|newscafe.ne.jp|radiko.jp|resemom.jp|response.jp|scan.netsecurity.ne.jp|spyder7.com|stage.parco.jp|viviennewestwood-tokyo.com|ymobile.jp
+@@||googletagmanager.com/gtm.js$script,domain=animeanime.jp|anond.hatelabo.jp|book.impress.co.jp|carcareplus.jp|cinemacafe.net|cyclestyle.net|gamebusiness.jp|gamespark.jp|hatenacorp.jp|inside-games.jp|kakuyomu.jp|mycar-life.com|newscafe.ne.jp|radiko.jp|reanimal.jp|resemom.jp|response.jp|scan.netsecurity.ne.jp|spyder7.com|stage.parco.jp|viviennewestwood-tokyo.com|ymobile.jp
 @@||in.treasuredata.com/js/*api_key$script,domain=retty.me
 @@||k-img.com/javascripts/modules/rst/analytics.js?$domain=tabelog.com
 @@||k-img.com/script/analytics/s_code.js$script,domain=kakaku.com

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -245,7 +245,7 @@
 @@||flipdesk.jp/wp/wp-content/themes/flipdesk/images/analytics3.png$image
 @@||game-tsutaya.tsite.jp/pc/common/scripts/analytics/s_code_ggame.js
 @@||googleadservices.com/pagead/conversion_async.js$script,domain=jp.square-enix.com
-@@||googletagmanager.com/gtm.js$script,domain=anond.hatelabo.jp|book.impress.co.jp|cyclestyle.net|hatenacorp.jp|kakuyomu.jp|radiko.jp|stage.parco.jp|viviennewestwood-tokyo.com|ymobile.jp
+@@||googletagmanager.com/gtm.js$script,domain=animeanime.jp|anond.hatelabo.jp|book.impress.co.jp|carcareplus.jp|cinemacafe.net|cyclestyle.net|gamebusiness.jp|gamespark.jp|hatenacorp.jp|inside-games.jp|kakuyomu.jp|mycar-life.com|newscafe.ne.jp|radiko.jp|resemom.jp|response.jp|scan.netsecurity.ne.jp|spyder7.com|stage.parco.jp|viviennewestwood-tokyo.com|ymobile.jp
 @@||in.treasuredata.com/js/*api_key$script,domain=retty.me
 @@||k-img.com/javascripts/modules/rst/analytics.js?$domain=tabelog.com
 @@||k-img.com/script/analytics/s_code.js$script,domain=kakaku.com


### PR DESCRIPTION
In-site search is broken by GTM:

![animeanime1](https://user-images.githubusercontent.com/58900598/124386788-fbe46380-dd16-11eb-8a4a-fb7f224fc04e.png)

![animeanime2](https://user-images.githubusercontent.com/58900598/124386790-fdae2700-dd16-11eb-9fff-fbe50ff99762.png)

The same issue as https://github.com/easylist/easylist/pull/7882 (2) and all of these sites I added here
```
animeanime.jp
carcareplus.jp
cinemacafe.net
gamebusiness.jp
gamespark.jp
inside-games.jp
mycar-life.com
newscafe.ne.jp
reanimal.jp
resemom.jp
response.jp
scan.netsecurity.ne.jp
spyder7.com
```
are under the same entity.