### PR TITLE
A: edition.cnn.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -67,6 +67,7 @@
 ||click.livedoor.com^
 ||cloudfront.net^*/sponsors/$domain=pbs.org
 ||cnn.com/ad/
+||cnn.com/ads/
 ||codelist.cc/bluehostbanner.jpg
 ||coincheck.com/images/affiliates/
 ||coincodex.com^$subdocument,~third-party


### PR DESCRIPTION
Not sure whether `||cnn.com/ad/` is still in use.