### PR TITLE
P: kiuruvesilehti.fi,urjalansanomat.fi (scrolling blocked if cookies not accepted)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -92,6 +92,7 @@ vr.fi##div[data-testid="modal"]
 aixfoam.*##[id="cc-notification"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
+kiuruvesilehti.fi,urjalansanomat.fi##+js(acs, cm_limit)
 esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())
 ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -92,7 +92,7 @@ vr.fi##div[data-testid="modal"]
 aixfoam.*##[id="cc-notification"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
-kiuruvesilehti.fi,urjalansanomat.fi##+js(acs, cm_limit)
+kiuruvesilehti.fi,urjalansanomat.fi##+js(aeld, scroll, innerHeight)
 esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())
 ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)


### PR DESCRIPTION
https://kiuruvesilehti.fi/
https://urjalansanomat.fi/

When cookies are not accepted on these sites, they will limit your scrolling so that you can only scroll and view a small part of the site.

Added fixes. Code responsible for this behavior:

```
function cm_limit(elh) {
	window.scrollTo(0,0);
	var vh = window.innerHeight;
	if (vh > elh) elh = vh;
	cm_elh = elh;
	var doc = document.documentElement;
	window.addEventListener('scroll',function(e) {
		var vh = window.innerHeight;
		var allow = cm_elh; /* - vh + 0; */
		var top = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
		if (top > allow) 
			window.scrollTo(0, allow);
	});
}
```
