### PR TITLE
A: [NSFW] https://www.maturetubehere.com/

### DIFF
--- a/easylist_adult/adult_specific_block.txt
+++ b/easylist_adult/adult_specific_block.txt
@@ -136,6 +136,8 @@
 ||madmen.alastonsuomi.com^
 ||mansurfer.com/flash_promo/
 ||matureworld.ws/images/banners/
+||maturetubehere.com/ai2/*/supc.php
+||maturetubehere.com/nb/bac_loa.php
 ||milffox.com/ab-s.js
 ||milffox.com/ai/s/s/js/ssu.
 ||milffox.com/ai/s/s/su.

--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -27,6 +27,7 @@ hotmovs.com###in_va
 freebunker.com,imagesnake.com,imgcarry.com,pornbus.org###introOverlayBg
 postyourpuss.com###leaderboard
 bootyoftheday.co###lj
+maturetubehere.com###lotal
 4tube.com###main-jessy-grid
 peekvids.com###mediaPlayerBanner
 pornvalleymedia.net###media_image-81
@@ -39,7 +40,7 @@ pornvalleymedia.net###media_image-88
 pornvalleymedia.net###media_image-90
 gifsfor.com###mob_banner
 eporner.com###movieplayer-box-adv
-amateur8.com###nopp
+amateur8.com,maturetubehere.com###nopp
 flashx.tv###nuevoa
 youjizz.com###onPausePrOverlay
 22pixx.xyz,imagevenue.com###overlayBg


### PR DESCRIPTION
Filters for blocking ads and Popunders + remaining placeholders at [maturetubehere](https://www.maturetubehere.com/)

Proposed filters: 
```
||maturetubehere.com/nb/bac_loa.php
||maturetubehere.com/ai2/*/supc.php
###lotal
###nopp
```

PS: There are couple of filters with /ai2/ , i believe they could go like : /ai2$domain=amateur8.com|maturetubehere.com|sortporn.com|bigtitslust.com|freeporn8.com

PS2: There are some with just /ai/ as well (4x)
<img width="1331" alt="Screenshot 2021-11-07 at 08 26 55" src="https://user-images.githubusercontent.com/65717387/140636361-af5ad1d2-9af4-4b70-bb08-37e5e8f186e3.png">
<img width="1438" alt="Screenshot 2021-11-07 at 08 00 57" src="https://user-images.githubusercontent.com/65717387/140636373-f48a34af-fc56-465c-a83e-ba9cf26effb2.png">

<details>
<summary>Screenshot page</summary>
![Uploading Screenshot 2021-11-07 at 08.20.36.png…]()
</details>

