### PR TITLE
P: https://www.e-trend.co.jp/cart/value_commerse_cushion.html

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -424,6 +424,7 @@
 @@||cdn.adsafeprotected.com/iasPET.1.js$script,domain=gentside.com|reuters.com
 @@||ced.sascdn.com/tag/*/smart.js$domain=dr.dk
 @@||cinema.pia.co.jp/img/ad/$image,~third-party
+@@||clj.valuecommerce.com/*/vcushion.min.js
 @@||cloudflare.com^*/videojs-contrib-ads.js$domain=wtk.pl
 @@||cloudinary.com/portalbici/advertisements/$domain=portalbici.es
 @@||core.windows.net^*/annonser/$image,domain=kmauto.no


### PR DESCRIPTION
### URL address of the web page

`http://buy.livedoor.biz/archives/51621754.html`

### Category

breakage

### Describe the issue
Similar issue: https://github.com/easylist/easylist/pull/8837

#### Expected

When you click the product image, you will redirect to the shopping website.

#### Actual

When you click the product image, you will get stuck on the cushion page in the middle of the redirect.

### Screenshot
<details>
<summary>Screenshot</summary>

![Screenshot](https://user-images.githubusercontent.com/82331005/144075704-189e4977-9323-46df-96a2-860f55d087a6.png)

</details>

### Configuration

<details>

```yaml
uBlock Origin: 1.39.0
Firefox: 94
filterset (summary): 
  network: 80972
  cosmetic: 43544
  scriptlet: 16198
  html: 598
listset (total-discarded, last updated): 
  default: 
    ublock-filters: 30283-29, now
    ublock-badware: 3494-1, now
    ublock-privacy: 183-0, now
    ublock-abuse: 74-0, now
    ublock-unbreak: 1708-0, now
    easylist: 61300-629, now
    easyprivacy: 26396-496, now
    urlhaus-1: 10185-0, now
    plowe-0: 3697-3, now
    JPN-1: 5311-14, now
filterset (user): [empty]
modifiedUserSettings: [none]
modifiedHiddenSettings: [none]
supportStats: 
  launchToReadiness: 638
  launchFromSelfie: false
```
</details>