### PR TITLE
A: www.future-labo.com

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -293,6 +293,7 @@
 /acbeacon2.
 /accAnal.js
 /AccessCounter/*
+/accessanalyzer/tracker?
 /accesslog?
 /accesstracking/*
 /AccessTrackingLogServlet?


### PR DESCRIPTION
What had been caught by now-removed `/tracker?*=`.