### PR TITLE
P: studio55.fi (article(s) removed)

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -487,6 +487,7 @@ weather.yahoo.com#@#.can_ad_slug
 business-hack.net,clip.m-boso.net,iine-tachikawa.net,meihong.work#@#.category-ads:not(html):not(body)
 blog.notebooksbilliger.de#@#.category-advertorial
 gegenstroemung.org#@#.change_AdContainer
+studio55.fi#@#.column-ad
 deals.kinja.com#@#.commerce-inset
 findicons.com,tattoodonkey.com#@#.container_ad
 insidefights.com#@#.container_row_ad


### PR DESCRIPTION
https://www.studio55.fi/

Easylist removes a couple of legit articles (red square around them).

![kuva](https://user-images.githubusercontent.com/17256841/130689525-0dee96f1-3009-4896-ab98-2c1bfd9db812.png)

![kuva](https://user-images.githubusercontent.com/17256841/130689556-bd3e1f08-85df-4389-851b-dedd198e3143.png)