### PR TITLE
A: www.is.fi (empty article sharing container remnant)

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -383,6 +383,7 @@ oneindia.com###youtube_promo
 opposingviews.com###yt
 petri.com,voiceofsandiego.org##.-social
 aboutamazon.co.uk,aboutamazon.com,iowapublicradio.org,latimes.com,sandiegouniontribune.com,washingtonexaminer.com,weeklystandard.com,wgbh.org##.ActionBar
+www.is.fi##.ab-test-article-sharing
 yahoo.com##.Btn-t
 comicbookmovie.com##.CBMFollow
 alwaght.com##.FollowLinks


### PR DESCRIPTION
https://www.is.fi/tampereen-seutu/art-2000008240088.html

![kuva](https://user-images.githubusercontent.com/17256841/132023692-1155c7dc-d5a2-42a5-b50d-66db59648e12.png)

I think it's better to retain www. part due to domain name being very short, so that it won't target any unintentional domains.