### PR TITLE
M: redundant filter

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -653,7 +653,6 @@ kitchentime.fi,makujakauppa.fi##.cookie
 blogit.fi,ilmainensanakirja.fi,telsu.fi##.cookies
 matkahuolto.fi##.css-jlvvqa
 ifolor.fi##.dialogBanner--align-bottom
-vr.fi##.headerContents > .infoMessages
 timma.fi##.modal-backdrop.in
 lidl.fi,pelit.fi,telia.fi##.notification
 helmet.fi##.notifier_warning


### PR DESCRIPTION
https://www.vr.fi/ has changed and they have different type of cookie banner, to this is not relevant anymore. Vr.fi's cookie banner not blockable in ABP but in Ubo it is. (There are Ubo specific rules already for it).