### PR TITLE
A: https://ads.shopee.sg/

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -20,6 +20,7 @@
 @@||ads.taboola.com^$popup
 @@||ads.tiktok.com^$popup
 @@||ads.twitter.com^$popup,~third-party
+@@||ads.shopee.*/$popup
 @@||adv.asahi.com^$popup
 @@||adv.cr^$popup
 @@||adv.gg^$popup


### PR DESCRIPTION
"https://ads.shopee.com.br",
"https://ads.shopee.tw",
"https://ads.shopee.sg",
"https://ads.shopee.com.my",
"https://ads.shopee.vn",
"https://ads.shopee.co.th",
"https://ads.shopee.ph",
"https://ads.shopee.cn",
"https://ads.shopee.kr",
"https://ads.shopee.com.mx"

Above lists our affected sites,
Our site will be intercepted by the $popup rules
While we can open our sites by in the address bar, we cannot open them through new windows, especially for AdGuard interceptors.

The sites above are actually block, and although we use the CDN to record the static resources, we still can't use the site properly
<img width="1018" alt="截屏2022-04-11 下午4 51 33" src="https://user-images.githubusercontent.com/52285315/162701295-510cbc76-6ed7-441d-852e-3974474ce11c.png">

I really hope that you can reply to us
I wish you a happy work