### PR TITLE
M: make generic

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -161,7 +161,7 @@
 ||banana.le.com^
 ||bc.qunar.com^
 ||bdwblog.eastmoney.com^
-||beacon.qq.com/analytics/
+||beacon.qq.com^
 ||btrace.qq.com^
 ||cherry.le.com^
 ||click.gamersky.com^


### PR DESCRIPTION
`||beacon.qq.com^` has long been blocked by AGTPF and no breakage reported.