### PR TITLE
Address tracking on mha[.]fi

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2176,6 +2176,7 @@
 ||simonsignal.com^$third-party
 ||simpleanalytics.io^$third-party
 ||simpleanalyticscdn.com^$third-party
+||simpleanalytics.com^$third-party
 ||simpleheatmaps.com^$third-party
 ||simplehitcounter.com^$third-party
 ||simplereach.com^$third-party


### PR DESCRIPTION
This PR addresses the tracking on `mha[.]fi` and fixes https://github.com/uBlockOrigin/uAssets/issues/10961