### PR TITLE
P: ylilauta.org (some pictures won't load)

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -271,6 +271,7 @@
 @@||yadayadayada.nl/banner/banner.php$image,domain=murf.nl|workhardclimbharder.nl
 @@||yaytrade.com^*/chunks/pages/advert/$~third-party
 @@||yimg.com/rq/darla/*/g-r-min.js$domain=yahoo.com
+@@||ylilauta.org/ad/*$image
 @@||z.moatads.com^$script,domain=standard.co.uk
 @@||zergnet.com^$image,script,stylesheet,domain=ci.craveonline.com|ci.gamerevolution.com|ci.momtastic.com|ci.thefashionspot.com|ci.totallyher.com
 @@||zohopublic.com^*/ADManager_$subdocument,xmlhttprequest,domain=manageengine.com|zohopublic.com


### PR DESCRIPTION
Caused by this filter:

`.org/ad/`

Whitelisting added.

Sample link:
https://ylilauta.org/ohjelmointi/129801379

The first picture cannot be clicked bigger and the site gives an error message due to that.

Maybe `.org/ad/` is too generic?