### PR TITLE
A: https://www.bilibili.com/

### DIFF
--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -363,6 +363,7 @@ cctv.com##.weima
 ||4gtv.tv^*/scriptUP.
 ||jsdelivr.net/gh/huang545/huang1111@1.0/bottom.png
 ||pcbeta.com/data/cache/blstGHLORZ.js
+||s1.hdslb.com/bfs/seed/jinkela/short/auto-append-spmid.js
 ||static.iqiyi.com/js/common/mars_v.js
 !
 ! ---------- Croatian Site Specific Hiding Rules ----------


### PR DESCRIPTION
This web script will automatically add the tracking parameter `?spm_id_from` after the link on the page
But since it's adding tracking parameters to the link, I don't know if this needs to be added to `EasyPrivacy`