### PR TITLE
block gelbooru header ad

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -550,6 +550,7 @@ $script,stylesheet,third-party,xmlhttprequest,domain=up-4ever.com|up-4ever.org
 ||gelbooru.com*/license.$script
 ||gelbooru.com*/tryt.$script
 ||gelbooru.com/halloween/
+gelbooru.com##div.headerAd
 ! vidtodo.com
 $image,script,stylesheet,subdocument,third-party,xmlhttprequest,domain=vidtodo.com|vidtodoo.com
 @@||vidtodo.com^$image,script,stylesheet,xmlhttprequest,domain=vidtodo.com|vidtodoo.com

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -550,7 +550,7 @@ $script,stylesheet,third-party,xmlhttprequest,domain=up-4ever.com|up-4ever.org
 ||gelbooru.com*/license.$script
 ||gelbooru.com*/tryt.$script
 ||gelbooru.com/halloween/
-gelbooru.com##div.headerAd
+gelbooru.com##.headerAd
 ! vidtodo.com
 $image,script,stylesheet,subdocument,third-party,xmlhttprequest,domain=vidtodo.com|vidtodoo.com
 @@||vidtodo.com^$image,script,stylesheet,xmlhttprequest,domain=vidtodo.com|vidtodoo.com

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -551,6 +551,7 @@ $script,stylesheet,third-party,xmlhttprequest,domain=up-4ever.com|up-4ever.org
 ||gelbooru.com*/tryt.$script
 ||gelbooru.com/halloween/
 gelbooru.com##.headerAd
+gelbooru.com##.video
 ! vidtodo.com
 $image,script,stylesheet,subdocument,third-party,xmlhttprequest,domain=vidtodo.com|vidtodoo.com
 @@||vidtodo.com^$image,script,stylesheet,xmlhttprequest,domain=vidtodo.com|vidtodoo.com


### PR DESCRIPTION
This banner is blocked atm, but leaves an empty space behind. This should take care of that. I hope edited the correct file. I just looked for existing gelbooru entries
![image](https://user-images.githubusercontent.com/61394004/147579084-b820848f-ce34-4d0e-8c46-b21783e98683.png)

