### PR TITLE
P: kmsv.jp

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -448,6 +448,7 @@
 @@||ingrossoprofumitester.it/img/ad-profumeria-$image,~third-party
 @@||jmedj.co.jp/files/$image,~third-party
 @@||kanalfrederikshavn.dk^*/jquery.openx.js?
+@@||kmsv.jp/images/ad/$image,~third-party
 @@||koshien-live.net/99/adtag.xml$domain=sportsbull.jp
 @@||krotoszyn.pl/uploads/pub/ads_files/$image,~third-party
 @@||labymod.net/affiliate/$~third-party


### PR DESCRIPTION
`https://kmsv.jp/`
I don't know why they assigned such path names but internal links are badly broken by `/images/ad/*`:

![kmsv](https://user-images.githubusercontent.com/58900598/126201213-9f5af05d-9532-410b-8be0-ce78bd3023b3.png)
