### PR TITLE
A: https://bt4g.org/

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -12657,6 +12657,7 @@
 ||sophang8.com^
 ||sophiasearch.com^
 ||sordidstir.com^
+||sorrowfulchemical.com^
 ||sorryfearknockout.com^
 ||sorryhorngait.com^
 ||sortacki.net^


### PR DESCRIPTION
Block adserver responsible for redirects at https://bt4g.org/

Screenshot:
<img width="1280" alt="Screenshot 2022-01-12 at 14 07 24" src="https://user-images.githubusercontent.com/65717387/149146358-0e2eb685-6832-47dc-b5e9-4c639cd80dc2.png">
