### PR TITLE
A: facebook.com (right rail ad)

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2067,6 +2067,7 @@ freshplaza.com##a.banner
 facebook.com,facebookcorewwwi.onion##a[ajaxify*="&eid="] + a[href^="https://l.facebook.com/l.php?u="]
 facebook.com##a[aria-label="Advertiser link"]
 facebook.com##a[aria-label="Advertiser"]
+facebook.com#?#div[data-pagelet="RightRail"] > div:-abp-has(a[aria-label][aria-labelledby][rel="nofollow noopener"][role="link"][target="_blank"][tabindex="0"])
 alibaba.com##a[campaignid][target="_blank"]
 bernama.com##a[class^="banner_photo_"]
 probuilds.net##a[class^="dl-blitz-"]


### PR DESCRIPTION
A rule to hide the right rail ad, language neutral version.

This current rule in EL:
`facebook.com##a[aria-label="Advertiser"]` hides the ad under "Sponsored" label in English FB, but not the Sponsored label itself.

My rule hides the whole thing (both label and ad), language neutrally.

![kuva](https://user-images.githubusercontent.com/17256841/132062333-bf79c427-b3da-422d-99a7-d9611fc6015d.png)

Screenshot of the ad this rule targets.