### PR TITLE
A: wolt.com (cookie banner hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -363,6 +363,7 @@ rockstargames.com##.ANJBsOK
 cryptokitties.co##.Banner
 cryptokitties.co##.BottomBanner
 itsfoss.com##.CampaignType--floating
+wolt.com##.ConsentsBannerOverlay
 postaffiliatepro.com##.CookieLaw
 perforce.com##.EUc
 tjc.co.uk##.GDPR


### PR DESCRIPTION
https://wolt.com/

Not worth adding as a generic filter: https://publicwww.com/websites/%22ConsentsBannerOverlay%22/