### PR TITLE
A: vuokraovi.com (specific data policy banner hide for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -22,6 +22,7 @@ schulze-immobilien.de##*:style(filter: none !important)
 gov.lv##body:style(overflow: auto !important;)
 !
 backmarket.de##._3NAusrrr
+vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
 elisaviihde.fi##.ea-cookie-disclaimer
 acea.it###cookieModal


### PR DESCRIPTION
https://www.vuokraovi.com/

Generic filter to hide this: `.alma-data-policy-banner` blinks occasionally in uBO, so a specific filter is needed.