### PR TITLE
P: kauppalehti.fi + other Alma media sites (content won't load unless cookies accepted)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -29,7 +29,6 @@
 @@||businessinsider.in/gdpr_js/version-12,minify-1.cms$script,~third-party
 @@||c.evidon.com/sitenotice/evidon-sitenotice-tag.js$script,domain=southpark.de|southparkstudios.nu
 @@||carport-diagnose.de/script/cookieconsent.min.js$script,~third-party
-@@||cdn.almamedia.fi/almacmp/$script,domain=iltalehti.fi
 @@||cdn.cookielaw.org^$script,stylesheet,xmlhttprequest,domain=cnn.com|comicbook.com|crfashionbook.com|crunchyroll.com|doctoroz.com|eurogamer.it|eurogamer.net|eurogamer.pl|eurogamer.pt|gamespot.com|gmx.com|gq-magazine.co.uk|mail.com|popculture.com|reuters.com|rockpapershotgun.com|rp-online.de|rte.ie|trustpilot.com|tvn24.pl|uefa.com|usgamer.net|vimeo.com|wargaming.net|worldsurfleague.com
 @@||chasecdn.com^*/cookie.js$script,domain=chase.com
 @@||civiccomputing.com^*/cookieControl-$script,domain=amplitude.com|kit.co|msi.com|romania-insider.com|videogameschronicle.com

--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -1,4 +1,4 @@
-###AF_GDPR
+﻿###AF_GDPR
 ###ATEDIN_cookie_warning
 ###AcceptCookie
 ###AcceptCookieContainer
@@ -721,7 +721,6 @@
 ###allowcookieandthirdparty
 ###allowcookiebanner
 ###allowusecookies
-###alma-cookie-consent
 ###alma-data-policy-banner
 ###alsb_CNIL_notice
 ###altea-cookiebox-wrapper
@@ -7079,7 +7078,6 @@
 ##.allowed-cookies
 ##.allreadycookie
 ##.alltricks-CnilRibbon
-##.alma-cookie-disclaimer
 ##.alma-data-policy-banner
 ##.altamira-gdpr-cookie-consent
 ##.alternative_cookie_layer_background

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -55,7 +55,6 @@
 !
 ! ---------- Finnish ----------
 !
-||almamedia.fi/almacmp/$script
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,5 +1,8 @@
-! uBO Sepecific fixes
+﻿! uBO Sepecific fixes
 ! :style fixes
+arvopaperi.fi,kauppalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,uusisuomi.fi###alma-cmpv2-container:style(display: none)
+arvopaperi.fi,kauppalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,uusisuomi.fi###root:has(.article-body div[color^="#"]) ~ #alma-cmpv2-container:style(display: block !important)
+arvopaperi.fi,kauppalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,uusisuomi.fi###root:has(.article-body p:has-text(Sisältöä ei voitu ladata.)) ~ #alma-cmpv2-container:style(display: block !important)
 yle.fi###yle-consent-sdk-container:style(display: none)
 yle.fi###yle-consent-sdk-container:has(~ .yle__app h2:has-text(Sisältöä ei voida näyttää)):style(display: block !important)
 wetter.at##.full.blured:style(filter: none !important;)

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -1,6 +1,5 @@
 ||admiral.mgr.consensu.org^$third-party
 ||akamaihd.net/cpmt/
-||alma-cmp.almamedia.io^
 ||analytics-consent-manager.azureedge.net^
 ||app.livemarketshoppers.com^$script,third-party
 ||assetlab.io/consent/

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -144,7 +144,7 @@
 @@||d2wzl9lnvjz3bh.cloudfront.net/frosmo.easy.js$domain=lippu.fi
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
-@@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
+@@||googletagmanager.com/gtm.js$script,domain=arvopaperi.fi|cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kauppalehti.fi|mediuutiset.fi|mikrobitti.fi|rumba.fi|soundi.fi|talouselama.fi|tekniikkatalous.fi|tilt.fi|tivi.fi|uusisuomi.fi|veho.fi
 @@||high.auriro.net/http/600x400/$image,domain=afterdawn.com|hardware.fi
 @@||images.sprinklecontent.com^$image,domain=como.fi|episodi.fi|fum.fi|inferno.fi|kaaoszine.fi|rumba.fi|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/frosmo.easy.js$domain=elisa.fi|kauppahalli24.fi


### PR DESCRIPTION
Original Pull Request: Fixes #9343 
I just squash the commits into one.
Thanks to @peace2000 

Original article
> Blocking Alma media's cookie script makes it impossible to accept cookies. Some content inside news articles won't load unless cookies are accepted. The whole cookie script blocking should be removed for all Alma Media's domains. It should be replaced via cosmetic filters, that are used in pages that don't have any content that requires accepting cookies. Also whitelisting of googletagmanager is needed.
> 
> (Removed also obsolete filters.)
> 
> Some sample links with issues:
> 
> https://www.kauppalehti.fi/uutiset/kl/5633eb79-0cd4-4f75-8986-50a426517b44 (embedded video won't appear)
> 
> https://www.tivi.fi/uutiset/kuumenevatko-tunteet-twitterissa-palvelu-alkaa-jakaa-varoituksia/3aef9c6f-8fd4-43a9-9714-dd3a2fdf84ed (tweets won't load)
> 
> https://www.mediuutiset.fi/uutiset/krista-kiuru-twitterissa-karaoke-ja-tanssikielto-poistuu-leviamisvaiheen-alueilta/5dd70390-af13-49c5-89d2-a88912a7324d (embedded tweet)
> 
> https://www.tekniikkatalous.fi/uutiset/facebook-instagram-ja-whatsapp-ovat-jalleen-toiminnassa-ongelma-paikannettu-runkoverkkoreitittimiin/32fe5cea-38e0-44e8-a282-da2adaea0cbe (embedded fb post and a tweet)
> 
> https://www.uusisuomi.fi/uutiset/poliisilta-jyrkka-syytos-elokapinalle-turvallisuusuhkaan-puututtiin-valtiosaantoasiantuntija-ihmettelee-poliisin-vaitetta/01266b30-e4be-4bc6-8250-641c6469ed3e (embedded tweets)
> 
> I didn't find good samples from all domains that are listed in my change proposal, but all those should be accepted as they all belong to the same site cluster of Alma Media and those sites work similarly.
> 
> **Notes concerning rules to be added:**
> 
> The point is to hide the dialog when it won't cause issues, but force it to be shown when articles have embedded stuff that won't work without accepting cookies.
> 
> There's a need to have two separate filters for forcing the dialog to be shown: that's because when there are embedded stuff, all these pages will display colorful boxes as a loading element in the place where embedded stuff should be:
> 
> ![kuva](https://user-images.githubusercontent.com/17256841/136638730-aa4a253c-7d9a-452e-a5cf-2aad5667de48.png)
> 
> Which will eventually change into a text:
> 
> ![kuva](https://user-images.githubusercontent.com/17256841/136638743-ad6faf12-f31f-415f-8927-abb2f268489f.png)
> 
> ```
> Sisältöä ei voitu ladata.
> Tämä voi johtua selainlaajennuksesta.
> ```
> 
> Translation:
> 
> ```
> Content couldn't be loaded.
> This could be caused by a browser extension.
> ```
> 
> **Sitenote:**
> 
> What it comes to removing obsolete filters, these filters: `###alma-data-policy-banner` `##.alma-data-policy-banner`
> 
> Aren't obsolete, they block a bottom banner which can be hid without any issues.
> 
> **Sidenote2:**
> 
> iltalehti.fi even being Alma Media's domain, is the only exception that doesn't require accepting cookies via a dialog. In iltalehti.fi, cookies can be clicked to be accepted afterwards if it's needed, but not on those other domains.
> 
> https://www.iltalehti.fi/kotimaa/a/7bda0d36-ad9d-4221-9f71-371881a1eb4f
> 
> ![kuva](https://user-images.githubusercontent.com/17256841/136662187-08888779-2f46-487b-b433-1bb0ba4ef253.png)
> 
> "hyväksy evästeiden käyttö" means "accept the use of cookies" (it can be clicked and it works).


