### PR TITLE
A: adQuery script

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -16696,6 +16696,7 @@
 ||adpushup.com^$third-party
 ||adqic.com^$third-party
 ||adquantix.com^$third-party
+||adquery.io^$third-party
 ||adquest3d.com^$third-party
 ||adrcdn.com^$third-party
 ||adreactor.com^$third-party

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7247,7 +7247,6 @@ _your_ad.
 _zedo.
 takeover_background.
 takeover_banner_
-||api.adquery.io/js/adquery*.js$third-party
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
 ||com/banners/$image,object,subdocument,domain=~pingdom.com|~thetvdb.com|~tooltrucks.com

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -7247,6 +7247,7 @@ _your_ad.
 _zedo.
 takeover_background.
 takeover_banner_
+||api.adquery.io/js/adquery*.js$third-party
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
 ||com/banners/$image,object,subdocument,domain=~pingdom.com|~thetvdb.com|~tooltrucks.com


### PR DESCRIPTION
May I ask you please if you can block in EasyList an adQuery script serving ads on mobile. The reason why I'm asking is because website is also available in English: https://adquery.io/en/ so blocking in EasyList could cover more websites.

**Steps to reproduce:**
-Sample URL: https://www.instalki.pl/aktualnosci/hardware/53225-doogee-s98-preorder.html
-ABP for Samsung Internet
-English + Polski list
-AA disabled
-Polish VPN

<img width="940" alt="a3q" src="https://user-images.githubusercontent.com/57706597/162252600-31dad6f9-b88e-4fbd-806b-151f9605f4b6.png">

<img width="972" alt="a2q" src="https://user-images.githubusercontent.com/57706597/162252598-03bb5bdf-2f11-417f-b269-7c19d75c87af.png">


![polski8](https://user-images.githubusercontent.com/57706597/162253853-f536fcdd-1f74-4089-b53b-92acecd55cbe.png)

