### PR TITLE
A: kotaku.com (specific cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -23,6 +23,7 @@
 ||jacquelinewilson.co.uk/style/cookies.css$stylesheet
 ||jimmychoo.com^*/first-time-visitor-
 ||kayak.*/privacy/
+||kotaku.com/wrapper/*/gdpr/$xmlhttprequest,domain=kotaku.com
 ||mad-daily.com^*/cp-module-
 ||masaltos.com/js/cookies-
 ||medicalnewstoday.com/_next/chunks/modal-0cb79-legacy.js


### PR DESCRIPTION
https://kotaku.com/