### PR TITLE
add exception rule

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -645,3 +645,5 @@
 @@||adservice.com/wp-content/themes/adservice/$~third-party
 @@||publisher.adservice.com^$domain=publisher.adservice.com
 @@||publisher.adservice.com^$generichide
+! ad-shield.io
+@@/css/ad-$domain=ad-shield.io


### PR DESCRIPTION
issue : #10959
The website is broken because the css file cannot be loaded due to the rule below.

rule: easylist_general_block.txt
```css/ad-```
https://github.com/easylist/easylist/blob/master/easylist/easylist_general_block.txt

Can you add this exception rule to not break the website?

exception rule : `@@/css/ad-$domain=ad-shield.io`
website link : `https://ad-shield.io/home`