### PR TITLE
A: https://nitropay.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -283,6 +283,7 @@
 ||republicmonitor.com/images/lundy-placeholder.jpeg
 ||richardroeper.com/assets/banner/
 ||rpgcodex.net^*/gog_button.jpg
+||s.nitropay.com/ads-$script
 ||s.radioreference.com/sm/$image
 ||s.speedostream.com^
 ||saabsunited.com/wp-content/uploads/*banner


### PR DESCRIPTION
This commit https://github.com/easylist/easylist/commit/c95af8945069198b7882c816b243401bda1315a5 caused Easylist to allow an ad script to serve. This PR rectifies a specific case that was unblocked.