### PR TITLE
A: https://mangatyrant.com/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -12166,6 +12166,7 @@
 ||sukausuka.com^
 ||sulphursceneryhenceforward.com^
 ||sultancolicin.com^
+||sumbalowen.com^
 ||sumofainstuff.com^
 ||sundayceremonytitanic.com^
 ||sundersetrgh.site^


### PR DESCRIPTION
Filter to block adserver responsible for popup messages at [mangatyrant](https://mangatyrant.com/manga/reverse-villain/chapter-88/) 

proposed filters: `||sumbalowen.com^`

Screenshot:
<img width="1440" alt="Screenshot 2021-11-11 at 19 30 21" src="https://user-images.githubusercontent.com/65717387/141350885-f2362f56-2c83-435c-8497-0e7fa5d39fa6.png">
