### PR TITLE
P: digitaltrends.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2915,7 +2915,7 @@ thewrap.com##.brid-default-skin
 mb.com.ph##.code-block
 techwalla.com##.component-article-section-jwplayer-wrapper
 ladbible.com##.css-1tc48v6
-digitaltrends.com##.dtvideos-container
+digitaltrends.com##.dtvideos-container[data-provider="jwplayer"]
 taskandpurpose.com##.empire-unit-prefill-container
 thestar.co.uk##.gOoqzH
 radaronline.com##.hIlCTc


### PR DESCRIPTION
Some article related videos are currently being hidden because of this filter, like for example the YouTube video here:
https://www.digitaltrends.com/gaming/nintendo-switch-sports-announcement/

I guess this filter has been added because of those "RECOMMENDED CONTENT" videos, like the one that can be found here:
https://www.digitaltrends.com/mobile/android-12-dynamic-theming-gms/

The change I'm suggesting should take care of those but still allow other videos.