### PR TITLE
P: https://mubi.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -463,7 +463,7 @@ cryptoquant.com##.ant-row-center
 leo.org##.app-footer-content
 crucial.com##.app-light > div[style*="fixed"]
 start.me##.app__message
-mubi.com##.appear-enter-done
+mubi.com##.css-1usnlyf
 annualreviews.org##.ar-news-footer
 argaam.com##.argaam-policy
 linkedin.com##.artdeco-global-alert


### PR DESCRIPTION
The currently used `appear-enter-done` class is used in a lot of places in mubi, and everything with this animation is removed when this filter list is active. It is unclear whether the automatically generated classname I replaced it with changes over time, but it is better to see the cookie banner then instead of not being able to start watching a movie.

Fixes https://github.com/easylist/easylist/issues/10877