### PR TITLE
A: espoo.fi (generic cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -12368,6 +12368,7 @@
 ##[aria-describedby="dialog-eu-cookie-law"]
 ##[aria-label="cookieconsent"]
 ##[aria-labelledby="ui-dialog-title-cookiebox"]
+##[aria-labelledby=cookie-dialog]
 ##[class^="CookieMessage_"]
 ##[class^="FooterGDPR"]
 ##[cnn-cookie-policy]


### PR DESCRIPTION
https://www.espoo.fi/en

The site has changed so cleaned old entries at the same time.