### PR TITLE
P: radiosun.fi (images blocking)

### DIFF
--- a/easylist/easylist_allowlist_dimensions.txt
+++ b/easylist/easylist_allowlist_dimensions.txt
@@ -7,6 +7,7 @@
 @@||leffatykki.com/media/banners/tykkibanneri-728x90.png$image,~third-party
 @@||nc-myus.com/images/pub/www/uploads/merchant-logos/$image,~third-party
 @@||przegladpiaseczynski.pl/wp-content/uploads/*-300x250-$image,~third-party
+@@||radiosun.fi/wp-content/uploads/*_300x250.$image,~third-party
 @@||reastatic.net/150x200-$domain=realestate.com.au
 @@||resize.blogsys.jp^*/300x250/$image,domain=blog.livedoor.jp
 @@||wavepc.pl/wp-content/*-500x100.png$image,~third-party

--- a/easylist/easylist_allowlist_dimensions.txt
+++ b/easylist/easylist_allowlist_dimensions.txt
@@ -7,7 +7,7 @@
 @@||leffatykki.com/media/banners/tykkibanneri-728x90.png$image,~third-party
 @@||nc-myus.com/images/pub/www/uploads/merchant-logos/$image,~third-party
 @@||przegladpiaseczynski.pl/wp-content/uploads/*-300x250-$image,~third-party
-@@||radiosun.fi/wp-content/uploads/*_300x250.$image,~third-party
+@@||radiosun.fi/wp-content/uploads/*300x250$image,~third-party
 @@||reastatic.net/150x200-$domain=realestate.com.au
 @@||resize.blogsys.jp^*/300x250/$image,domain=blog.livedoor.jp
 @@||wavepc.pl/wp-content/*-500x100.png$image,~third-party


### PR DESCRIPTION
Dimensional rules need whitelisting, non-ad pictures are removed.

https://radiosun.fi/

![kuva](https://user-images.githubusercontent.com/17256841/130686801-abefcb5a-2612-427b-8ad4-5dc23d8a9612.png)

Link to a removed image:
https://radiosun.fi/wp-content/uploads/2021/08/RL_300x250.jpg

This image was removed also, noticed it one year ago (not in the front page anymore:
https://radiosun.fi/wp-content/uploads/2020/09/Ylojarven-keilahalli-300x250-1.jpg