### PR TITLE
Remove priceline.com/svcs* from the list

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -501,7 +501,6 @@
 ||pornhublive.com/api/metrics
 ||potterybarnkids.com/pkimgs/*/external/thirdparty.js
 ||priceline.com/pws/v1/ace/impression/
-||priceline.com/svcs/
 ||princetonreview.com/logging/
 ||privacy-api.9gag.com^
 ||privacyfriendly.netlify.app^


### PR DESCRIPTION
Should resolve #8538. This is breaking a couple of services for priceline.com including typeahead and email subscription. 