### PR TITLE
Handle false positives on https://bookdown.org/

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist.txt
+++ b/fanboy-addon/fanboy_social_allowlist.txt
@@ -90,6 +90,7 @@
 @@||bittorrent.com/public/min/index.php?ipbv=*/socialicons.css
 @@||bluejeans.com^*/images/auth/$image
 @@||bnf.fr/assets/*/sociallinks_controller.js$script
+@@||bookdown.org/*/images/social-
 @@||bpm-power.com/static/templates/it/boxes/socialSharing.html?$xmlhttprequest
 @@||bramkasms.pl/templates/ja_social/$image
 @@||brave.com/wp-content/uploads/$image,~third-party


### PR DESCRIPTION
The generic filter `/images/social-` blocked screenshots in books, e.g. here: https://bookdown.org/yihui/bookdown/features-for-html-publishing.html#metadata-for-sharing