### PR TITLE
A: theverge.com (cookie banner hide for non video articles)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -905,6 +905,7 @@ iubenda.com##a[style="padding-top: 10px; display: block;"]
 shab.ch##agb-bar
 orcid.org##app-banners
 bethesda.net#?#visor-alert[name="visor-alert"] > div[class=""] > div > div:last-child:-abp-has( > a[href$="/cookie-policy"])
+theverge.com#?#.m-privacy-consent:not(:-abp-has(~ .l-root .c-video-embed))
 myscience.org##body > .block > .center
 openbookpublishers.com##body > .menu-header
 facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]


### PR DESCRIPTION
In this site, cookies have to be accepted in order to see embedded videos. But as not all articles have embedded videos, it's not needed to whitelist the whole site, only those articles that actually have videos (one browsing the site might not always read articles that have videos, those articles are a minority.).

I know this filter blinks sometimes but it will be fixed when browsers start to support CSS4 (and native `:has`). But even a small blink is better than not to hide that big annoying banner at all.

Article having an embedded video (banner won't be hid):
https://www.theverge.com/2018/8/21/17761424/

Article not having an embedded video: (banner will be hid)
https://www.theverge.com/22705148/windows-11-upgrade-beta-release-preview-impressions

