### PR TITLE
P: m.nettiauto.com (multiple domains, product info texts hid)

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -331,6 +331,7 @@ iejima.org#@#.ad_banner
 focustaiwan.tw,lavozdegalicia.es,sozai-good.com#@#.ad_block
 panarmenian.net#@#.ad_body
 joins.com#@#.ad_bottom
+m.nettiauto.com,m.nettikaravaani.com,m.nettikone.com,m.nettimarkkina.com,m.nettimokki.com,m.nettimoto.com,m.nettivaraosa.com,m.nettivaraosa.com,m.nettivene.com,m.nettivuokraus.com#@#.ad_caption
 go.com,robhasawebsite.com,thelocal.at,thelocal.ch,thelocal.de,thelocal.dk,thelocal.es,thelocal.fr,thelocal.it,thelocal.no,thelocal.se#@#.ad_container
 environmentjob.co.uk,lowcarbonjobs.com,myhouseabroad.com#@#.ad_description
 318racing.org,linuxforums.org,modelhorseblab.com#@#.ad_global_header


### PR DESCRIPTION
A filter rule hides product info texts, whitelisting added.

Sample site: https://m.nettiauto.com/ford/mondeo/12210087?vifAdCount=28&vifNav=Y

info texts blocked:
![kuva](https://user-images.githubusercontent.com/17256841/124789083-a1374b80-df52-11eb-9a09-02c6dc69dcb7.png)

whitelisted:
![kuva](https://user-images.githubusercontent.com/17256841/124789024-95e42000-df52-11eb-8560-5e792a7f4189.png)

Multiple domains. All these sites belong to the same site cluster and they have a desktop version (with www-prefix). Though m.nettivuokraus.com does not actually exist currently, I hope it could still be included because some day nettivuokraus.com could have a mobile version of m.nettivuokraus.com and if that happens, this issue would happen with that domain as well and nobody is notifying when that site goes to live. All these other domains have a m-prefixed mobile version.

(The mobile version I linked, can be accessed on desktop by this button:)

![kuva](https://user-images.githubusercontent.com/17256841/124790951-4999df80-df54-11eb-88e9-8e4af45f1e52.png)



