### PR TITLE
A: bloomberg.com (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -23,7 +23,6 @@
 ||jacquelinewilson.co.uk/style/cookies.css$stylesheet
 ||jimmychoo.com^*/first-time-visitor-
 ||kayak.*/privacy/
-||kotaku.com/wrapper/*/gdpr/$xmlhttprequest,domain=kotaku.com
 ||mad-daily.com^*/cp-module-
 ||masaltos.com/js/cookies-
 ||medicalnewstoday.com/_next/chunks/modal-0cb79-legacy.js

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -78,6 +78,7 @@
 ||signatu.com^$third-party
 ||smartadserver.mgr.consensu.org^$third-party
 ||smartcookies.it^$third-party
+||sourcepoint*/wrapper/*/gdpr/$xmlhttprequest
 ||sourcepoint.mgr.consensu.org^$third-party
 ||termly.io^$third-party
 ||thirdfloor.it^$third-party


### PR DESCRIPTION
https://www.bloomberg.com/europe

Also in https://kotaku.com/ - better to make this generic as there are probably other sites using this same dialog as well.

