### PR TITLE
A: https://animeheaven.ru/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -15486,6 +15486,7 @@
 ||plopx.com^$third-party
 ||pointclicktrack.com^$third-party
 ||points2shop.com^$third-party
+||poneridcreels.com^$third-party
 ||popmajor.com^$third-party
 ||popmonetizer.com^$third-party
 ||poponclick.com^$third-party


### PR DESCRIPTION
Filter to block adserver responsible for redirect popups messages at [animeheaven](https://animeheaven.ru/)

Proposed filter: `||poneridcreels.com^$third-party`

Screenshot: 
<img width="1440" alt="Screenshot 2021-11-03 at 12 17 28" src="https://user-images.githubusercontent.com/65717387/140052300-221f11a8-13d7-4a6b-8f7c-9c2b6a66a19d.png">


