### PR TITLE
A: https://www.desktophut.com/

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -594,6 +594,7 @@
 ||d359wjs9dpy12d.cloudfront.net^
 ||d36zfztxfflmqo.cloudfront.net^
 ||d37abonb6ucrhx.cloudfront.net^
+||d38goz54x5g9rw.cloudfront.net^
 ||d38itq6vdv6gr9.cloudfront.net^
 ||d39hdzmeufnl50.cloudfront.net^
 ||d39ion77s0ucuz.cloudfront.net^


### PR DESCRIPTION
Filter to block hosted adserver at desktophut.com

Proposed filter: `||d38goz54x5g9rw.cloudfront.net`

screenshots: 
<img width="1440" alt="Screenshot 2021-11-18 at 15 15 52" src="https://user-images.githubusercontent.com/65717387/142432074-5bb8a556-e7fb-4202-9810-247c895b4e8a.png">

