### PR TITLE
Inoreader: Hide ad-area between posts

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1771,6 +1771,7 @@ atlasobscura.com##.siderail-bottom-affix-placeholder
 nabble.com##.signature
 greatis.com##.sing
 inoreader.com##.sinner_inner
+inoreader.com##.sinner.ad_size_mobile_leaderboard.mobile_leaderboard_ad.block_article_ad
 deshdoaba.com##.site-branding
 sassyhongkong.com##.site-leaderboard
 wahcricket.com##.site-mainhead


### PR DESCRIPTION
Currently, Inoreader hides the actual advertising, but leaves the placeholder for advertising posts between RSS messages. This will be hidden herewith.