### PR TITLE
M: redundant filter

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -199,7 +199,6 @@ bankmillennium.pl#@#.cookies-info
 mydealz.de#@#.cookies-message
 vtimes.io#@#.cookies-modal:not(body):not(html)
 vtimes.io#@#.cookies-modal__background
-alko.fi#@#.cookies-open
 diy.com#@#.cookies-policy
 tatilsepeti.com#@#.cookies.active
 delhaize.be,milliman.com#@#.cookiesModal


### PR DESCRIPTION
https://www.alko.fi/ doesn't use cookie banner anymore.

Edit, it uses but is blocked via `||cookielaw.org^$3p`

So whitelist rule is useless anyway. I didn't notice issues on that site.