### PR TITLE
Restore Angular Material dialog backdrop

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -7785,7 +7785,6 @@
 ##.ccwrap
 ##.cczcook_banner-wrapper
 ##.cd__cookie
-##.cdk-overlay-container > .cdk-overlay-backdrop
 ##.cdp-cookies-alerta
 ##.ce-banner
 ##.ce-banner-html


### PR DESCRIPTION
Because the selector is too wide, it will break legit behavior of all apps
that use Angular Material and their dialog systems. This include standard
modal dialogs, but also datepickers, auto-completion and so on.

With this selector, it would make it impossible to close the dialog by clicking
outside of it.

This is testable on the library official documentation: https://material.angular.io/components/dialog/overview. Clicking on "Pick one" will open a dialog, and clicking anywhere outside of the dialog should close it.

![image](https://user-images.githubusercontent.com/72603/151781893-d03f1be3-aafb-4b4d-ba47-605dcafb7b74.png)
