### PR TITLE
me-gay.com

### DIFF
--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -136,6 +136,7 @@ onlydudes.tv##.b-side-col
 japan-whores.com##.b-sidebar
 dofap.com##.b_videobot
 pornburst.xxx##.bann3rss
+me-gay.com##a[href^="https://los.2hisnd.com/resource?zones"]
 3movs.xxx,analpornpix.com,chaturbate.com,fboomporn.com,fetishshrine.com,freepornpicss.com,imagezog.com,oldies.name,paradisehill.cc,playvids.com,porngames.com,private.com,vidxnet.com,vjav.com,watchhentaivideo.com,waybig.com,xbabe.com,xcum.com,yourdailygirls.com,youx.xxx##.banner
 javfor.tv##.banner-c
 grannymommy.com##.banner-on-player


### PR DESCRIPTION
Removes two 3rd party links in menu

I've made these lengthy url to minimize the risk of FP

```css
me-gay.com##a[href^="https://los.2hisnd.com/resource?zones"]
```

![image](https://user-images.githubusercontent.com/44526987/143704094-e2d80373-9228-46a1-ac83-f19e5da6d682.png)


Append to https://github.com/easylist/easylist/pull/9874

Related:
- https://github.com/easylist/easylist/pull/9874
- https://github.com/AdguardTeam/AdguardFilters/issues/101357
- https://mypdns.org/my-privacy-dns/porn-records/-/issues/1774