### PR TITLE
A: https://www.govtrack.us

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -141,6 +141,7 @@ wired.com###follow-wired
 diffen.com###followDfn
 womenonwheels.co.za###followLink
 thisoldhouse.com###followToh
+govtrack.us###followus_modal
 businessinsider.com,businessinsider.com.au###follow_wrap
 people.com###footer-article
 gambling.com###footer-connect-list


### PR DESCRIPTION
Hides annoying "follow us" social media promo overlay