### PR TITLE
A: https://www2.zoechip.com/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -7670,6 +7670,7 @@
 ||lambingsyddir.com^
 ||lamellisation.site^
 ||lamforsung.com^
+||lamiumericius.com^
 ||lamplosts.site^
 ||lanchaeanly.pro^
 ||land-flirtgirl1.com^


### PR DESCRIPTION
Block adserver responsible for redirects at https://www2.zoechip.com/

Screenshots:
<img width="1661" alt="Screenshot 2021-12-21 at 07 14 18" src="https://user-images.githubusercontent.com/65717387/146881041-c1fd0ea4-88df-45b6-ab05-4efa3602bc67.png">
