### PR TITLE
P: http://adcreative.es/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1509,7 +1509,7 @@
 /adcore_$domain=~adcore.ch|~adcore.com.au
 /adcount.$domain=~adcount.com|~adcount.fi
 /adcounter.
-/adcreative.
+/adcreative.$domain=~adcreative.es
 /adcreative/*$~image
 /adcreatives/*
 /adcss/*$~image


### PR DESCRIPTION
EL filter: `/adcreative.` breaking http://adcreative.es/

<img width="931" alt="adc" src="https://user-images.githubusercontent.com/57706597/162583453-015834ae-d305-4320-9974-0f693b964845.png">
