### PR TITLE
A: specific cookie block (wsj.com)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -8,6 +8,7 @@
 ||appconsent.io^
 ||asus.com/js/*/alert-info.js
 ||bysarahkhan.com/wp-content/plugins/surbma-yes-no-popup/
+||cdn.privacy-mgmt.com^$domain=wsj.com
 ||cmp.cdn.thesun.ie^
 ||cmp.infopro-digital.com^
 ||cmp.osano.com^


### PR DESCRIPTION
Doesn't cause issues with videos:

https://www.wsj.com/articles/tsunami-warning-ordered-for-tonga-following-undersea-volcano-eruption-11642242710

https://www.wsj.com/video/series/on-the-news/beijing-winter-olympics-chinas-extreme-covid-19-rules-to-stop-omicron/403AF204-16CC-49BB-A1AB-13507DC02D0D

`cdn.privacy-mgmt.com^` not safe as a generic rule (might cause breakages in some sites) so made this specific.