### PR TITLE
A: bbc.com (cookie dialog hide for non-video pages, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -4,13 +4,14 @@ yle.fi###yle-consent-sdk-container:style(display: none)
 yle.fi###yle-consent-sdk-container:has(~ .yle__app h2:has-text(Sisältöä ei voida näyttää)):style(display: block !important)
 wetter.at##.full.blured:style(filter: none !important;)
 taloon.com##.header__top:style(position: unset !important)
+bbc.com##body:has(div[class*="Styled"][class*="Container"] [data-testid="bbc-logo-wrapper"]) > .fc-consent-root:style(display: flex !important)
 bosch-easycontrol.com##.modal-open:style(overflow: auto !important; padding-right: 0 !important;)
 taloon.com##.page-header:style(padding-top: 0 !important)
 html5games.com##div[class="app-container"]:style(filter:none !important;opacity:1 !important)
 gesund24.at,oe24.at,wirkochen.at,xn--sterreich-ppa80c.at##.wrapper.blured:style(filter: none !important;)
 germany.travel##body.consent-overlay:style(overflow:auto !important)
 kpcen-torun.edu.pl,taxfix.de,analog.com,zeoob.com##body.modal-open:style(overflow:auto !important)
-yle.fi,adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
+bbc.com,yle.fi,adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
 anacondastores.com,bing.com,1blu.de,vaillant.de,interfriendship.de,interfriendship.at,interfriendship.ch,interfriendship.com,western-men.com,sajt-znakomstv-interfriendship.ru,noriel.ro,sufilog.com,iracing.com,reuters.com,okazik.pl,pamiatki.pl,asseco.com,craftserve.pl,pressherald.com,thw.de,techmot24.pl,rocket-league.com##html:style(overflow: auto !important)
 okazii.ro,terveyskirjasto.fi##body:style(overflow: scroll !important)
 earthsky.org,e-wie-einfach.de,nerim.com,markets.com,researchaffiliates.com,nmhh.hu,zsgarwolin.pl,pelix-media.de##body,html:style(height: auto !important; overflow: auto !important)
@@ -30,6 +31,7 @@ uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
 luhta.com##.cookie-consent
 elisaviihde.fi##.ea-cookie-disclaimer
+bbc.com##.fc-consent-root
 pringles.com##.truste_box_overlay
 pringles.com##.truste_overlay
 luhta.com###cookie-consent


### PR DESCRIPTION
This set of filters will:

1. unlock scrolling
2. hide the cookie dialog
3. force the cookie dialog to be shown on those pages that have videos needing to accept cookies (not all videos need this) - if a video container has `[data-testid="bbc-logo-wrapper"]`, then it's needed to accept cookies.

Sample links:
https://www.bbc.com/news/technology-58490048 (no videos, dialog will be hid)
https://www.bbc.com/news/av/world-us-canada-58823812 (video at the beginning, dialog won't be hid)
https://www.bbc.com/news/world-us-canada-58820070 (video at the end, dialog won't be hid)
https://www.bbc.com/news/world-asia-58842793 (video that does not need accepting cookies, dialog will be hid)