### PR TITLE
A: [NSFW] http://porn00.org

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -322,6 +322,7 @@
 ||clkpback3.com^$popup
 ||clkrev.com^$popup
 ||clksecure.com^$popup
+||clodsplit.com^$popup
 ||cloudsrvtrk.com^$popup
 ||cloudtraff.com^$popup
 ||clupc.com^$popup


### PR DESCRIPTION
Filter for blocking adserver responsible for redirect popups after clicking in any content at [porn00](http://porn00.org)

Proposed filter: `||clodsplit.com^$popup`

<details>
<summary>Screenshot:</summary>
<img width="1440" alt="Screenshot 2021-10-26 at 14 31 43" src="https://user-images.githubusercontent.com/65717387/138932268-610cb1f8-f404-473f-967b-15dd8a337fa9.png">
</details>