### PR TITLE
A: / M: espoo.fi (generic cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -12393,6 +12393,7 @@
 ##[aria-describedby="cookies-policy-message"]
 ##[aria-describedby="dialog-eu-cookie-law"]
 ##[aria-label="cookieconsent"]
+##[aria-labelledby="cookie-dialog"]
 ##[aria-labelledby="ui-dialog-title-cookiebox"]
 ##[class^="CookieMessage_"]
 ##[class^="FooterGDPR"]

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -105,7 +105,6 @@ aixfoam.*##[id="cc-notification"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
 kiuruvesilehti.fi,urjalansanomat.fi##+js(aeld, scroll, innerHeight)
-esbo.fi,espoo.fi##+js(aeld, /^(?:DOMContentLoaded|load)$/, function I())
 ubuntu.com##+js(aeld, DOMContentLoaded, js-revoke-cookie-manager)
 sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)
 vr.fi##+js(aeld, wheel, preventDefault)


### PR DESCRIPTION
https://www.espoo.fi/en

The site has changed so cleaned old entries at the same time.

esbo.fi not in use anymore, it redirects to espoo.fi.