### PR TITLE
A: iltalehti.fi (cookie banner hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -414,6 +414,7 @@ autotask.com##.alertbar
 investec.com##.alerts-top
 newsnow.co.uk##.alertsscroll_container
 aliexpress.com##.aliexpress-notice
+iltalehti.fi##.alma-cmpv2-container
 marsh.com##.alt-opt-secure
 codesignal.com##.analytics-banner
 giraffe360.com##.animate-privacy-policy-show


### PR DESCRIPTION
https://www.iltalehti.fi/

Note: this site has cookie script allowed because blocking of it causes issues: https://github.com/easylist/easylist/pull/8508

But the cookie overlay can be safely hid without an issue.