### PR TITLE
A: https://readcomiconline.li/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5643,6 +5643,7 @@
 ||gecl.xyz^
 ||geealingsa.space^
 ||geedoovu.net^
+||geeksundigne.com^
 ||geethoap.com^
 ||gefadythi.pro^
 ||geilid.com^


### PR DESCRIPTION
Block adserver responsible for redirect popups at https://readcomiconline.li/

To reproduce: Tested as mobile.

Screenshot: 
<img width="997" alt="Screenshot 2021-12-16 at 09 03 55" src="https://user-images.githubusercontent.com/65717387/146332501-6c8adfdd-1bf0-4d30-a8b2-68b5f953aed3.png">

