### PR TITLE
A: utorrent.com (generic cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -7732,6 +7732,7 @@
 ##.connect-cookie-bar
 ##.consent-at-bottom
 ##.consent-banner
+##.consent-banner-container:not(body):not(html)
 ##.consent-bar
 ##.consent-bg:not(html):not(body)
 ##.consent-confirmation-banner


### PR DESCRIPTION
https://www.utorrent.com/

I added `:not(body):not(html)` as as precaution because it's too common for these entries to blank out websites by matching body or html element.

Imo, precaution entries should be used even more widely in the Cookie list, see my suggestion here:

https://github.com/easylist/easylist/issues/8367