### PR TITLE
 P: dawn.fi (other articles thumbnails blocked)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -148,7 +148,7 @@
 @@||dynamicyield.com/api/$script,domain=gigantti.fi
 @@||frosmo.com^$xmlhttprequest,domain=kauppahalli24.fi
 @@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
-@@||high.auriro.net/http/600x400/$image,domain=afterdawn.com|hardware.fi
+@@||high.auriro.net/http/600x400/$image,domain=afterdawn.com|dawn.fi|hardware.fi
 @@||images.sprinklecontent.com^$image,domain=como.fi|episodi.fi|fum.fi|inferno.fi|kaaoszine.fi|rumba.fi|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/frosmo.easy.js$domain=elisa.fi|kauppahalli24.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi


### PR DESCRIPTION
https://dawn.fi/artikkeli.cfm/2021/10/14/kyberturvallisuuskeskus-kehotus-paivita-windows-laite-win32k-haavoittuvuus

![kuva](https://user-images.githubusercontent.com/17256841/137532270-f98ebe6e-1820-427d-8c39-9d7bfdebbe2b.png)

Fixed ->

![kuva](https://user-images.githubusercontent.com/17256841/137532197-7ceafbfb-fef6-4900-8615-259633ed116d.png)
