### PR TITLE
A: tv.telia.fi (cookie banner hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -673,6 +673,7 @@ terveystalo.com##.st-consent-banner
 lehtodigital.fi##[class^="__ld_cookie_"]
 sttinfo.fi##[class^="styledBarNotification__BarNotificationWrapper"]
 dplay.fi##div[class^="notification"]
+tv.telia.fi##div[ng-show^="model.notifications"]
 alasatakunta.fi,lapuansanomat.fi##div[style="position: fixed; bottom: 0px; left: 0px; right: 0px; display: flex; justify-content: center; z-index: 100000; transition: transform 200ms ease 0s;"]
 scandinavianphoto.fi##div[style^="opacity: 1; height: "][style$="px;"]
 linnunrata.org##div[style^="position:fixed;right:0;top:0;"]


### PR DESCRIPTION
https://tv.telia.fi/

(Note, main domain telia.fi is already covered and it has different kind of banner / dialog.)