### PR TITLE
A: yle.fi (cookie dialog hide for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,5 +1,7 @@
 ! uBO Sepecific fixes
 ! :style fixes
+yle.fi###yle-consent-sdk-container:style(display: none)
+yle.fi###yle-consent-sdk-container:has(~ .yle__app a[href^="https://twitter.com/"]):style(display: block !important)
 wetter.at##.full.blured:style(filter: none !important;)
 taloon.com##.header__top:style(position: unset !important)
 bosch-easycontrol.com##.modal-open:style(overflow: auto !important; padding-right: 0 !important;)
@@ -8,7 +10,7 @@ html5games.com##div[class="app-container"]:style(filter:none !important;opacity:
 gesund24.at,oe24.at,wirkochen.at,xn--sterreich-ppa80c.at##.wrapper.blured:style(filter: none !important;)
 germany.travel##body.consent-overlay:style(overflow:auto !important)
 kpcen-torun.edu.pl,taxfix.de,analog.com,zeoob.com##body.modal-open:style(overflow:auto !important)
-adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
+adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-yle.fi,image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
 anacondastores.com,bing.com,1blu.de,vaillant.de,interfriendship.de,interfriendship.at,interfriendship.ch,interfriendship.com,western-men.com,sajt-znakomstv-interfriendship.ru,noriel.ro,sufilog.com,iracing.com,reuters.com,okazik.pl,pamiatki.pl,asseco.com,craftserve.pl,pressherald.com,thw.de,techmot24.pl##html:style(overflow: auto !important)
 okazii.ro,terveyskirjasto.fi##body:style(overflow: scroll !important)
 earthsky.org,e-wie-einfach.de,nerim.com,markets.com,researchaffiliates.com,nmhh.hu,zsgarwolin.pl,pelix-media.de##body,html:style(height: auto !important; overflow: auto !important)


### PR DESCRIPTION
Fixes #8518

My set of filters will:

1. Open scrolling
2. Hide the cookie dialog (without any blinking)
3. Force the cookie dialog to be shown when the article has an embedded tweet

Test links:
https://yle.fi/uutiset/3-12127230 (doesn't have a tweet)
https://yle.fi/uutiset/3-11972567 (has a tweet)
