### PR TITLE
A: https://herogayab.net/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5347,6 +5347,7 @@
 ||flatcapspriggy.cam^
 ||flatepicbats.com^
 ||flatlyforensics.com^
+||flaxierfilmset.com^
 ||flaxseedssoenrh4372ojd.com^
 ||fleckbest.com^
 ||fleckspoken.com^
@@ -12032,6 +12033,7 @@
 ||sandelf.com^
 ||sangogne.com^
 ||sankaudacityrefine.com^
+||santonpardal.com^
 ||sapclasped.com^
 ||saporshoping.com^
 ||sapsixysho.pro^


### PR DESCRIPTION
Block adservers responsible for popups at https://herogayab.net/

Screenshots:
<img width="1241" alt="Screenshot 2022-01-10 at 16 13 00" src="https://user-images.githubusercontent.com/65717387/148790183-4691dc29-2fc7-4271-b7ff-737ceb388411.png">

<img width="1280" alt="Screenshot 2022-01-10 at 16 13 05" src="https://user-images.githubusercontent.com/65717387/148790165-9632ba07-d45e-4fd0-b3ae-83c282db8925.png">
