### PR TITLE
P: http://tcm-koko.ed.jp/

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -496,6 +496,7 @@
 @@||strangermeetup.com/socket.io/$~third-party
 @@||success-games.net/*/hold_ad.png?
 @@||tabiat.gov.tr/KACMS/Files/ad-$image,~third-party
+@@||tcm-koko.ed.jp/images/ad.jpg
 @@||tra.scds.pmdstatic.net/advertising-core/$domain=voici.fr
 @@||uze-ads.com/ads/$~third-party
 @@||valuecommerce.com^$image,domain=pointtown.com


### PR DESCRIPTION
This is a high-school site and a button to check results of **ad**mission is blocked by `images/ad.` The button currently returns 404 but this is no wonder as now it's not the season of admission here in Japan.

![tcm-koko](https://user-images.githubusercontent.com/58900598/127647200-321daa9e-990f-45e8-bc72-00ccf4cf18cd.png)
