### PR TITLE
mistaken entry

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -10038,7 +10038,6 @@
 ||qppdqcid.com^
 ||qptqoylpxmqbz.com^
 ||qpwiyfmlkhbxop.com^
-||qqqporn.com^
 ||qqqwes.com^
 ||qrclevrfjw.com^
 ||qrezvwhtppiv.com^


### PR DESCRIPTION
not an ad server, in fact [qqqporn.com](https://qqqporn.com/) does not serve ads at all