### PR TITLE
 A: bosch-home.* (cookie list, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1,5 +1,6 @@
 ! uBO Sepecific fixes
 ! :style fixes
+bosch-home.*##.g-container, .feedback-button:style(filter: none !important)
 mtvuutiset.fi###onetrust-consent-sdk:style(display: none)
 mtvuutiset.fi##.container:has(.consent-blocking-embed-message) ~ #onetrust-consent-sdk:style(display: block !important)
 yle.fi###yle-consent-sdk-container:style(display: none)
@@ -13,7 +14,7 @@ html5games.com##div[class="app-container"]:style(filter:none !important;opacity:
 gesund24.at,oe24.at,wirkochen.at,xn--sterreich-ppa80c.at##.wrapper.blured:style(filter: none !important;)
 germany.travel##body.consent-overlay:style(overflow:auto !important)
 kpcen-torun.edu.pl,taxfix.de,analog.com,zeoob.com##body.modal-open:style(overflow:auto !important)
-calvinklein.*,coolblue.nl,smb.museum,bbc.com,yle.fi,adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
+bosch-home.*,calvinklein.*,coolblue.nl,smb.museum,bbc.com,yle.fi,adidas.*,varma.fi,mundodeportivo.com,lavanguardia.com,mega-image.ro,autonet.ro,my.acea.it,defencediscountservice.co.uk,cbp4you.fr,lulus.com,razer.com,litebit.eu,wwz.ch,coseleurope.eu,wtk.pl,medicalnewstoday.com,schroders.com,telecomitalia.it,lego.com,answear.ua,ogloszenia.plock.pl,tme.eu,uniroyal.pl,backmarket.de,imoradar24.ro,what3words.com,masmovil.es,yoigo.com,interestingengineering.com,bundesanzeiger.de,chaussures.fr,eavalyne.lt,ecipele.hr,ecipo.hu,efootwear.eu,eobuv.com,eobuv.com.ua,eobuv.cz,eobuv.sk,eobuwie.com.pl,epantofi.ro,epapoutsia.gr,escarpe.it,eschuhe.ch,eschuhe.de,eskor.se,fandom.com,obuvki.bg,patient.info,swatch.com,vr.fi,zapatos.es##body:style(overflow: auto !important;)
 anacondastores.com,bing.com,1blu.de,vaillant.de,interfriendship.de,interfriendship.at,interfriendship.ch,interfriendship.com,western-men.com,sajt-znakomstv-interfriendship.ru,noriel.ro,sufilog.com,iracing.com,reuters.com,okazik.pl,pamiatki.pl,asseco.com,craftserve.pl,pressherald.com,thw.de,techmot24.pl,rocket-league.com##html:style(overflow: auto !important)
 okazii.ro,terveyskirjasto.fi##body:style(overflow: scroll !important)
 earthsky.org,e-wie-einfach.de,nerim.com,markets.com,researchaffiliates.com,nmhh.hu,zsgarwolin.pl,pelix-media.de##body,html:style(height: auto !important; overflow: auto !important)
@@ -28,6 +29,7 @@ gov.lv##body:style(overflow: auto !important;)
 vr.fi##div[data-testid="modal"]:not(:has(div[data-testid="cookie-consent-modal"])):style(display: block !important)
 !
 backmarket.de##._3NAusrrr
+bosch-home.*##.cookielaw-modal-layer
 ylasatakunta.fi##.ag_cookie_banner
 uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
@@ -104,6 +106,7 @@ what3words.com,masmovil.es##.MuiDialog-root
 bundesanzeiger.de###cc
 interestingengineering.com##.modal-backdrop
 bundesanzeiger.de###cc > #cc_banner
+bosch-home.*##[class="o-cookielaw"]
 paihdelinkki.fi###sliding-popup.sliding-popup-bottom
 luhta.com##[class~="cookie-consent"]
 vr.fi##div[data-testid="modal"]
@@ -121,6 +124,7 @@ podleze-piekielko.pl##+js(aopr, cookieman)
 danskebank.*##+js(rc, cookie-consent-banner-open, html)
 luhta.com##+js(rc, body-fixed, body, stay)
 taloon.com##+js(rc, cookie_popup_exists, div.page-wrapper, stay)
+bosch-home.*##+js(rc, pinned|cookielaw-blur-background, body, stay)
 ! Generichide fixes
 dogemate.com###cconsent-bar
 analog.com###cookie-consent-container.modal


### PR DESCRIPTION
https://www.bosch-home.fi and all it's other numerous top level domains.

Rule `bosch-home.*##.cookielaw-modal-layer` is needed at least in the Finnish site, probably for others as well.

`bosch-home.*##[class="o-cookielaw"]` is needed at least here: https://www.bosch-home.com/?clear=1#/Togglebox=region-toggle-4/ (probably for other TLD's as well)

`bosch-home.*##+js(rc, pinned|cookielaw-blur-background, body, stay)` will remove blur effect and overflow hidden properties from the body element.

`bosch-home.*##body:style(overflow: auto !important)` (this works faster than +js so it's included as well)

`bosch-home.*##.g-container, .feedback-button:style(filter: none !important)` Is added in order to avoid seeing visible blinking of blurring effect (+js not always fast enough to remove it).
This site and it's TLD's use blur effect on many elements and menus (pics from the Finnish TLD):

![kuva](https://user-images.githubusercontent.com/17256841/126881066-9d962819-e332-4ad2-ba9f-92300e5accbb.png)

![kuva](https://user-images.githubusercontent.com/17256841/126881073-c1b34e86-428f-4d83-a296-6927731939a0.png)

(Imo, not necessary to apply `:style(filter: none !important)` to each element in these sites, only for those that need it.)