### PR TITLE
Filter for theyarehuge.com

### DIFF
--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -100,9 +100,9 @@ chaturbate.com,playboy.com,rampant.tv,sex.com,signbucks.com,tallermaintenancar.c
 pinflix.com##.ad-container
 xtube.com##.adContainer
 sex3.com##.add-box
-babesandstars.com,gosexy.mobi,javseen.tv,mobilepornmovies.com,mypornstarbook.net,pichunter.com,theyarehuge.com,thisav.com##.ads
+babesandstars.com,gosexy.mobi,javseen.tv,mobilepornmovies.com,mypornstarbook.net,pichunter.com,thisav.com##.ads
 tube8.com,tube8.es,tube8.fr##.adsbytrafficjunky
-anyporn.com,cartoon-sex.tv,pervertslut.com,webanddesigners.com##.adv
+anyporn.com,cartoon-sex.tv,pervertslut.com,theyarehuge.com,webanddesigners.com##.adv
 sex3.com##.adv-leftside
 reddflix.com##.advbox
 hungangels.com##.advert


### PR DESCRIPTION
Filter for hiding ads at [theyarehuge - video example](https://www.theyarehuge.com/v/hitomi-tanaka-jogging-mrs-3-part-1-169231750370521.big-boobs)

Proposed filter: `##.adv` (just added the domain at the existing filter)

<details open>
<summary>Screenshot</summary>
<img width="1440" alt="Screenshot 2021-10-12 at 00 53 42" src="https://user-images.githubusercontent.com/65717387/136888608-d65b0fba-fac8-4b7f-b540-856dd26da649.png">
</details>


