### PR TITLE
A: jarviseudunsanomat.fi (generic cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -4662,6 +4662,7 @@
 ###hardloop-cookie-notice
 ###have-a-cookie
 ###hays-cookie-notice
+###haveacookie
 ###hb-cc-wrap
 ###hbCookieConsentDialog
 ###hc_evt_tooltip_modal


### PR DESCRIPTION
https://www.jarviseudunsanomat.fi/