### PR TITLE
A: https://blog.csdn.net/m0_59537084/article/details/120079513

### DIFF
--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -318,6 +318,7 @@ jarir.com##a[title="top"]
 acfun.cn###btn-top-shortcut
 699pic.com###landlord
 thestandnews.com###mc_embed_signup
+blog.csdn.net###passportbox
 thepaper.cn###pjax-switch
 ifeng.com###qrCode
 xiachufang.com###scrollTop
@@ -342,6 +343,7 @@ sogou.com##.index-top
 hisense.com##.js-return-top
 sg169.com##.jy-pos-3
 baike.com##.li-top
+blog.csdn.net##.login-mark
 cyberctm.com##.news-control
 am730.com.hk##.news-pagination
 qq.com##.qm_toolbarSubTitle


### PR DESCRIPTION
Fix https://github.com/uBlockOrigin/uAssets/issues/9697#issuecomment-892831828
The page will automatically pop up the login window.
Login is hosted at https://passport.csdn.net/account/login, nothing is broken by blocking that overlay.
![2021-08-04_20-58-25](https://user-images.githubusercontent.com/66902050/128184856-d35fbebd-ef2f-4187-80a4-8da8f04b272c.gif)