### PR TITLE
P: https://web.bridge-net.jp/blog/2070/ (related: https://github.com/…

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -320,7 +320,6 @@
 @@||ssl-images-amazon.com^*/satelliteLib-$script,domain=audible.com
 @@||ssl.gstatic.com/analytics/$script,domain=analytics.google.com
 @@||starbucksassets.com/weblx/static/optimizely.$script,domain=starbucks.ca|starbucks.com
-@@||statcounter.com/css/packed/statcounter-$stylesheet,~third-party
 @@||statcounter.com/js/packed/statcounter-$script,~third-party
 @@||static.amazon.jobs/assets/analytics-$script,domain=amazon.jobs
 @@||static.atgsvcs.com/js/atgsvcs.js$domain=lenovo.com|officedepot.com|shop.lego.com

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3965,7 +3965,7 @@
 /statcollector.
 /statcollector/*
 /statcount.
-/statcounter-
+/statcounter-$script
 /statcounter.asp
 /statcounter.js
 /statcountex/count.asp?


### PR DESCRIPTION
…AdguardTeam/AdguardFilters/issues/101671)
Images broken by the filter added in https://github.com/easylist/easylist/commit/ccff0a2fdf93d8056e8eaae35c7686c382fcaadb

The filter no more hits on `www.freepik.com` but you can find hit on `https://charicificvalley.com/` (TBH not much worth blocking).

Sidenote: this is also blocked when I'm searching statcounter on publicwww: `https://publicwww.com/images/labels.2/statcounter-min.png`