### PR TITLE
A: [Fix] https://pokeminers.com/

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -37,6 +37,7 @@ job.inshokuten.com#@#.ad-area
 job.inshokuten.com,sexgr.net#@#.ad-box
 livedoorblogstyle.jp#@#.ad-center
 flat-ads.com,job.inshokuten.com#@#.ad-content
+pokeminers.com#@#.ad-container
 transparencyreport.google.com#@#.ad-icon
 flat-ads.com,lastpass.com#@#.ad-img
 guloggratis.dk#@#.ad-links


### PR DESCRIPTION
https://pokeminers.com/ is breaking with the following filter applied : ##.ad-container

Screenshot:
![b8e8e1c9-9710-4f54-9969-226fb6085238](https://user-images.githubusercontent.com/65717387/145339827-24eedb85-d379-456d-9ce7-116bd4a82323.png)
