### PR TITLE
A: https://readcomicsonline.ru

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -1,4 +1,6 @@
 ! Non-flagged (Generic blocks)
+||windsplay.com^
+||everalwerf.xyz^
 ||006a039c957c142bb.com^
 ||00aaa2d81c1d174.com^
 ||012469af389a1d1246d.com^

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -394,8 +394,6 @@
 ||youtube.com/ad_companion
 ||youtube.com/pagead/
 ||zdnet.com/leadgen/
-||windsplay.com$script
-||everalwerf.xyz^
 !
 /^https?:\/\/.*.(club|bid|biz|xyz|site|pro|info|online|icu|monster|buzz|fun|website|biz|re|me|casa|top|space|network|live|work|systems|me|ml|world|life)\/.*/$third-party,domain=9xupload.xyz|bdupload.asia|desiupload.co|downloadpirate.com|flashx.net|flashx.tv|powvideo.net|powvldeo.me|slreamplay.cc|steanplay.cc|streanplay.cc|videobin.co
 !

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -394,6 +394,8 @@
 ||youtube.com/ad_companion
 ||youtube.com/pagead/
 ||zdnet.com/leadgen/
+||windsplay.com$script
+||everalwerf.xyz^
 !
 /^https?:\/\/.*.(club|bid|biz|xyz|site|pro|info|online|icu|monster|buzz|fun|website|biz|re|me|casa|top|space|network|live|work|systems|me|ml|world|life)\/.*/$third-party,domain=9xupload.xyz|bdupload.asia|desiupload.co|downloadpirate.com|flashx.net|flashx.tv|powvideo.net|powvldeo.me|slreamplay.cc|steanplay.cc|streanplay.cc|videobin.co
 !


### PR DESCRIPTION
Filters for blocking scripts and subdocument related to ads at [readcomicsonline](https://readcomicsonline.ru/comic/inferno-2021/1/3)

Proposed blocking filters: 
Placeholders in all subpages and main page: `||windsplay.com$script`
Referrals after clicking the comics to pass the page: `||everalwerf.xyz^`

How to reproduce the referral: Go to [comics](https://readcomicsonline.ru/comic/sword-2020/8) and click above the cartoon or try to click at "home" button at the header.

Screenshot of placeholders + script:
<img width="1440" alt="Screenshot 2021-09-30 at 10 20 52" src="https://user-images.githubusercontent.com/65717387/135463002-e3fcd697-11ec-445f-8c77-3c5a6e21f091.png">
 
