### PR TITLE
A: stackexchange.com (cookie specific hide uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -92,6 +92,7 @@ metro.de##.cookie-disclaimer-intrusive
 kpcen-torun.edu.pl###app > #cookieModal
 kpcen-torun.edu.pl,wtk.pl##.show.modal-backdrop
 swatch.com##.b-modal_overlay
+stackexchange.com##.js-consent-banner
 thw.de##.mfp-container
 thw.de##.mfp-bg
 thw.de##.mfp-wrap


### PR DESCRIPTION
Specific hiding filter for uBO to overcome blinking issues.

Sample domains:
https://android.stackexchange.com/
https://coffee.stackexchange.com/
https://apple.stackexchange.com/