### PR TITLE
A: https://gowatchseries.online/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3686,6 +3686,7 @@
 ||denety.com^
 ||denis-pj0823031-491201b.com^
 ||denouncetenantequipment.com^
+||denseplatter.com^
 ||dentalsadness.com^
 ||deostr.com^
 ||departedbeings.com^

--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -435,6 +435,7 @@
 ||eastbour.mobi^$popup
 ||easydownloadnow.com^$popup
 ||easykits.org^$popup
+||ecmjckvcqiceia.xyz^$popup
 ||edchargina.pro^$popup
 ||effectiveperformancenetwork.com^$popup
 ||elephant-ads.com^$popup


### PR DESCRIPTION
Filters for blocking adserver responsible for popup messages and for blocking popup redirects at [gowatchseries](https://gowatchseries.online/)

Proposed filters: 
`||denseplatter.com^` - popup messages
`||ecmjckvcqiceia.xyz^$popup` - redirects popups, to reproduce, open any movie pick vidnode proxy and try to press play

Screenshots: 
<img width="1440" alt="Screenshot 2021-10-22 at 08 48 52" src="https://user-images.githubusercontent.com/65717387/138449422-45ef308f-2ca9-417e-9042-4bad0c6097f9.png">
<img width="1440" alt="Screenshot 2021-10-22 at 08 40 28" src="https://user-images.githubusercontent.com/65717387/138449439-b5e2877f-6c28-4aa9-a0f1-8b6b288fbf99.png">





