### PR TITLE
A: www.newyorker.com (fixes https://github.com/AdguardTeam/AdguardFil…

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -22485,6 +22485,7 @@
 ##div[class^="PreAd_"]
 ##div[class^="ResponsiveAd-"]
 ##div[class^="SponsoredAds"]
+##div[class^="StickyHeroAdWrapper-"]
 ##div[class^="adUnit_"]
 ##div[class^="ad_border_"]
 ##div[class^="ad_position_"]


### PR DESCRIPTION
…ters/issues/90108 and some more issues too)
https://github.com/AdguardTeam/AdguardFilters/issues/90108

Apparently sometimes covered by existing filters such as `##.ad-stickyhero` and other times not:

![ny](https://user-images.githubusercontent.com/58900598/128328470-63ada9e7-1623-48d0-b405-4b1e5f660f04.png)
