### PR TITLE
P: luhta.com (cookie dialog whitelist for ABP)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -24,7 +24,7 @@ sandisk.ae,sandisk.cn,sandisk.co.jp,sandisk.co.kr,sandisk.co.uk,sandisk.com,sand
 roussillhotel.com#@##cookie-banner
 dm-drogeriemarkt.it,okazii.ro#@##cookie-bar
 travelchannel.co.uk#@##cookie-body
-airam.fi,biotechusa.hu,hscollective.org,litebit.eu#@##cookie-consent
+airam.fi,biotechusa.hu,hscollective.org,litebit.eu,luhta.com#@##cookie-consent
 analog.com#@##cookie-consent-container
 lauritz.com,qxl.de,qxl.dk,qxl.fi,qxl.no,qxl.se#@##cookie-container
 okazik.pl,skuola.net#@##cookie-dialog
@@ -133,7 +133,7 @@ zwijsen.nl#@#.cookie-consent-content
 artyferia.pl#@#.cookie-consent-show
 berliner-volksbank.de,dovoba.de#@#.cookie-consent-v2
 zwijsen.nl#@#.cookie-consent-wrapper
-airam.fi,berliner-volksbank.de,codra.net,dovoba.de,medicinenet.com,meinebank.de,mvb.de#@#.cookie-consent:not(body):not(html)
+airam.fi,berliner-volksbank.de,codra.net,dovoba.de,luhta.com,medicinenet.com,meinebank.de,mvb.de#@#.cookie-consent:not(body):not(html)
 metro.de#@#.cookie-container
 bokadirekt.se,calameo.com,danbolig.dk,hongkong.fi,okazii.ro,rusta.com,xmradio.nl#@#.cookie-content
 danbolig.dk,mega.io,skuola.net#@#.cookie-dialog

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -31,12 +31,10 @@ backmarket.de##._3NAusrrr
 ylasatakunta.fi##.ag_cookie_banner
 uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
-luhta.com##.cookie-consent
 elisaviihde.fi##.ea-cookie-disclaimer
 bbc.com##.fc-consent-root
 pringles.com##.truste_box_overlay
 pringles.com##.truste_overlay
-luhta.com###cookie-consent
 maxgaming.fi###cookie_consent
 acea.it###cookieModal
 varusteleka.com,varusteleka.fi##.cookie_settings_container
@@ -104,8 +102,10 @@ bundesanzeiger.de###cc
 interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
 paihdelinkki.fi###sliding-popup.sliding-popup-bottom
+luhta.com##[class~="cookie-consent"]
 vr.fi##div[data-testid="modal"]
 aixfoam.*##[id="cc-notification"]
+luhta.com##[id="cookie-consent"]
 terveyskirjasto.fi##div[id^="general-cookies-modal"]
 ! scripts
 kiuruvesilehti.fi,urjalansanomat.fi##+js(aeld, scroll, innerHeight)


### PR DESCRIPTION
https://luhta.com/

Cookie dialog has to whitelisted for ABP. uBO currently has filters to handle the dialog properly (which are already added in Easylist Cookie).

Re-adjusted cosmetic uBO filters to avoid matching to proposed whitelist filters.