### PR TITLE
A: kotipizza.fi (cookie banner hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -663,6 +663,7 @@ ifolor.fi##.dialogBanner--align-bottom
 timma.fi##.modal-backdrop.in
 lauttakyla.fi##.modalElement
 lidl.fi,pelit.fi,telia.fi##.notification
+kotipizza.fi##.notification-bottom-margin.notification-warning
 helmet.fi##.notifier_warning
 suomi24.fi##.s24_cc_banner-wrapper
 terveystalo.com##.st-consent-banner


### PR DESCRIPTION
https://www.kotipizza.fi/tuotteet/rullat/kebabrulla

Note, the banner is only visible on the first page load. If you refresh the page, it will always disappear (need to clear cache to see it again).

![kuva](https://user-images.githubusercontent.com/17256841/136667149-8dab9562-2f94-466d-baa6-8400dc591e08.png)
