### PR TITLE
Remove /reporting/metrics - too generic

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3542,7 +3542,6 @@
 /reporting.do?
 /reporting/analytics.js
 /reporting/campaignresolution/?
-/reporting/metrics
 /request_tracker+
 /RequestTrackerServlet?
 /resmeter.js


### PR DESCRIPTION
Removes /reporting/metrics which is breaking multiple b2b products, fixes issue: https://github.com/easylist/easylist/issues/9274