### PR TITLE
P: iltalehti.fi (cookie accept button removed, and the button can't be clicked)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -25,6 +25,7 @@
 @@||businessinsider.in/gdpr_js/version-12,minify-1.cms$script,~third-party
 @@||c.evidon.com/sitenotice/evidon-sitenotice-tag.js$script,domain=southpark.de|southparkstudios.nu
 @@||carport-diagnose.de/script/cookieconsent.min.js$script,~third-party
+@@||cdn.almamedia.fi/almacmp/$script,domain=iltalehti.fi
 @@||cdn.cookielaw.org^$script,stylesheet,xmlhttprequest,domain=cnn.com|comicbook.com|crfashionbook.com|crunchyroll.com|doctoroz.com|eurogamer.net|gamespot.com|gmx.com|gq-magazine.co.uk|mail.com|popculture.com|reuters.com|rockpapershotgun.com|rp-online.de|rte.ie|trustpilot.com|tvn24.pl|uefa.com|vimeo.com|wargaming.net|worldsurfleague.com
 @@||chasecdn.com^*/cookie.js$script,domain=chase.com
 @@||civiccomputing.com^*/cookieControl-$script,domain=amplitude.com|msi.com|romania-insider.com|videogameschronicle.com

--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -6899,7 +6899,7 @@
 ##.accept-cookies-prompt
 ##.accept-cookies-toast
 ##.accept-cookies-wrapper
-##.accept-cookies:not(html)
+##.accept-cookies:not(html):not(button)
 ##.accept-my-cookie
 ##.accept-privacypolicy
 ##.acceptCookie


### PR DESCRIPTION
https://www.iltalehti.fi/kotimaa/a/7bda0d36-ad9d-4221-9f71-371881a1eb4f

![kuva](https://user-images.githubusercontent.com/17256841/128403603-9ed9288a-9e39-46d8-9b7e-4ad4cba264a0.png)


```
Sisältöä ei voida näyttää evästeasetusten vuoksi. Nähdäksesi sisällön,
hyväksy evästeiden käyttö.

```
Translation:

```
Content can't be shown due to cookie settings. In order to see the content,
please accept cookies.
```

But the accept button is removed due this filter, so added exception...

EDIT:

I also found out that a whitelist rule (network filter) is needed so that the button can be clicked.