### PR TITLE
A: https://www.1337x.to/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -12451,6 +12451,7 @@
 ||stardatis.com^
 ||stargamesaffiliate.com^
 ||stargoug.com^
+||starkhelperidentifier.com^
 ||starkpropagandaattacks.com^
 ||starkunfinisheddestroyed.com^
 ||start-xyz.com^


### PR DESCRIPTION
Block adserver responsible for popups at https://www.1337x.to/

Proposed filter: `||starkhelperidentifier.com^`

Screenshot:
<img width="1261" alt="Screenshot 2021-12-01 at 00 39 23" src="https://user-images.githubusercontent.com/65717387/144145377-1018e0df-e733-4216-9985-88647772962f.png">

