### PR TITLE
P: vaasa.fi (incorrect blocking & scrolling broken)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -210,7 +210,7 @@ google.ac,google.ad,google.ae,google.al,google.am,google.as,google.at,google.az,
 metallica.com#@#.privacy_policy_message_box
 online.no,telenor.no#@#.privacy_prompt
 uniroyal.pl#@#.privacyhint
-handies.com,ligurianautica.com,referencerecordings.com,studio100.it,taxelocale6.ro,tko.pl#@#.pum[data-popmake*="cookies"]
+handies.com,ligurianautica.com,referencerecordings.com,studio100.it,taxelocale6.ro,tko.pl,vaasa.fi#@#.pum[data-popmake*="cookies"]
 dogedash.com#@#.react-cookie-banner
 motofaktor.pl#@#.rodo-accept
 farmacja.pl,mgr.farm#@#.rodo-modal


### PR DESCRIPTION
https://www.vaasa.fi/asu-ja-ela/sosiaalipalvelut-ja-arjen-tuki/arjen-tuki-vammaisille/

`##.pum[data-popmake*="cookies"]` blocks this notification:

![image](https://user-images.githubusercontent.com/17256841/159724238-ad25346a-14e6-44f2-97a2-00f611199229.png)

Which is not a cookie dialog. It's about organizational changes. Scrolling is also broken. Added a fix.