### PR TITLE
P: iltalehti.fi (anti adblock nag, whitelist to be undetected)

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -39,6 +39,7 @@ flat-ads.com,job.inshokuten.com#@#.ad-content
 transparencyreport.google.com#@#.ad-icon
 flat-ads.com,lastpass.com#@#.ad-img
 guloggratis.dk#@#.ad-links
+iltalehti.fi#@#.ad-placement
 hulu.com#@#.ad-root
 wiki.fextralife.com#@#.ad-sidebar
 wegotads.co.za#@#.ad-source


### PR DESCRIPTION
`https://www.iltalehti.fi/iltv-paivarinta/a/efc6d8b4-0806-4696-a6b3-1b652c7d9964`

If filter `##.ad-placement` is in use, the site will detect adblockers. Whitelisting this element makes adblocking undetected. Whitelisting that element won't show any ads.

![kuva](https://user-images.githubusercontent.com/17256841/134344380-7512a933-9615-426c-8a9f-9e4aa3af4139.png)

`Tämä sisältö on sinulle maksuton. Maksuttomuus on mahdollista ilmoitustuloilla, joten siksi tämän videon katsominen edellyttää Adblocker-ohjelman poistamista.`

Translation:
`
This content is free of charge for you. Freeness is possible with notification revenue, which is why watching this video requires removing an adblocker program.`