### PR TITLE
M: https://healthy.kaiserpermanente.org/front-door - more granular blocking for Dynatrace

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1610,7 +1610,7 @@
 /DynamicAnalytics.
 /dynamictag.
 /dynamicyield/*
-/dynatrace-
+/dynatrace-ag
 /dynaTraceMonitor^
 /dynimpression?rkey=
 /e.gif?


### PR DESCRIPTION
Extend the rule for Dynatrace. This still matches URLs like https://dynatrace-ag1.kp.org/jstag/managed/ea96fd35-4a91-4571-9999-391fba61c917/2244804940fc3be6_complete.js on websites like https://healthy.kaiserpermanente.org/front-door but avoids broken pages on websites like https://www.dynatrace.com/news/customers/.