### PR TITLE
Fix es[.]wallapop[.]com

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -121,6 +121,7 @@
 @@||google.com/adsense/$subdocument,domain=sedo.co.uk|sedo.com|sedo.jp|sedo.kr|sedo.pl
 @@||google.com/images/integrations/$image,~third-party
 @@||googletagservices.com/tag/js/gpt.js$domain=epaper.timesgroup.com|k2radio.com|koel.com|kowb1290.com|nbcsports.com|scotsman.com|uefa.com|vimeo.com|windalert.com
+@@||googleoptimize.com/optimize.js$script,domain=wallapop.com
 @@||gpt-worldwide.com/js/gpt.js$~third-party
 @@||guim.co.uk/uploader/$image,~third-party
 @@||gumtree.co.za/my/ads.html$~third-party


### PR DESCRIPTION
Fixes https://github.com/uBlockOrigin/uAssets/issues/11091
Reported by @gitbobbed 
Adds the filter `@@||googleoptimize.com/optimize.js$script,domain=wallapop.com` as recommended by @uBlock-user