### PR TITLE
A: https://blog.adplayer.pro

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -13488,7 +13488,7 @@
 ||starvationdefence.com^
 ||starvationpatio.com^
 ||stashedaccel.cam^
-||stat-rock.com^
+||stat-rock.com^$domain=~adplayer.pro
 ||statcamp.net^
 ||statementsorb.com^
 ||statementssupervisorthorough.com^


### PR DESCRIPTION
Easylist rule: `||stat-rock.com^` is blocking a video at https://blog.adplayer.pro/2020/02/13/adplayerpro-commentary-mwc-2020-cancellation/

Blocked script: `https://cdn.stat-rock.com/player/demo.js`
Adjustment: `||stat-rock.com^$domain=~adplayer.pro`

Previous fixes in Easylist: `/adplayer.$domain=~adplayer.media|~adplayer.pro` 

<img width="1200" alt="adp_r" src="https://user-images.githubusercontent.com/57706597/162433737-339a591f-cc9d-4c85-ac91-b79c49516fa0.png">

