### PR TITLE
P: https://www.bs11.jp/program/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -257,6 +257,7 @@
 @@||assets.adobedtm.com^*-librarycode_source.min.js$script,domain=mora.jp
 @@||atwiki.jp/common/_img/spacer.gif?$image,domain=atwiki.jp
 @@||b-cloud.templatebank.com/js/gtag.js$~third-party
+@@||bangumi.org/sdk/rakuraku.js?referer=$domain=bs11.jp
 @@||bdash-cloud.com/recommend-script/$script,domain=junonline.jp
 @@||bdash-cloud.com/tracking-script/*/tracking.js$domain=junonline.jp
 @@||browser.sentry-cdn.com^$domain=marshmallow-qa.com


### PR DESCRIPTION
Contents not shown:
![bs11-1](https://user-images.githubusercontent.com/58900598/144880727-ce743a67-1671-4e95-ab02-c135aadc8afe.png)

![bs11-2](https://user-images.githubusercontent.com/58900598/144880732-2acd5ffa-e78a-4522-9f17-3bbc9b6b41a2.png)

Frankly, I think the blocking rule can be removed - it partly blocks consensu and all the problems by this which should arise only by Annoyance list do happen by EP too. https://github.com/uBlockOrigin/uAssets/issues/10491
