### PR TITLE
A: http://www.4399.com/

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -69,3 +69,5 @@ newrepublic.com##html:style(overflow: auto !important)
 ! revolver.news
 revolver.news##body:style(overflow: auto !important;)
 revolver.news##.blocker
+! 4399.com
+4399.com##+js(aopr, defaultbackgroundimg)


### PR DESCRIPTION
This page has an annoying self-promotion on the background page (see screenshot) and it doesn't seem to be able to be hidden.
![image](https://user-images.githubusercontent.com/66902050/146399610-5f884075-7ca6-41dd-b66c-254429b5e782.png)