### PR TITLE
Fix Monzo Sentry

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -253,7 +253,6 @@
 @@||playcanvas.com.*/keen.min.js
 @@||player.ooyala.com^*/analytics-plugin/$script,domain=formula1.com|nintendo.com
 @@||player.sundaysky.com^$subdocument
-@@||playstation.net/event/$domain=playstation.com|playstation.net|sony.com
 @@||plugins.matomo.org^$image,~third-party
 @@||postex.com/api/ping?$~third-party
 @@||pro.ip-api.com/json$xmlhttprequest,domain=aljazeera.com|cookappsgames.com|sheee.co.il|walla.co.il

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1012,6 +1012,7 @@
 /bsuite/worker.php?
 /bt.gif?
 /btn_tracking_pixel.
+/btrack.php?
 /buffer.pgif?r=
 /buffermetrics/*
 /bug/pic.gif?


### PR DESCRIPTION
The Monzo (https://monzo.com/) payment verification process is broken by the widescale blocking of sentry (introduced in d610e11), because it uses sentry to send events to the payment page once the user has verified payment in their app.

With the block in place, the user will approve the payment in the Monzo app, but the merchants page will never update (you can force it by right clicking on the frame and choosing reload).

More discussion can be found on Twitter here - https://twitter.com/bentasker/status/1420354891453763588