### PR TITLE
P: reklama.tochka.com [rule fix]

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5668,7 +5668,7 @@
 /reklam-ads2.
 /reklam.$domain=~reklam.com.tr
 /reklam/*$domain=~reklam.com.tr
-/reklama.$~stylesheet,domain=~pracuj.pl|~reklama.cinema.sk|~reklama.grajewo.net.pl|~reklama.mariafm.ru|~reklama.ringieraxelspringer.pl|~reklama.tochka.com
+/reklama.$~stylesheet,$domain=~pracuj.pl|~reklama.cinema.sk|~reklama.grajewo.net.pl|~reklama.mariafm.ru|~reklama.ringieraxelspringer.pl|~reklama.tochka.com
 /reklama/*
 /reklama1.
 /reklama2.


### PR DESCRIPTION
Hi guys!
I've found missing $ sign in $domain specifier according to syntax [rules](https://help.eyeo.com/adblockplus/how-to-write-filters), so actually, this didn't work for [8665](https://github.com/easylist/easylist/pull/8665).


