### PR TITLE
P: pelaaja.fi (link can't be clicked, Easyprivacy)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -156,6 +156,7 @@
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 @@||mpsnare.iesnare.com/snare.js$script,domain=power.fi
 @@||nettix.fi^*_analytics.js$domain=nettiauto.com|nettikaravaani.com|nettikone.com|nettimokki.com|nettimoto.com|nettivaraosa.com
+@@||pelaaja.fi/sites/default/files/googleanalytics/analytics.js$~third-party
 @@||scdn.cxense.com/cx.js$script,domain=ksml.fi|savonsanomat.fi
 @@||widgets.spklw.com/v1/$xmlhttprequest,domain=como.fi|episodi.fi|fum.fi|inferno.fi|kaaoszine.fi|rumba.fi|soundi.fi|tilt.fi
 @@||widgets.sprinklecontent.com/v2/$script,xmlhttprequest,domain=como.fi|episodi.fi|fum.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi


### PR DESCRIPTION
Reference https://github.com/easylist/easylist/pull/8317

https://pelaaja.fi/

Even if that uBO specific fix is not added, EP still needs this whitelist rule anyway to unbreak opening of the link in the yellow bar:

![kuva](https://user-images.githubusercontent.com/17256841/137587006-c3b6ab68-ecab-40cf-a1cf-1f4ed830d4cf.png)

@ryanbr 
