### PR TITLE
D: pushinpage.com

### DIFF
--- a/fanboy-addon/fanboy_notifications_thirdparty.txt
+++ b/fanboy-addon/fanboy_notifications_thirdparty.txt
@@ -48,7 +48,6 @@
 ||pushe.co^$third-party
 ||pusherapp.com^$third-party
 ||pushiki.ru^$third-party
-||pushinpage.com^$third-party
 ||pushinstruments.com^$third-party
 ||pushkahouse.com^$third-party
 ||pushkaplus.com^$third-party


### PR DESCRIPTION
I suggest we removes `||pushinpage.com^$third-party` as already listed in the easylist_adservers.txt

And the $domain.tld is anyhow only a API frontend

Relates to:
  - https://github.com/easylist/easylist/pull/7552
  - https://mypdns.org/my-privacy-dns/matrix/-/issues/2610