### PR TITLE
A: reuters.com (generic ad hiding)

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -22754,6 +22754,7 @@
 ##div[class^="Ad__bigBox"]
 ##div[class^="Ad__container"]
 ##div[class^="AdhesionAd_"]
+##div[class^="AdSlot__container"] 
 ##div[class^="BannerAd_"]
 ##div[class^="BlockAdvert-"]
 ##div[class^="Component-dfp-"]


### PR DESCRIPTION
https://www.reuters.com/article/health-coronavirus-mexico-vaccines-idUSKBN2970H3

Empty adslot containers inside articles.

![kuva](https://user-images.githubusercontent.com/17256841/103478561-4587dc00-4dd0-11eb-88d6-15f564dcce0c.png)

(Remade old broken PR)

