### PR TITLE
A: https://files.im/4w80lhxorm16

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -23302,6 +23302,7 @@
 ##a[href^="https://www.xvinlink.com/?a_fid="]
 ##a[href^="https://x.trafficandoffers.com/"]
 ##a[href^="https://zononi.com/"]
+##a[href^="https://galaxyroms.net/?scr=files.im"]
 ##ad-desktop-sidebar
 ##amp-ad-custom
 ##app-advertisement


### PR DESCRIPTION
Hide ad button at http://files.im/

**Steps to reproduce:**
Sample URL: https://files.im/4w80lhxorm16
Click on the `Download button` and the ad appears above `CREATE DOWNLOAD LINK` button.
<img width="1292" alt="d91" src="https://user-images.githubusercontent.com/57706597/161340258-cf012805-0d45-4b5f-8f07-4888385bf48d.png">



**Suggested filter:**
##a[href^="https://galaxyroms.net/?scr=files.im"]