### PR TITLE
A: etsy.com - Hide cookie dialog

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -83,6 +83,7 @@ hrkgame.com##.dimmer
 imoradar24.ro##.show.modal-cookies
 uniroyal.pl##.js-cookie-banner > div
 wtk.pl###GDPR-modal
+etsy.com###gdpr-single-choice-overlay
 craftserve.pl###rodo
 ogloszenia.plock.pl###dialog-rodo
 lego.com##.fICElI
@@ -118,6 +119,8 @@ sss.fi##+js(aeld, load, function(){if(s.readyState==XMLHttpRequest.DONE)
 vr.fi##+js(aeld, wheel, preventDefault)
 al.com,allkpop.com,cinemablend.com,windows101tricks.com,foxvalleyfoodie.com,toledoblade.com,foxvalleyfoodie.com,merriam-webster.com,playstationlifestyle.net,calendarpedia.co.uk,ccn.com,sportsnaut.com,cleveland.com,comicsands.com,duffelblog.com,gamepur.com,gamerevolution.com,interestingengineering.com,keengamer.com,listenonrepeat.com,mandatory.com,mlive.com,musicfeeds.com.au,newatlas.com,pgatour.com,readlightnovel.org,secondnexus.com,sevenforums.com,sport24.co.za,superherohype.com,thefashionspot.com,theodysseyonline.com,totalbeauty.com,westernjournal.com##+js(aopr, __cmpGdprAppliesGlobally)
 podleze-piekielko.pl##+js(aopr, cookieman)
+etsy.com##+js(ra, style, .wt-body-no-scroll)
+etsy.com##+js(rc, wt-body-no-scroll, body)
 danskebank.*##+js(rc, cookie-consent-banner-open, html)
 luhta.com##+js(rc, body-fixed, body, stay)
 taloon.com##+js(rc, cookie_popup_exists, div.page-wrapper, stay)


### PR DESCRIPTION
`https://www.etsy.com/`

Fixed https://github.com/easylist/easylist/pull/9536. 

The problem was that the page "shrank" slightly each time you expanded the preview image.