### PR TITLE
fix risepeople.com for browser.sentry-cdn.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -76,7 +76,7 @@
 @@||webapp.simplisafe.com^*/angulartics-ga.min.js$script,~third-party
 @@||wsj.net/iweb/static_html_files/cxense-candy.js$script,domain=marketwatch.com
 ! @@||browser.sentry-cdn.com^$domain=cardiffmedia.co.uk|connect.shore.com|crrowd.com|gina-phillips.com|gracevanberkum.com|imperial.ac.uk|loveotv.com|onginnovations.com|simonparkes.org|stockforecasttoday.com|tekku.co.za|theangryviking1776.com|thegivingblock.com|thepittsburghoratory.org|truenews4u.com|washingtonpost.com|wix.com
-@@||browser.sentry-cdn.com^$domain=doconcall.com.my|eco-clobber.co.uk
+@@||browser.sentry-cdn.com^$domain=doconcall.com.my|eco-clobber.co.uk|risepeople.com
 @@||brsrvr.com/api/$xmlhttprequest,domain=dollargeneral.com
 @@||c.paypal.com/da/r/fb.js$script
 @@||cbsinteractive.com^*/lib/tracking/comscore/$script


### PR DESCRIPTION
URL: https://risepeople.com

![image](https://user-images.githubusercontent.com/10557218/124521275-37526100-ddef-11eb-86e1-ccbcfc53a126.png)
