### PR TITLE
P: https://tarzanweb.jp/post-239101?mode=slide&no=2&p=2 (fixes https:…

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -243,7 +243,8 @@
 @@||atwiki.jp/common/_img/spacer.gif?$image,domain=atwiki.jp
 @@||browser.sentry-cdn.com^$domain=marshmallow-qa.com
 @@||carsensor.net/usedcar/modules/clicklog_top_lp_revo.php$xmlhttprequest
-@@||cdn.cxense.com/cx.js$domain=wpb.shueisha.co.jp
+@@||cdn.cxense.com/cx.cce.js$domain=tarzanweb.jp
+@@||cdn.cxense.com/cx.js$domain=tarzanweb.jp|wpb.shueisha.co.jp
 @@||cdn.treasuredata.com/sdk/$script,domain=retty.me
 @@||chancro.jp/assets/lib/googleanalytics-$script
 @@||cm-beacon.nakanohito.jp/at/ranking/$script

--- a/fanboy-addon/fanboy_annoyance_allowlist.txt
+++ b/fanboy-addon/fanboy_annoyance_allowlist.txt
@@ -20,6 +20,7 @@
 @@||complexmedianetwork.com/js/cmnUNT.js
 @@||config.parsely.com/config/$script,domain=express.co.uk
 @@||csm.cxpublic.com/Shueisha.js$domain=wpb.shueisha.co.jp
+@@||csm.cxpublic.com^$script,domain=tarzanweb.jp
 @@||disqus.com^*/social-icons.png
 @@||dollartree.com^*/backToTop.min.js
 @@||drivek.it^*/jquery.cookiecuttr.min.js


### PR DESCRIPTION
…//github.com/AdguardTeam/AdguardFilters/issues/97196)
Allowing only `https://csm.cxpublic.com/MagazineHouse.js` doesn't work, hence `@@||csm.cxpublic.com^$script,domain=tarzanweb.jp`.