### PR TITLE
A: www.crunchyroll.com

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -4426,6 +4426,7 @@
 /tracker/trackView?
 /tracker/visitor/*
 /tracker2.js
+/tracker?t=
 /tracker_activityStream.
 /tracker_article
 /tracker_async.


### PR DESCRIPTION
What had been blocked by now-removed `/tracker?*=`.