### PR TITLE
M: update broken cookie filter, scandinavianphoto.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -662,7 +662,7 @@ terveystalo.com##.st-consent-banner
 lehtodigital.fi##[class^="__ld_cookie_"]
 sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
 dplay.fi##div[class^="notification"]
-scandinavianphoto.fi##div[style="opacity: 1; height: 77px;"]
+scandinavianphoto.fi##div[style^="opacity: 1; height: "][style$="px;"]
 linnunrata.org##div[style^="position:fixed;right:0;top:0;"]
 !
 ! ---------- Greek ----------


### PR DESCRIPTION
https://www.scandinavianphoto.fi/

The height of the cookie banner is dependant on browser window size so height can't be used used directly in the filter. Rephrased the filter in a way that height is skipped.