### PR TITLE
A: aamulehti (statistics)

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -424,6 +424,7 @@
 ! Finnish
 ||almamedia.fi^*/scroll-monitor.min.js
 ||dnt-userreport.com^
+||er.sanoma-sndp.fi/stats/
 ||inpref.s3.amazonaws.com^$third-party
 ||insight.fonecta.fi^
 ||tags.op-palvelut.fi^


### PR DESCRIPTION
 https://www.aamulehti.fi/
 
 Also other sanoma pages use it:
 
  https://www.satakunnankansa.fi/
https://www.hs.fi/
https://www.jamsanseutu.fi/
https://www.kmvlehti.fi/
https://www.nokianuutiset.fi/
https://www.valkeakoskensanomat.fi/
https://www.tyrvaansanomat.fi/
https://www.suurkeuruu.fi/
https://www.rannikkoseutu.fi/
https://www.janakkalansanomat.fi/
https://www.kankaanpaanseutu.fi/
https://www.merikarvialehti.fi/
https://www.sydansatakunta.fi/
https://www.is.fi/

(I don' know if it's safe to block the whole domain)