### PR TITLE
A: businessinsider.com (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -9,6 +9,7 @@
 ||californiatimes.com/gdpr/
 ||ccmp.eu^$third-party
 ||ccpa-script.psg.nexstardigital.net^
+||cdn.privacy-mgmt.com^$third-party
 ||civiccomputing.com^*=cookie$third-party
 ||clickio.mgr.consensu.org^$third-party
 ||clickiocdn.com/t/cmp/$third-party


### PR DESCRIPTION
https://www.businessinsider.com/federal-court-affirms-block-on-biden-vaccine-rules-says-overreach-2021-11?r=US&IR=T

Videos work at the sample site properly, there's a video at the end of the article.