### PR TITLE
A: paramountplus.com (specific cookie hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -256,7 +256,7 @@ novapdf.com###novapdf_accept_cookies
 professionalbatterychargers.com###nscmsboxboxsimple
 spreaker.com###nt_container
 northwell.edu###nwh_footer_banner_legal
-msn.com,rockpapershotgun.com,soundcloud.com###onetrust-consent-sdk
+msn.com,paramountplus.com,rockpapershotgun.com,soundcloud.com###onetrust-consent-sdk
 play-cricket.com###openglobal_privacy_widget
 accenture.com###optanon-minimize-wrapper
 harvester.co.uk###optin-optout


### PR DESCRIPTION
Needs specific filter because there's `$generichide` filter for this site in main EasyList.