### PR TITLE
M: pageviews.toolforge.org → pageviews.wmcloud.org

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3225,7 +3225,7 @@
 /pageview?user_guid=
 /pageviews-counter-
 /pageviews.gif?
-/pageviews/*$domain=~mediawiki.org|~pageviews.toolforge.org|~tools.wmflabs.org|~wikimedia.org|~wikipedia.org
+/pageviews/*$domain=~mediawiki.org|~pageviews.wmcloud.org|~tools.wmflabs.org|~wikimedia.org|~wikipedia.org
 /pageviews?token=
 /pageviews_counter.
 /PageviewsTracker.


### PR DESCRIPTION
Wikimedia's pageview tool at ``pageviews.toolforge.org`` has been unblocked for years. They changed the URL to ``pageviews.wmcloud.org``. The old URL ``pageviews.toolforge.org`` now redirects to ``pageviews.wmcloud.org``.