### PR TITLE
M: add regex to catch revolving adservers on NSFW sites

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7322,6 +7322,8 @@ takeover_banner_
 /pop2.js
 ! Native advert
 /\:\/\/data.*\.com\/[a-zA-Z0-9]{30,}/$third-party,xmlhttprequest
+! porn ad script
+/^https:\/\/[0-9a-f]{10}\.[0-9a-f]{10}\.com\/[0-9a-f]{32}\.js$/$script,third-party
 ! Ad-insertion script (see on: celebrityweightloss.com, myfirstclasslife.com, cultofmac.com)
 .webp?*&cb=$script,~third-party
 /banger.js


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/96575
https://github.com/AdguardTeam/AdguardFilters/issues/95717
https://github.com/AdguardTeam/AdguardFilters/issues/95978
https://github.com/uBlockOrigin/uAssets/issues/10147
https://github.com/AdguardTeam/AdguardFilters/commit/04b1522a9c75a14e8ee5c7e02de7fe18a79f5913
https://github.com/AdguardTeam/AdguardFilters/commit/cf989ea00ebdfb97d131a688da02db45324049bf
https://github.com/easylist/easylistchina/commit/0a4b1c7ae5fc213d5787058c6724e14803e27de5

Those adservers have been changing daily and it's unlikely old domain to be reused.