### PR TITLE
M: [NSFW] (Fix) https://freeadultcomix.com/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5231,7 +5231,6 @@
 ||frbyvuxzvmqpb.com^
 ||freakspybad.com^
 ||free-domain.net^
-||freeadultcomix.com^
 ||freebiesurveys.com^
 ||freecouponbiz.com^
 ||freedownloadsoft.net^

--- a/easylist_adult/adult_adservers.txt
+++ b/easylist_adult/adult_adservers.txt
@@ -106,6 +106,7 @@
 ||fncnet1.com^$third-party
 ||forkjork12.com^$third-party
 ||freakads.com^$third-party
+||freeadultcomix.com^$third-party
 ||freevideos24h.com^$third-party
 ||freewebfonts.org^$third-party
 ||frestacero.com^$third-party
@@ -127,6 +128,7 @@
 ||getiton.com^$third-party
 ||ggwcash.com^$third-party
 ||golderotica.com^$third-party
+||hentaimotel.com$third-party
 ||home-soon.com^$third-party
 ||hookupbucks.com^$third-party
 ||hornymatches.com^$third-party


### PR DESCRIPTION
Filter for fix broken webpage + adding adserver responsible for redirect popups

Proposed filters: 
M: `||freeadultcomix.com` to `||freeadultcomix.com^$third-party`
A: `||hentaimotel.com^$third-party`

Screenshots:
<img width="1440" alt="Screenshot 2021-11-10 at 10 12 35" src="https://user-images.githubusercontent.com/65717387/141085852-2a5f2366-4d3a-4c48-ac9b-910015a74607.png">

<img width="1438" alt="Screenshot 2021-11-10 at 10 24 27" src="https://user-images.githubusercontent.com/65717387/141086467-b4e5b524-91fd-45bc-9bcc-06cbc30fb4d7.png">

