### PR TITLE
Filter out blank domains in FOP.py

### DIFF
--- a/FOP.py
+++ b/FOP.py
@@ -272,7 +272,7 @@ def filtertidy (filterin):
         optionlist = sorted(set(filter(lambda option: option not in removeentries, optionlist)), key = lambda option: (option[1:] + "~") if option[0] == "~" else option)
         # If applicable, sort domain restrictions and append them to the list of options
         if domainlist:
-            optionlist.append("domain={domainlist}".format(domainlist = "|".join(sorted(set(domainlist), key = lambda domain: domain.strip("~")))))
+            optionlist.append("domain={domainlist}".format(domainlist = "|".join(sorted(set(filter(lambda domain: domain != "", domainlist)), key = lambda domain: domain.strip("~")))))
 
         # Return the full filter
         return "{filtertext}${options}".format(filtertext = filtertext, options = ",".join(optionlist))


### PR DESCRIPTION
[Cliqz](https://cliqz.com/en/whycliqz/adblocking) ignores filters containing blank domains.

Background: https://github.com/cliqz-oss/adblocker/discussions/2114#discussioncomment-1133958