### PR TITLE
A: [NSFW] https://fapopedia.net

### DIFF
--- a/easylist_adult/adult_adservers.txt
+++ b/easylist_adult/adult_adservers.txt
@@ -50,6 +50,7 @@
 ||citysex.com^$third-party
 ||clickadu.com^$third-party
 ||clickaine.com^$third-party
+||creptdeservedprofanity.com^$third-party
 ||cross-system.com^$third-party
 ||cybernetentertainment.com^$third-party
 ||daiporno.com^$third-party


### PR DESCRIPTION
Block adserver related to redirect popups at [fapopedia](https://fapopedia.net)

Proposed filter: `||creptdeservedprofanity.com^$third-party`

Screenshots:
<img width="1440" alt="Screenshot 2021-11-22 at 16 28 26" src="https://user-images.githubusercontent.com/65717387/142888733-80e5acb3-b9a2-468e-8dea-86e958d9cdbb.png">
