### PR TITLE
Improve specificity of citi.com tracker block

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1552,7 +1552,7 @@
 /Diagnostics?hit=
 /didna-pixel-
 /diffuser.js
-/digital//reporting/metrics
+/digital/reporting/metrics
 /digital-data-enrichment.
 /DigitalAnalytics.umd.
 /digitalice_tag.js

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1552,6 +1552,7 @@
 /Diagnostics?hit=
 /didna-pixel-
 /diffuser.js
+/digital//reporting/metrics
 /digital-data-enrichment.
 /DigitalAnalytics.umd.
 /digitalice_tag.js
@@ -3543,7 +3544,6 @@
 /reporting.do?
 /reporting/analytics.js
 /reporting/campaignresolution/?
-/reporting/metrics
 /request_tracker+
 /RequestTrackerServlet?
 /resmeter.js


### PR DESCRIPTION
Improves the specificity of the block issued for https://github.com/easylist/easylist/issues/9233, while taking into account concerns raised in https://github.com/easylist/easylist/issues/9274