### PR TITLE
A: https://kissanimes.su/ep/kanojo-okarishimasu-episode-3-english-sub…

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -448,6 +448,7 @@
 ||ratesupermarket.ca/widgets/
 ||rcm*.amazon.$third-party
 ||readme.ru/informer/
+||recipefy.net/rssfeed.php
 ||redirect-ads.com^$~subdocument,third-party
 ||redtram.com^$script,third-party
 ||regnow.com/vendor/

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1617,6 +1617,7 @@
 ||realtidbits.com^*/analytics.js
 ||rebel.ai/track?
 ||recart.com/tracking/
+||recipefy.net/analytics.js
 ||recs.atgsvcs.com^$third-party
 ||redditstatic.com/ads/pixel.js
 ||redfast.com/ping/


### PR DESCRIPTION
…bed/1071719/
https://github.com/easylist/easylist/pull/8631 again, but somehow ads are not visible this time:

![kissanimes](https://user-images.githubusercontent.com/58900598/131252224-7b67bb24-8306-4f8d-a5c8-9e6ae784db21.png)

`recipefy.net/analytics.js` is apparently only used in those widgets and not in recipefy site itself so may be redundant - no request if `recipefy.net/rssfeed.php` is already blocked.

![kissanimes2](https://user-images.githubusercontent.com/58900598/131252280-4d25a69b-6bfa-45f8-8594-5f726d13c503.png)
