### PR TITLE
A: vpd.fi (specific cookie hide for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -34,6 +34,7 @@ uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 bing.com##.bnp_cookie_banner
 calvinklein.*##.ck-modal--cookieModalMain
 elisaviihde.fi##.ea-cookie-disclaimer
+vpd.fi##.ec-gtm-cookie-directive
 bbc.com##.fc-consent-root
 elisa.fi##.react-navi-ea-cookie-disclaimer
 pringles.com##.truste_box_overlay


### PR DESCRIPTION
https://www.vpd.fi/seagate-game-drive-ps4-ulkoinen-kiintolevy-2-tb.html

Specific filter needed to overcome blinking issues with the generic filter.