### PR TITLE
Fix https://github.com/uBlockOrigin/uAssets/issues/10644

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1035,6 +1035,7 @@ github.com##.hx_cookie-banner
 ivi.tv##.lowest-teaser
 rp-online.de##.park-snackbar-cookies
 walmart.ca##.privacy-open > div > [class] > div[class^="css"]
+mgtv.com##.m-agreement
 ! Multi-national sites
 spot-a-shop.at,spot-a-shop.de,spot-a-shop.fi,spot-a-shop.fr,spot-a-shop.pl,spot-a-shop.se###__next > div > div > div[class^="css"]
 globalblue.cn,globalblue.com,globalblue.ru##.gbnew-cookie-bar


### PR DESCRIPTION
This PR addresses https://github.com/uBlockOrigin/uAssets/issues/10644 by adding `mgtv.com##.m-agreement` to the Easylist Cookie specific hide area
### Steps to reproduce
- Visit mgtv.com
- Clear the cookies for that side and reload (only if you have already visited this site) or use a private browsing window
- Notice the cookie consent