### PR TITLE
A: https://www.booking.com/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -113,6 +113,8 @@
 ||binocule21c.merriam-webster.com^
 ||biomedcentral.com/track/
 ||booking.com/logo?
+||booking.com/navigation_times
+||booking.com/sendlayoutevents
 ||boomerang.dell.com^
 ||brightside.me/metric-collector
 ||browser.mi-img.com^


### PR DESCRIPTION
Adds two endpoints used for tracking by Booking.

To reproduce: Open https://www.booking.com/ and check network requests.