### PR TITLE
Drop too short filters in FOP.py

### DIFF
--- a/FOP.py
+++ b/FOP.py
@@ -216,6 +216,9 @@ def fopsort (filename):
                         filterlines = elementlines = 0
                     outputfile.write("{line}\n".format(line = line))
                 else:
+                    # Skip filters containing less than three characters
+                    if len(line) < 3:
+                        continue
                     # Neaten up filters and, if necessary, check their type for the sorting algorithm
                     elementparts = re.match(ELEMENTPATTERN, line)
                     if elementparts:


### PR DESCRIPTION
Based on a request from @ryanbr 

If a filter contains less than three characters and is _not_ a comment, it should be dropped.

Input:

```
a
ab
abc
```

Output:

```
abc
```
