### PR TITLE
A: bosch-home.fi | .* (cookie list, Ubo)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,7 +1,6 @@
 ! uBO Sepecific fixes
 ! :style fixes
-bosch-home.*##.g-container:style(filter: none !important)
-bosch-home.*##.feedback-button:style(filter: none !important)
+bosch-home.*##.g-container, .feedback-button:style(filter: none !important)
 wetter.at##.full.blured:style(filter: none !important;)
 bosch-easycontrol.com##.modal-open:style(overflow: auto !important; padding-right: 0 !important;)
 danskebank.fi##.nav:style(position: unset !important)

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,5 +1,7 @@
 ! uBO Sepecific fixes
 ! :style fixes
+bosch-home.*##.g-container:style(filter: none !important)
+bosch-home.*##.feedback-button:style(filter: none !important)
 wetter.at##.full.blured:style(filter: none !important;)
 bosch-easycontrol.com##.modal-open:style(overflow: auto !important; padding-right: 0 !important;)
 danskebank.fi##.nav:style(position: unset !important)
@@ -8,7 +10,7 @@ html5games.com##div[class="app-container"]:style(filter:none !important;opacity:
 gesund24.at,oe24.at,wirkochen.at,xn--sterreich-ppa80c.at##.wrapper.blured:style(filter: none !important;)
 germany.travel##body.consent-overlay:style(overflow:auto !important)
 kpcen-torun.edu.pl,taxfix.de,analog.com,zeoob.com##body.modal-open:style(overflow:auto !important)
-lulus.com,podleze-piekielko.pl,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,danskebank.fi,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,zapatos.es##body:style(overflow: auto !important;)
+bosch-home.*,lulus.com,podleze-piekielko.pl,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,danskebank.fi,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,zapatos.es##body:style(overflow: auto !important;)
 sufilog.com,iracing.com,reuters.com,okazik.pl,pamiatki.pl,asseco.com,craftserve.pl,pressherald.com,thw.de,techmot24.pl##html:style(overflow:auto !important)
 terveyskirjasto.fi##body:style(overflow: scroll !important)
 e-wie-einfach.de,nerim.com,markets.com,researchaffiliates.com,nmhh.hu,imobiliare.ro,zsgarwolin.pl,pelix-media.de##body,html:style(height: auto !important; overflow: auto !important)
@@ -20,6 +22,7 @@ schulze-immobilien.de##*:style(filter: none !important)
 gov.lv##body:style(overflow: auto !important;)
 !
 backmarket.de##._3NAusrrr
+bosch-home.*##.cookielaw-modal-layer
 elisaviihde.fi##.ea-cookie-disclaimer
 iracing.com##.modal-background
 myrobotcenter.co.uk,myrobotcenter.at,myrobotcenter.de##.modals-wrapper
@@ -68,12 +71,14 @@ what3words.com,masmovil.es##.MuiDialog-root
 bundesanzeiger.de###cc
 interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
+bosch-home.*##[class="o-cookielaw"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
 esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())
 ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)
 al.com,allkpop.com,cinemablend.com,windows101tricks.com,foxvalleyfoodie.com,toledoblade.com,foxvalleyfoodie.com,merriam-webster.com,playstationlifestyle.net,calendarpedia.co.uk,ccn.com,sportsnaut.com,cleveland.com,comicsands.com,duffelblog.com,gamepur.com,gamerevolution.com,interestingengineering.com,keengamer.com,listenonrepeat.com,mandatory.com,mlive.com,musicfeeds.com.au,newatlas.com,pgatour.com,readlightnovel.org,secondnexus.com,sevenforums.com,sport24.co.za,superherohype.com,thefashionspot.com,theodysseyonline.com,totalbeauty.com,westernjournal.com##+js(aopr, __cmpGdprAppliesGlobally)
+bosch-home.*##+js(rc, pinned|cookielaw-blur-background, body, stay)
 ! Generichide fixes
 dogemate.com###cconsent-bar
 analog.com###cookie-consent-container.modal


### PR DESCRIPTION
https://www.bosch-home.fi and all it's other top level domains as there are many of them.

Rule `bosch-home.*##.cookielaw-modal-layer` is needed at least in the Finnish site.

`bosch-home.*##[class="o-cookielaw"]` is needed at least here: https://www.bosch-home.com/?clear=1#/Togglebox=region-toggle-4/

`bosch-home.*##+js(rc, pinned|cookielaw-blur-background, body, stay)` will remove blur effect and overflow hidden properties from the body element.

Style rules
```
bosch-home.*##body:style(overflow: auto !important)
bosch-home.*##.g-container, .feedback-button:style(filter: none !important)
```

Are added in order to avoid blinking issues on visible blurred elements.
That site cluster uses blur effect on many elements and menus (Cookie notification related):

![kuva](https://user-images.githubusercontent.com/17256841/126881066-9d962819-e332-4ad2-ba9f-92300e5accbb.png)

![kuva](https://user-images.githubusercontent.com/17256841/126881073-c1b34e86-428f-4d83-a296-6927731939a0.png)

So it's not wise to individually apply style rules to every element on that site. Just applied it to those elements that are immediately visible to avoid blinking. Scriplet will take care of the rest without blinking.

Hopefully you got the idea. :D... This might look a bit complex but imo every filter is necessary.