### PR TITLE
Block tracking requests on Oracle cloud console

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -167,6 +167,8 @@
 ||colvk.viki.io^
 ||confiant.msn.com^
 ||consent.ghostery.com/v1.js
+||console-telemetry.oci.oraclecloud.com/v1/metrics
+||console-telemetry.oci.oraclecloud.com/v1/tracking-events
 ||contents2.00110.citi.com^
 ||count.rin.ru^
 ||coursehero.com/v1/data-tracking

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -167,8 +167,7 @@
 ||colvk.viki.io^
 ||confiant.msn.com^
 ||consent.ghostery.com/v1.js
-||console-telemetry.oci.oraclecloud.com/v1/metrics
-||console-telemetry.oci.oraclecloud.com/v1/tracking-events
+||console-telemetry.oci.oraclecloud.com^
 ||contents2.00110.citi.com^
 ||count.rin.ru^
 ||coursehero.com/v1/data-tracking


### PR DESCRIPTION
Blocks tracking requests to `https://console-telemetry.oci.oraclecloud.com/v1/metrics` and ` https://console-telemetry.oci.oraclecloud.com/v1/tracking-events`.