### PR TITLE
A: https://www.usagoals.sx/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -7713,6 +7713,7 @@
 ||kvygpqttzqhhl.com^
 ||kwnq4hg2n9.com^
 ||kwqptcvwaalgur.com^
+||kwwinyvxxzsmny.com^
 ||kxbvazfrioxs.com^
 ||kxclorpruisyo.com^
 ||kxmvoppmbtzdi.com^
@@ -8885,6 +8886,7 @@
 ||mugleafly.com^
 ||mugpothop.com^
 ||muhaingi.com^
+||muhite.com^
 ||mujap.com^
 ||mujilora.com^
 ||mujnmhmfhrubzq.com^


### PR DESCRIPTION
Block adservers at https://www.usagoals.sx/

also: `||oqhedrmfet.com` `||zewhpnrmykj.com`
mentioned at: #https://github.com/easylist/easylist/pull/10398

Screenshot:
<img width="1274" alt="Screenshot 2022-01-06 at 16 20 36" src="https://user-images.githubusercontent.com/65717387/148407282-0ce20cf0-4fd2-4402-8072-319a9d40e17a.png">
<img width="1280" alt="Screenshot 2022-01-06 at 16 19 48" src="https://user-images.githubusercontent.com/65717387/148407298-ace95bdc-368c-4603-bf03-866093c799fb.png">
<img width="1278" alt="Screenshot 2022-01-06 at 16 18 31" src="https://user-images.githubusercontent.com/65717387/148407302-27408565-79ae-45e9-ba5a-45d71cc64a9f.png">
<img width="1279" alt="Screenshot 2022-01-06 at 16 18 21" src="https://user-images.githubusercontent.com/65717387/148407304-99a3b84f-ca78-41ba-a6eb-281dba1ea6f3.png">

