### PR TITLE
A: https://www.torlock.com/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5134,6 +5134,7 @@
 ||fouptauk.com^
 ||fourthchoseark.com^
 ||fourthug.com^
+||fowink.com^
 ||foxcdn.life^
 ||foxilymartext.cam^
 ||foxrevenue.com^
@@ -11325,6 +11326,7 @@
 ||seskeu3zk7.com^
 ||setbackrelishdivine.com^
 ||setemoump.com^
+||setflooded.cam^
 ||setmeg.com^
 ||setoyourad.biz^
 ||setpadchat.com^

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1929,6 +1929,7 @@ thepostmillennial.com##.surfsharkcontent
 timesofmalta.com##.sw-Top
 saltwire.com##.sw-banner
 emoneyspace.com##.t_a_c
+torlock.com##table.hidden-xs
 thelocal.at,thelocal.ch,thelocal.de,thelocal.dk,thelocal.es,thelocal.fr,thelocal.it,thelocal.no,thelocal.se##.taboola-row
 protocol.com##.tag-sponsored
 recombu.com##.takeover-right


### PR DESCRIPTION
Filters for blocking adservers (popup messages + redirects) and hiding VPN ad at [torlock](https://www.torlock.com/all/torrents/no-time-to-die.html)

Proposed filters: 
`||setflooded.cam^` - popup messages
`||fowink.com^` - script responsible for some of the redirects (click in any content) 
`torlock.com##table.hidden-xs` - specific hide for VPN ad

Screenshots:
![2ec00ece-4709-462f-b7ca-aa4c4c2a3fb1](https://user-images.githubusercontent.com/65717387/139100960-1c66e562-399e-4263-9950-4146cc815037.png)
<img width="1424" alt="Screenshot 2021-10-27 at 12 48 00" src="https://user-images.githubusercontent.com/65717387/139100980-5145054a-575e-4c69-9d3f-ab1ea27838ab.png">

Example of the redirect by the filter mentioned above: https://adhied.com/aliexpress/index.html?&sourceid=gpdes2585611&clickid=16353496903007572011039844242491697&nor=1

