### PR TITLE
A: https://9anime.to/

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -685,6 +685,7 @@
 ||klavront.com^$popup
 ||kmisln.com^$popup
 ||kogutcho.net^$popup
+||kolkwi4tzicraamabilis.com^$popup
 ||korexo.com^$popup
 ||kotikinar2ko8tiki09.com^$popup
 ||ladsreds.com^$popup


### PR DESCRIPTION
Filter for blocking adserver responsable for redirect popups at [9anime](https://9anime.to/)

Proposed filter: `||kolkwi4tzicraamabilis.com^$popup`

How to reproduce: 
As the webpage won't allow you to open the devtools, the way is to try to play the video using the VideoVard server, after that you will be redirect to the following 
<img width="1435" alt="Screenshot 2021-10-28 at 13 14 24" src="https://user-images.githubusercontent.com/65717387/139295234-b9ffd24a-ed3e-4b83-94ba-992f676ffb1a.png">
<img width="605" alt="Screenshot 2021-10-28 at 13 06 43" src="https://user-images.githubusercontent.com/65717387/139295248-d6807be0-7a0a-4047-9fa1-a4fb452cec38.png">


