### PR TITLE
P: esbo.fi / espoo.fi (element won't load, cookie banner issue)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -69,7 +69,6 @@ interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
-esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())
 ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)
 al.com,allkpop.com,cinemablend.com,windows101tricks.com,foxvalleyfoodie.com,toledoblade.com,foxvalleyfoodie.com,merriam-webster.com,playstationlifestyle.net,calendarpedia.co.uk,ccn.com,sportsnaut.com,cleveland.com,comicsands.com,duffelblog.com,gamepur.com,gamerevolution.com,interestingengineering.com,keengamer.com,listenonrepeat.com,mandatory.com,mlive.com,musicfeeds.com.au,newatlas.com,pgatour.com,readlightnovel.org,secondnexus.com,sevenforums.com,sport24.co.za,superherohype.com,thefashionspot.com,theodysseyonline.com,totalbeauty.com,westernjournal.com##+js(aopr, __cmpGdprAppliesGlobally)

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -20,6 +20,7 @@ schulze-immobilien.de##*:style(filter: none !important)
 gov.lv##body:style(overflow: auto !important;)
 !
 backmarket.de##._3NAusrrr
+esbo.fi,espoo.fi##.cookienotification
 elisaviihde.fi##.ea-cookie-disclaimer
 iracing.com##.modal-background
 myrobotcenter.co.uk,myrobotcenter.at,myrobotcenter.de##.modals-wrapper


### PR DESCRIPTION
https://www.espoo.fi

Due to scriplet that prevents the cookie banner from appearing, a specific element won't load.

![kuva](https://user-images.githubusercontent.com/17256841/126380630-5a16cc39-1a32-4d8a-8c35-3a97333bd328.png)

"Suosituimmat sivut" (Most popular pages) is endlessly loading.

Replacing it with a specific hiding filter (generic hiding filter works slowly on Ubo with this site).