### PR TITLE
thecybersecurity.news

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1220,7 +1220,7 @@ coinmarketcap.com##.cmc-native-ad-row
 news18.com##.cn-add-section-1
 thisismoney.co.uk##.cnr5
 iotwreport.com##.code-block
-ets2.lt,geekdashboard.com,geekspin.co,getdroidtips.com,kanonitv.net,whats-on-netflix.com##.code-block-1
+thecybersecurity.news,ets2.lt,geekdashboard.com,geekspin.co,getdroidtips.com,kanonitv.net,whats-on-netflix.com##.code-block-1
 getdroidtips.com##.code-block-13
 getdroidtips.com##.code-block-15
 geekspin.co,kanonitv.net,mikeprg.com##.code-block-2


### PR DESCRIPTION
**Issue URL (Annoyance)**: https://thecybersecurity.news/general-cyber-security-news/chinese-espionage-group-unc215-targeted-israeli-government-networks-11845/


<details><summary>Screenshots:</summary>



![image](https://user-images.githubusercontent.com/76880977/128968895-527aeb7c-0535-4a3a-832e-341ade922ec6.png)

</details><br/>

<details><summary>System configuration:</summary>

![image](https://user-images.githubusercontent.com/76880977/126797496-0434116b-fc94-42c9-8139-fba02a985cf2.png)
</details><br/>