### PR TITLE
A: https://animeheaven.ru/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -9713,6 +9713,7 @@
 ||ponchowafesargb.com^
 ||ponderaura.com^
 ||pooboafi.net^
+||poodsboiko.com^
 ||poogriry.click^
 ||poolgmsd.com^
 ||poolunbelievably.com^


### PR DESCRIPTION
Filter to block adserver responsible for popup messages at [animeheaven](https://animeheaven.ru/)

Proposed filter: `||poodsboiko.com^`

Screenshot:
![17ca3838-a8d7-4faf-b3b0-52608e15ee71](https://user-images.githubusercontent.com/65717387/139075412-237351ce-2d24-4a85-ba73-f686a4a1e677.png)
