### PR TITLE
M: redundant filter

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -32,7 +32,6 @@ calciomercato.napoli.it,clever-zoeger.de,datakauppa.fi,ddz24.eu,lewento.de,manag
 penny.hu,pennymarket.it#@##cookie-message
 bokadirekt.se,cancercentrum.se,d-power-modellbau.com,modellbau-metz.com,pelix-media.de,steinmetz-baldauf.de,zlm.nl#@##cookie-modal
 makelaarsland.nl#@##cookie-notice
-power.fi#@##cookie-notification
 danbolig.dk,finanzen.ch#@##cookie-overlay
 patient.info#@##cookie-policy
 flybe.com#@##cookie-policy-modal


### PR DESCRIPTION
This was added by this request: https://github.com/easylist/easylist/pull/5500 but it's not needed anymore, the site has changed it's way how they implement cookie banner. Product reviews work now normally.