### PR TITLE
A: bloomberg.com (cookie hide, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -9,6 +9,7 @@ taloon.com##.header__top:style(position: unset !important)
 bbc.com##body:has(div[class*="Styled"][class*="Container"] [data-testid="bbc-logo-wrapper"]) > .fc-consent-root:style(display: flex !important)
 bosch-easycontrol.com##.modal-open:style(overflow: auto !important; padding-right: 0 !important;)
 taloon.com##.page-header:style(padding-top: 0 !important)
+bloomberg.com##.sp-message-open:style(overflow: unset !important; position: unset !important)
 html5games.com##div[class="app-container"]:style(filter:none !important;opacity:1 !important)
 gesund24.at,oe24.at,wirkochen.at,xn--sterreich-ppa80c.at##.wrapper.blured:style(filter: none !important;)
 germany.travel##body.consent-overlay:style(overflow:auto !important)
@@ -127,6 +128,7 @@ podleze-piekielko.pl##+js(aopr, cookieman)
 danskebank.*##+js(rc, cookie-consent-banner-open, html)
 luhta.com##+js(rc, body-fixed, body, stay)
 taloon.com##+js(rc, cookie_popup_exists, div.page-wrapper, stay)
+bloomberg.com##body:not(:has(div[class*="player" i][class*="_container"])) > div[id^="sp_message_container"]
 ! Generichide fixes
 dogemate.com###cconsent-bar
 analog.com###cookie-consent-container.modal


### PR DESCRIPTION
Cookie dialog hide for non-video pages. If the dialog is hid for video pages, videos won't sometimes start and sometimes it takes a lot of time.

Sample links:

Cookie dialog won't be hid:
https://www.bloomberg.com/live/europe
https://www.bloomberg.com/qt/live
https://www.bloomberg.com/news/articles/2021-11-19/germany-s-coronavirus-crisis-is-getting-out-of-control
https://www.bloomberg.com/news/videos/2021-11-19/reaction-from-kenosha-after-rittenhouse-found-not-guilty-video

Cookie dialog will be hid:
https://www.bloomberg.com/europe
https://www.bloomberg.com/news/features/2021-11-18/tirana-2030-design-plan-pits-density-against-history
https://www.bloomberg.com/news/articles/2021-11-20/coffee-prices-are-climbing-and-roasters-are-switching-beans