### PR TITLE
A: baku.ws

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -4177,6 +4177,7 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||standingnest.com^
 ||standingsack.com^
 ||standtrouble.com^
+||stat.pet^$third-party
 ||statementsweater.com^
 ||statuesquebrush.com^
 ||steadfastseat.com^


### PR DESCRIPTION
Has login page `https://stat.pet/login` so third-party