### PR TITLE
M: (fix) https://www.cliquesteria.net/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3024,7 +3024,6 @@
 ||clickxchange.com^
 ||clientsviolet.com^
 ||climbingdivertshabby.com^
-||cliquesteria.net^
 ||clixsense.com^
 ||clkepd.com^
 ||clknrtrg.pro^
@@ -15203,6 +15202,7 @@
 ||clickpoint.com^$third-party
 ||clicksor.com^$third-party
 ||clicktripz.com^$third-party
+||cliquesteria.net^$third-party
 ||clixco.in^$third-party
 ||clixtrac.com^$third-party
 ||cogocast.net^$third-party


### PR DESCRIPTION
Changes on the filter to avoid website to break [cliquesteria](https://www.cliquesteria.net/)

Proposed change: From `||cliquesteria.net^` to `||cliquesteria.net^$third-party`

Screenshot:
<img width="1439" alt="Screenshot 2021-11-12 at 09 28 32" src="https://user-images.githubusercontent.com/65717387/141435360-d14b1cd6-5768-47a9-951e-e1e988ca9e99.png">
