### PR TITLE
jjcus.com

### DIFF
--- a/easylist_adult/adult_adservers.txt
+++ b/easylist_adult/adult_adservers.txt
@@ -181,6 +181,7 @@
 ||javbucks.com^$third-party
 ||jaymancash.com^$third-party
 ||joyourself.com^$third-party
+||jjcus.com^
 ||k9x.net^$third-party
 ||kadam.ru^$third-party
 ||kaplay.com^$third-party


### PR DESCRIPTION
No need for ^$third-party as there are not even a A record associated to the second level domain

Further details: https://mypdns.org/my-privacy-dns/matrix/-/issues/2529

```shell
$ drill jjcus.com
;; ->>HEADER<<- opcode: QUERY, rcode: NXDOMAIN, id: 38544
;; flags: qr rd ra ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0 
;; QUESTION SECTION:
;; jjcus.com.   IN      A

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 1 msec
;; SERVER: 127.0.0.1
;; WHEN: Wed Aug 18 11:21:49 2021
;; MSG SIZE  rcvd: 27
```