### PR TITLE
Remove extra anchor before data: protocol

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -23,7 +23,7 @@
 @@||adv.gg^$popup
 @@||adv.welaika.com^$popup
 @@||dashboard.mgid.com^$popup
-@@||data:text^$popup,domain=box.com|clker.com|labcorp.com|zipit.io
+@@|data:text^$popup,domain=box.com|clker.com|labcorp.com|zipit.io
 @@||doubleclick.net/clk;$popup,domain=3g.co.uk|4g.co.uk|hotukdeals.com|jobamatic.com|play.google.com|santander.co.uk|techrepublic.com
 @@||g.doubleclick.net/aclk?$popup,domain=bodas.com.mx|bodas.net|casamentos.com.br|casamentos.pt|casamiento.com.uy|casamientos.com.ar|mariages.net|matrimonio.com|matrimonio.com.co|matrimonio.com.pe|matrimonios.cl|pianobuyer.com|weddingspot.co.uk|zillow.com
 @@||hutchgo.advertserve.com^$popup,domain=hutchgo.com|hutchgo.com.cn|hutchgo.com.hk|hutchgo.com.sg|hutchgo.com.tw


### PR DESCRIPTION
There should be only one `|` before the protocol. e.g. `|https://example.com/`.