### PR TITLE
A: thesun.co.uk (cookie block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -34,6 +34,7 @@
 ||omgubuntu.co.uk/wp-content/plugins/omg-magnific/magnific.min.js
 ||onlive.co.uk/account/cookie_notice
 ||parliamentlive.tv/cookie/
+||privacy-mgmt.com^$domain=thesun.co.uk
 ||privacy.claytonhomes.com^
 ||privacypolicy.trgr.be^
 ||propcom.co.uk/cookie/


### PR DESCRIPTION
Blocking the gdpr script/request doesn't cause issues to videos:

https://www.thesun.co.uk/sport/football/16909888/carrick-rangnick-man-utd/

https://www.thesun.co.uk/tech/16887564/cyber-monday-hackers-fake-amazon-surverys/

Suggesting a specific rule as ryanbr recently implied that generic blocking of this domain would cause issues.