### PR TITLE
Added `third-party`

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -6123,7 +6123,6 @@
 ||medicalchilly.com^
 ||mediuminsert.com^
 ||medleyads.com^
-||medyagundem.com^
 ||medyanetads.com^
 ||meehaina.net^
 ||meepwrite.com^
@@ -12902,6 +12901,7 @@
 ||mediatarget.com^$third-party
 ||mediatraffic.com^$third-party
 ||mediavine.com^$third-party
+||medyagundem.com^$third-party
 ||medyanet.net^$third-party
 ||meendocash.com^$third-party
 ||mellowads.com^$third-party


### PR DESCRIPTION
`http://www.medyagundem.com/parkta-icerde-dehseti/`

<details> <summary>Screenshot</summary>

![mdyg](https://user-images.githubusercontent.com/74098460/126850265-c3bade39-dc7a-45e8-b864-f33a87a40f89.png)


</details>

The rule breaks the `medyagundem.com` site. Also site has very few visitors.  Actually, it doesn't look like an ad server. I think it should be removed permanently.