### PR TITLE
A: elisaviihde.fi (cookie banner hide, Ubo)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -20,6 +20,7 @@ schulze-immobilien.de##*:style(filter: none !important)
 gov.lv##body:style(overflow: auto !important;)
 !
 backmarket.de##._3NAusrrr
+elisaviihde.fi##.ea-cookie-disclaimer
 iracing.com##.modal-background
 myrobotcenter.co.uk,myrobotcenter.at,myrobotcenter.de##.modals-wrapper
 reuters.com###onetrust-consent-sdk


### PR DESCRIPTION
https://elisaviihde.fi

I know that `##.ea-cookie-disclaimer` exists as a generic filter already, but as Ubo does not inject all thousands of generic filters unconditionally on each and page (which is a great performance optimization), it may lead to a situation where a generic filter causes the element to flicker once before it's hidden. I experience flickering somewhat often on this page, which is why I want to add a specific filter in order to avoid flickering.

https://www.reddit.com/r/uBlockOrigin/comments/ok2u55/how_to_block_a_cookie_banner_via_scriplets/