### PR TITLE
A: https://www.jianshu.com/p/31cbbbc5f9fa/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -360,6 +360,7 @@
 ||tce.alicdn.com^
 ||tns.simba.taobao.com^
 ||toruk.tanx.com^
+||tr.jianshu.com^
 ||tr.n2.hk^
 ||track.ra.icast.cn^
 ||track.tomwx.net^

--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -31,3 +31,10 @@ monroenews.com,poconorecord.com##body,html:style(height: auto !important; overfl
 ! audioholics
 audioholics.com##.modal
 audioholics.com##.modal-backdrop
+! jianshu.com (mobile)
+jianshu.com##.call-app-btn
+jianshu.com##.collapse-tips
+jianshu.com##.download-app-guidance
+jianshu.com##.dt-open-bg[data-scene="leftBtn"]
+jianshu.com##.collapse-free-content:style(overflow: auto !important;height: auto !important)
+jianshu.com##body:style(overflow: auto !important)


### PR DESCRIPTION
Fixes https://github.com/easylist/easylist/pull/9154
Fixes https://github.com/easylist/easylist/pull/9149
<details><summary>Pull #9154</summary>

Ref: https://github.com/AdguardTeam/AdguardFilters/pull/89571

The page will collapse the content and when the button to expand the content is clicked, the page will promote its own products.

These rules can automatically expand all content, thus blocking self-promotion

![Screenshot_2021-09-12-23-47-23-986_org mozilla firefox](https://user-images.githubusercontent.com/66902050/132994129-ac485d3f-b6ca-44c1-b28c-042b99149b58.jpg)
</details>

<details><summary>Pull #9149</summary>

This is a tracker on the website

![Screenshot_2021-09-18-00-21-28-598_org mozilla firefox](https://user-images.githubusercontent.com/66902050/133821701-628ff90a-803c-49e0-8439-f13a39f021d7.jpg)
</details>