### PR TITLE
A: cbsnews.com (Hide cookie banner background overlay)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -732,6 +732,7 @@ norma-ammunition.com##.on-screen-messages
 suncorp.com.au##.one-pixel-margin-bottom.sg-Box
 wpengine.com##.opt-in-modal
 origin.com##.origin-sitestripe
+cbsnews.com##.ot-fade-in
 vmware.com##.ot-sdk-show-settings
 flashscore.co.uk,flashscore.com,soccerstand.com##.otPlaceholder
 ratemyprofessors.com##.overlay


### PR DESCRIPTION
`https://www.cbsnews.com/`

Seems to need specific filter for it.