### PR TITLE
A: kuntsari.fi + other sites (generic cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -58,6 +58,7 @@
 ||a-lehdet.fi^*/cmp.js
 ||almamedia.fi/almacmp/$script
 ||browser-consent-front.coco.s-cloud.fi/js/$script
+||cdn.gravito.net/cmp/$script
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js


### PR DESCRIPTION
https://www.kuntsari.fi/

Used in some Finnish sites: https://publicwww.com/websites/cdn.gravito.net%2Fcmp%2F/