### PR TITLE
M: remove obsolete tracker

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2327,7 +2327,6 @@
 ||surveyscout.com^$third-party
 ||surveywriter.com^$third-party
 ||survicate.com^$third-party
-||swcs.jp^$third-party
 ||swfstats.com^$third-party
 ||swiss-counter.com^$third-party
 ||synergy-e.com^$third-party


### PR DESCRIPTION
See `http://fdu.a.swcs.jp/1/j/` used on `www.eiga-log.com`.