### PR TITLE
A: ruohonjuuri.fi (generic cookie block, 3rd party)

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -45,6 +45,7 @@
 ||donkeymob.com^$third-party
 ||ecookie.nl^$third-party
 ||fc2.com/share/js/gdpr/
+||gdpr-legal-cookie.beeclever.app^$third-party
 ||gdpr-service.herokuapp.com^$third-party
 ||gdpr.studybreakmedia.com^
 ||global.mgr.consensu.org^$third-party


### PR DESCRIPTION
https://www.ruohonjuuri.fi/

Used widely: https://publicwww.com/websites/%22gdpr-legal-cookie.beeclever.app%22/