### PR TITLE
A: [NSFW] https://cuntlick.net/

### DIFF
--- a/easylist_adult/adult_adservers.txt
+++ b/easylist_adult/adult_adservers.txt
@@ -204,6 +204,7 @@
 ||luvcom.com^$third-party
 ||lwxjg.com^$third-party
 ||madbanner.com^$third-party
+||mailboxleadsphone.com^$third-party
 ||malakasonline.com^$third-party
 ||mallcom.com^$third-party
 ||manfys.com^$third-party

--- a/easylist_adult/adult_specific_block.txt
+++ b/easylist_adult/adult_specific_block.txt
@@ -63,6 +63,7 @@
 ||cherrynudes.com/t33638ba5008.js
 ||creatives.cliphunter.com^
 ||creatives.pichunter.com^
+||cuntlick.net/banner/
 ||daftporn.com/nb_
 ||definebabe.com/sponsor_
 ||delivery.porn.com^


### PR DESCRIPTION
Filters to block image ad and adserver responsible for popup messages at [cuntlick](https://cuntlick.net/)

Proposed filters: 
```
||mailboxleadsphone.com^$third-party
||cuntlick.net/banner/
```

Screenshots: 
<img width="402" alt="Screenshot 2021-11-09 at 11 45 13" src="https://user-images.githubusercontent.com/65717387/140910489-58e5ee31-1cf5-4813-842a-ccc53533f56e.png">
<img width="1411" alt="Screenshot 2021-11-09 at 11 43 48" src="https://user-images.githubusercontent.com/65717387/140910493-0e3175d7-e196-415d-b338-987de22ce6ac.png">

