### PR TITLE
P: vr.fi (login dialog blocked)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -87,8 +87,8 @@ bundesanzeiger.de###cc
 interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
 paihdelinkki.fi###sliding-popup.sliding-popup-bottom
-vr.fi##div[data-testid="modal"]
 aixfoam.*##[id="cc-notification"]
+vr.fi##body > script[src] + div[data-testid="modal"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
 esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -20,6 +20,7 @@ mega.io,mega.nz##.overlayed .bottom-page.scroll-block:style(filter: none !import
 aixfoam.*##.wrapper:style(filter: none !important)
 schulze-immobilien.de##*:style(filter: none !important)
 gov.lv##body:style(overflow: auto !important;)
+vr.fi##div[data-testid="modal"]:not(:has(div[data-testid="cookie-consent-modal"])):style(display: block !important)
 !
 backmarket.de##._3NAusrrr
 bing.com##.bnp_cookie_banner
@@ -87,8 +88,8 @@ bundesanzeiger.de###cc
 interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
 paihdelinkki.fi###sliding-popup.sliding-popup-bottom
+vr.fi##div[data-testid="modal"]
 aixfoam.*##[id="cc-notification"]
-vr.fi##body > script[src] + div[data-testid="modal"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
 esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())


### PR DESCRIPTION
Cookie dialog hiding rule hides also the login dialog. The issue is that the cookie dialog and login dialog have the exact same name:

`##div[data-testid="modal"]`

And using pseudo selectors such as `:nth-of-type()` won't help here because those elements change their position, depending if you have previously accepted cookies for this site or not. Also opening the login dialog changes things.

So I took a different approach. I'll let `##div[data-testid="modal"]` to hide the dialog but I added another rule: `##div[data-testid="modal"]:not(:has(div[data-testid="cookie-consent-modal"])):style(display: block !important)` to force the (login) dialog to go visible, if the dialog doesn't contain `cookie-consent-modal` as a descendant. The latter rule is indeed a procedural but it doesn't matter, the login dialog will show up very quickly anyway. And there won't be a blink of that cookie dialog at all as it will be hid via standard css rule.

Test link: https://www.vr.fi/en/train-tickets/multi-ticket

Click "Log in"
![image](https://user-images.githubusercontent.com/17256841/133826732-870e4f50-4d31-4f51-b266-4c243f734443.png)