### PR TITLE
M: make `##.sqs-announcement-bar` specific

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -11987,7 +11987,6 @@
 ##.spkcookie
 ##.sprd-cookie-banner
 ##.sqrcookie
-##.sqs-announcement-bar
 ##.sqs-cookie-banner-v2
 ##.src-components-CookiePolicy-__style__root
 ##.srf-cookie-notice

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -850,6 +850,7 @@ spreadshirt.com##.sprd-consent
 adventure-team.eu,certum.eu,conference2go.com,opentuition.com##.spu-bg
 adventure-team.eu,certum.eu##.spu-box
 spox.com##.spxcib
+blueflag.global,lemoncode.net,records.team##.sqs-announcement-bar
 bonsaipartners.eu##.sqs-slide-layer-content
 openweathermap.org##.stick-footer-panel
 grafana.com##.sticky-footer

--- a/fanboy-addon/fanboy_annoyance_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_allowlist_general_hide.txt
@@ -78,7 +78,6 @@ hyperoptic.com,playtech.co.nz,porozmawiajmyoit.pl,scan.co.uk,zdorovodeti.ru#@#.s
 ltn.com.tw,theuptake.org#@#.scrolltop:not(body):not(html)
 github.com,kifi.com,okcupid.com,retailmenot.com,zoom.us#@#.signup-email
 dualshockers.com#@#.socialfooter
-blackboat.com#@#.sqs-announcement-bar
 xhamster.com#@#.subscribe-block
 humblebundle.com#@#.subscribe-box
 oneplus.com,stackexchange.com#@#.subscribe-container


### PR DESCRIPTION
 The class `.sqs-announcement-bar` is used far more for announcements than for cookie notice probably because the Squarespace framework provides `.sqs-cookie-banner-v2` for cookie banners.

 I found filters from [I don't care about cookies](https://www.i-dont-care-about-cookies.eu/abp/) that still be valid, so I added it to compensate for the removing of `##.sqs-announcement-bar`.

The filter `##.sqs-announcement-bar` was introduced by https://github.com/easylist/easylist/commit/7b18e0c49f1, but the associated url is dead.

### List the website(s) you're having issues:
- `https://www.bibliocommons.com/`
- `https://cpm.org/`
- `https://www.neverware.com/freedownload#intro-text`
- More examples can be found from `https://publicwww.com/websites/%22.sqs-announcement-bar%22/`