### PR TITLE
hide realbooru ad on gelbooru

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1369,7 +1369,7 @@ tribuna.com##.footer-helper__min-height-after-header
 supercars.com##.footer-promo
 skidrowcodexreloaded.com##.footer-sticky
 searchcommander.com##.footer-widget
-ru.com##.footerAd2
+gelbooru.com##.footerAd2
 dg-premium.com##.footer__partner-logo
 pbs.org##.footer__sub
 satbeams.com##.footer_banner

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1369,7 +1369,7 @@ tribuna.com##.footer-helper__min-height-after-header
 supercars.com##.footer-promo
 skidrowcodexreloaded.com##.footer-sticky
 searchcommander.com##.footer-widget
-gelbooru.com##.footerAd2
+ru.com##.footerAd2
 dg-premium.com##.footer__partner-logo
 pbs.org##.footer__sub
 satbeams.com##.footer_banner
@@ -2437,6 +2437,7 @@ coingolive.com##[href^="https://bitpreco.com/"]
 dappradar.com##[href^="https://bogged.finance/"]
 analyticsindiamag.com##[href^="https://business.louisville.edu/"]
 gelbooru.com##[href^="https://buymyshit.moneygrubbingwhore.com/"]
+gelbooru.com##[href^='https://realbooru.com/']
 highdemandskills.com##[href^="https://click.linksynergy.com/"]
 coingolive.com##[href^="https://coinext.com.br/"]
 wccftech.com##[href^="https://cutt.ly/"]


### PR DESCRIPTION
I tried coming up with a more general rule, but couldn't get it to work. Fortunately this seems like the only ad left,

![image](https://user-images.githubusercontent.com/61394004/150451467-6297a070-32c8-4117-8c9e-681caa7bd16e.png)

On a sidenote;
i see that other PRs are following some convention w.r.t. title (e.h. "A:"). I cant find where it says what this convention exactly is