### PR TITLE
P: iltalehti.fi (Twitter tweets removed)

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -77,6 +77,7 @@ adobe.com,epicgames.com,tomshardware.com#@#.SocialButton
 epicgames.com#@#.SocialIcon
 ctvnews.ca#@#.StoryShareBottom
 twitter.com#@#.Twitter-icon
+iltalehti.fi#@#.twitter-container
 yachtingjournal.com#@#.addthis:not(body)
 onbeing.org#@#.addthis_32x32_style
 free18.net,onbeing.org#@#.addthis_default_style


### PR DESCRIPTION
https://www.iltalehti.fi/kotimaa/a/ab17fc98-f600-4ce3-a92e-51753726b467

Social blocking list removes embedded tweets.