### PR TITLE
A: uusisuomi.fi (specific cookie hide uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -23,7 +23,7 @@ gov.lv##body:style(overflow: auto !important;)
 !
 backmarket.de##._3NAusrrr
 ylasatakunta.fi##.ag_cookie_banner
-vuokraovi.com##.alma-data-policy-banner
+uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
 luhta.com##.cookie-consent
 elisaviihde.fi##.ea-cookie-disclaimer


### PR DESCRIPTION
The element blinked on this domain https://vapaavuoro.uusisuomi.fi/

But it's reasonable to cover the main domain as well, and also it's subdomains via one rule.

Subdomains:
https://vapaavuoro.uusisuomi.fi/
https://puheenvuoro.uusisuomi.fi/

Main domain:
https://www.uusisuomi.fi/