### PR TITLE
A: https://ytmp3.cc/en26/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -22,6 +22,7 @@ road.cc###Top-Billboard
 warisboring.com###WIB300x250_IA_M_HB
 eetimes.com###WelcomeAdContainer
 eetimes.com###WelcomeAdContainer + #overlay
+ytmp3.cc###a-320-50
 egotastic.com###a46c6331
 egotasticsports.com###a83042c4
 krunker.io###aHolder
@@ -2365,6 +2366,7 @@ micky.com.au##iframe[height="90"]
 coincodex.com,yourbittorrent.com##iframe[src]
 fansshare.com##iframe[width="300"]
 shoesession.com##iframe[width="732"]
+ytmp3.cc##iframe[style*="z-index: 2147483647"]
 windycitymediagroup.com,windycitytimes.com##img[alt*="Sponsor"]
 thecuttingedgenews.com##img[alt="Ad by The Cutting Edge News"]
 nta.ng##img[alt="Online Ads WeConnect Platform"]


### PR DESCRIPTION
Filter for hiding popup messages placeholders and "fake buttons ads" at [ytmp3](https://ytmp3.cc/en26/)

Proposed filters: 
`ytmp3.cc###a-320-50` - fake buttons ads
`ytmp3.cc##iframe[style*="z-index: 2147483647"]` - message popups placeholders. To reproduce you will need to place some link.

Screenshots: 
<img width="1440" alt="Screenshot 2021-10-22 at 08 13 05" src="https://user-images.githubusercontent.com/65717387/138445063-834097b6-f9fa-4bbf-8800-cdbb2891aafe.png">
<img width="1126" alt="Screenshot 2021-10-22 at 07 59 08" src="https://user-images.githubusercontent.com/65717387/138445093-9fbee190-3642-4931-b765-a972985ca45f.png">

