### PR TITLE
M: fix Matomo Marketplace HeatmapSessionRecording plugin

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2178,7 +2178,7 @@
 /headupstats.gif?
 /healthanalytics.js
 /heatmap_log.js
-/HeatmapSessionRecording/*
+/HeatmapSessionRecording/*$domain=~shop.matomo.org|~plugins.matomo.org
 /hg?hc=&hb=*&vjs=
 /hgct?hc=&hb=*&vjs=
 /hints.netflame.cc/*


### PR DESCRIPTION
fixes https://github.com/uBlockOrigin/uBlock-issues/issues/1708

This allows no additional tracking, but makes sure that the HeatmapSessionRecording plugin can be bought here successfully:
https://plugins.matomo.org/HeatmapSessionRecording