### PR TITLE
A: mtvuutiset.fi (cookie banner hide for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -30,7 +30,7 @@
 @@||c.evidon.com/sitenotice/evidon-sitenotice-tag.js$script,domain=southpark.de|southparkstudios.nu
 @@||carport-diagnose.de/script/cookieconsent.min.js$script,~third-party
 @@||cdn.almamedia.fi/almacmp/$script,domain=iltalehti.fi
-@@||cdn.cookielaw.org^$script,stylesheet,xmlhttprequest,domain=cnn.com|comicbook.com|crfashionbook.com|crunchyroll.com|doctoroz.com|eurogamer.it|eurogamer.net|eurogamer.pl|eurogamer.pt|gamespot.com|gmx.com|gq-magazine.co.uk|mail.com|popculture.com|reuters.com|rockpapershotgun.com|rp-online.de|rte.ie|trustpilot.com|tvn24.pl|uefa.com|usgamer.net|vimeo.com|wargaming.net|worldsurfleague.com
+@@||cdn.cookielaw.org^$script,stylesheet,xmlhttprequest,domain=cnn.com|comicbook.com|crfashionbook.com|crunchyroll.com|doctoroz.com|eurogamer.it|eurogamer.net|eurogamer.pl|eurogamer.pt|gamespot.com|gmx.com|gq-magazine.co.uk|mail.com|mtvuutiset.fi|popculture.com|reuters.com|rockpapershotgun.com|rp-online.de|rte.ie|trustpilot.com|tvn24.pl|uefa.com|usgamer.net|vimeo.com|wargaming.net|worldsurfleague.com
 @@||chasecdn.com^*/cookie.js$script,domain=chase.com
 @@||civiccomputing.com^*/cookieControl-$script,domain=amplitude.com|kit.co|msi.com|romania-insider.com|videogameschronicle.com
 @@||cloudflare.com^*/cookieconsent.min.js$domain=ehftv.com|pixieset.com|sammobile.com|xnview.com

--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -87,8 +87,8 @@ faberkabel.de#@##modalCookie
 imobiliare.ro#@##modalCookies
 microsoft.com#@##ms-cookie-banner
 thesocialmedwork.com#@##notice-cookie-block
-gq-magazine.co.uk,mail.com,rockpapershotgun.com,uefa.com,zdnet.com#@##onetrust-banner-sdk
-eurogamer.it,eurogamer.pl,eurogamer.pt,gq-magazine.co.uk,mail.com,rockpapershotgun.com,uefa.com,usgamer.net,zdnet.com#@##onetrust-consent-sdk
+gq-magazine.co.uk,mail.com,mtvuutiset.fi,rockpapershotgun.com,uefa.com,zdnet.com#@##onetrust-banner-sdk
+eurogamer.it,eurogamer.pl,eurogamer.pt,gq-magazine.co.uk,mail.com,mtvuutiset.fi,rockpapershotgun.com,uefa.com,usgamer.net,zdnet.com#@##onetrust-consent-sdk
 api.newsguardtech.com,rockpapershotgun.com#@##optanon
 ign.com#@##policyNotice
 theverge.com#@##privacy-consent

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,5 +1,7 @@
 ! uBO Sepecific fixes
 ! :style fixes
+mtvuutiset.fi###onetrust-consent-sdk:style(display: none)
+mtvuutiset.fi##.container:has(.consent-blocking-embed-message) ~ #onetrust-consent-sdk:style(display: block !important)
 yle.fi###yle-consent-sdk-container:style(display: none)
 yle.fi###yle-consent-sdk-container:has(~ .yle__app h2:has-text(Sisältöä ei voida näyttää)):style(display: block !important)
 wetter.at##.full.blured:style(filter: none !important;)

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -139,6 +139,7 @@
 !
 @@||adobedtm.com^*/satelliteLib-$script,domain=gigantti.fi
 @@||api.cxense.com/public/widget/data?json=$script,domain=ksml.fi|savonsanomat.fi
+@@||assets.adobedtm.com^$script,domain=mtvuutiset.fi
 @@||assets.strossle.com/strossle-widget-sdk/$script,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi
 @@||certona.net^*/resonance.js$domain=zooplus.fi
 @@||d2wzl9lnvjz3bh.cloudfront.net/frosmo.easy.js$domain=lippu.fi


### PR DESCRIPTION
My set of filters will:

1. Hide the banner generally for this site
2. Force it to be shown on those pages that have iframe-videos or embedded tweets. Those elements won't even show up if cookies are not accepted
3. Whitelist in EP is needed because the error message concerning unaccepted cookies isn't visible otherwise.
<details>

![kuva](https://user-images.githubusercontent.com/17256841/137024414-b9cad96c-82d0-4d24-a720-4386ac19c02c.png)

</details>
For other blockers than uBO and AG, those banners have to be whitelisted. Also cookie consent script has to be whitelisted as well.

Sample pages:

<details>

https://www.mtvuutiset.fi/artikkeli/10-vuotias-poika-putosi-koskeen-oulussa-seurassa-ollut-mies-sai-pojan-pelastettua-kylmissaan-kovassa-virrassa-odottelivat-apua/8242750 (doesn't have embedded stuff)

https://www.mtvuutiset.fi/artikkeli/kilpikonna-kiitoradalla-viivytti-viitta-lentoa-japanissa/8248130 (has embedded iframe video at the mid article)

https://www.mtvuutiset.fi/artikkeli/salossa-etsitaan-kadonnutta-vanhusta/8242082 (has embedded tweet)
</details>