### PR TITLE
P: manba.co.jp/manba_magazines/38

### DIFF
--- a/fanboy-addon/fanboy_social_thirdparty.txt
+++ b/fanboy-addon/fanboy_social_thirdparty.txt
@@ -51,7 +51,7 @@
 ||dailymotion.com/badge/user/$third-party
 ||digg.com^$script,subdocument,third-party
 ||diggstatic.com^*/follow_buttons/
-||digitiminimi.com^$third-party
+||jsoon.digitiminimi.com^$third-party
 ||encrypted-tbn2.gstatic.com/images?$domain=vitorrent.org
 ||facebook.com*/plugins/like.php?$third-party
 ||facebook.com/connect/connect.*connections$third-party,domain=~farmville.com


### PR DESCRIPTION
### List the website(s) you're having issues:

`https://manba.co.jp/manba_magazines/38/`

### What happens?

`||digitiminimi.com^$third-party` in Fanboy's Social blocks images in the article when cname uncloaking enabled.

#### Current behaviour
<details><summary>Screenshot:</summary>

![image (current)](https://user-images.githubusercontent.com/82331005/136011285-6255fc6b-95c1-4ba2-a8e9-9b30b0b2f384.png)
</details>

#### Expected behaviour
<details><summary>Screenshot:</summary>

![image (expected)](https://user-images.githubusercontent.com/82331005/136011605-38548c70-963f-4dad-9646-a4bd88e94a21.png)
</details>

### Other details:
For the usage of `||digitiminimi.com^$third-party` as a social widget, see 
-  https://github.com/easylist/easylist/pull/7772


