### PR TITLE
A: https://flixrs.com/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -12260,6 +12260,7 @@
 ||specialistcartoonparable.com^
 ||specialityparentalconcluded.com^
 ||speciallyspecifiedsandwich.com^
+||specialscammerinitially.com^
 ||specialtywoollenactively.com^
 ||speciesdecency.com^
 ||specificallydoubtless.com^


### PR DESCRIPTION
Block adserver responsible for redirect popups at https://flixrs.com/

proposed filter: `||specialscammerinitially.com^`

Screenshot: 
<img width="1280" alt="Screenshot 2021-12-08 at 07 53 57" src="https://user-images.githubusercontent.com/65717387/145163001-e83f14c9-5974-4041-97e1-6020f7413bc2.png">
