### PR TITLE
A: (nsfw) book.dmm.co.jp

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2316,6 +2316,7 @@
 /imp?*&sz=
 /imp?*&u=
 /imp?imgid=
+/imp?imp_key=
 /imp?sid=
 /imp_check.php
 /imp_cnt.gif?


### PR DESCRIPTION
`||cn.dap.dmm.co.jp^` is blocked in JPF (not pure tracking server) but it'll be worth their tracking pixel blocked in EP as well.

<details>
<summary>Screenshot</summary>

![dmm](https://user-images.githubusercontent.com/58900598/141628622-93513dc2-7c76-46bb-a784-0ec114ac4149.png)

</details>