### PR TITLE
Hide specific AMP elements instead of .amp-unresolved

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -14396,7 +14396,6 @@
 ##.amp-ad
 ##.amp-ads
 ##.amp-ads-container
-##.amp-unresolved
 ##.ampFlyAdd
 ##.amsSparkleAdWrapper
 ##.anc_ads_show
@@ -17393,7 +17392,6 @@
 ##.hwg-row-ad
 ##.hyad
 ##.hype_adrotate_widget
-##.i-amphtml-unresolved
 ##.i360ad
 ##.iAdserver
 ##.iRx9
@@ -22854,6 +22852,7 @@
 ##.ampad
 ##.spotim-amp-list-ad
 ##AMP-AD
+##amp-sticky-ad
 ! Dealnews (Hearst Newspapers)
 ##div[class$="dealnews"] > .dealnews
 ! Genric mobile element

--- a/fanboy-addon/fanboy_annoyance_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_general_hide.txt
@@ -3698,3 +3698,5 @@
 ###searchform > #gb > #gbw .gb_Mc[aria-label="promo"] > .gb_ea
 ! Google default homepage nag
 ###searchform > #gb > #gbw .gb_Vc[aria-label="promo"] > .gb_ga
+! Amp
+##amp-apester-media

--- a/fanboy-addon/fanboy_notifications_general_hide.txt
+++ b/fanboy-addon/fanboy_notifications_general_hide.txt
@@ -150,6 +150,7 @@
 ##.window-push
 ##.wordpress-fire-push-popup
 ##.ys-push
+##amp-user-notification
 ##amp-web-push-widget
 ##div[class^="container_NotificationsBanner_"]
 ! Mobile Notifications


### PR DESCRIPTION
AMP adds `.amp-unresolved` to every element while its associated JS file is being downloaded. When the JS file is downloaded, the element is "upgraded" and we remove the `.amp-unresolved` class.

I believe easylist is taking advantage of this to hide the elements that have their JS blocked. However, this causes a lot of Cumulative Layout Shift issues, because elements are popping into view when the JS downloads. Eg, all of our `<amp-img>` (which aren't blocked by easylist) start as `display: none` and then once they're upgraded they become visible, causing shifts.

This is a big issue for us, as one of our core goals is for elements to never shift the pages layout. We go through a lot work to make sure every AMP element on the page has the correct size as early as possible.

Worse yet, AMP is working on a new element upgrade system that defers expensive work until it's necessary. We've essentially implemented something just like lazy loading images, but it'll work for every AMP element on the page. This depends on knowing exactly where the element is on the page, so that we can defer the upgrade until it's near viewport. Because easylist is hiding every AMP element on the page, our `IntersectionObserver` will never fire. This means we'll never upgrade the element (and we'll never remove the `.amp-unresolved` class because that happens _after_ upgrade). So every AMP element just stays hidden permanently. See https://github.com/ampproject/amphtml/pull/35845.

So instead hiding elements indirectly through `.amp-unresolved`, I've gone through and hidden the specific element that's associated with a blocked JS file.

| List                                   | Blocked JS                                                              | Hidden Elements                                                          |
|----------------------------------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------|
| fanboy_notifications_general_block.txt | - `/amp-user-notification-` <br> - `/amp-web-push-`                     | - `##amp-user-notification` <br> - `##amp-web-push-widget`               |
| fanboy_annoyance_general_block.txt     | - `/amp-apester-`                                                       | - `##amp-apester-media` (**new**)                                        |
| fanboy_social_general_block.txt        | - `/amp-social-`                                                        | - `##amp-social-share`                                                   |
| easylist_cookie_general_block.txt      | - `/amp-consent-`                                                       | - `##amp-consent`                                                        |
| easylist_general_block.txt             | - `/amp-ad-` <br> - `/amp-auto-ads-` <br> - `/amp-sticky-ad-` (**new**) | - `##amp-ad` <br> - `##amp-custom-ad` <br> - `##amp-sticky-ad` (**new**) |

(This effectively reverts https://github.com/easylist/easylist/commit/f1e088a3f00)