### PR TITLE
A: Hide ads on Unsplash.com

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5278,7 +5278,6 @@
 /pcOfficialAdTags;
 /pd-ads/*
 /pdpads.
-/peel.js
 /peel.php?
 /peel/?webscr=
 /peel1.js

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -775,7 +775,7 @@ google.com##.GISRH3UDHB
 thefocus.news##.GRVMpuWrapper
 metservice.com##.Header
 unsplash.com##.HjpWP
-unsplash.com##div[data-test="say-thanks-card"] > a[rel^="sponsored"]
+unsplash.com##a[rel^="sponsored"]
 sporcle.com##.IMGgi
 israelnationalnews.com##.InfoIn
 israelnationalnews.com##.InfoIn2

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2974,7 +2974,7 @@ mediabiasfactcheck.com##div[id^="media-"]
 gamebyte.com##div[id^="mpu"]
 ebay.co.uk,ebay.com,ebay.com.au,ebay.de##div[id^="plmt_html_"]:not(#plmt_html_101113):not(#plmt_html_101224)
 progamerage.com##div[id^="proga-"]
-progamerage.com/##.vc_separator
+progamerage.com##.vc_separator
 yopmail.com,yopmail.fr,yopmail.net##div[id^="pub"]
 howtogeek.com##div[id^="purch_"]
 simpleflying.com##div[id^="simpl-"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2974,6 +2974,7 @@ mediabiasfactcheck.com##div[id^="media-"]
 gamebyte.com##div[id^="mpu"]
 ebay.co.uk,ebay.com,ebay.com.au,ebay.de##div[id^="plmt_html_"]:not(#plmt_html_101113):not(#plmt_html_101224)
 progamerage.com##div[id^="proga-"]
+progamerage.com/##.vc_separator
 yopmail.com,yopmail.fr,yopmail.net##div[id^="pub"]
 howtogeek.com##div[id^="purch_"]
 simpleflying.com##div[id^="simpl-"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -774,7 +774,7 @@ google.com##.GGQPGYLCMCB
 google.com##.GISRH3UDHB
 thefocus.news##.GRVMpuWrapper
 metservice.com##.Header
-unsplash.com##.HjpWP#
+unsplash.com##.HjpWP
 unsplash.com##div[data-test="say-thanks-card"] > a[rel^="sponsored"]
 sporcle.com##.IMGgi
 israelnationalnews.com##.InfoIn

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -774,7 +774,8 @@ google.com##.GGQPGYLCMCB
 google.com##.GISRH3UDHB
 thefocus.news##.GRVMpuWrapper
 metservice.com##.Header
-unsplash.com##.HjpWP
+unsplash.com##.HjpWP#
+unsplash.com##div[data-test="say-thanks-card"] > a[rel^="sponsored"]
 sporcle.com##.IMGgi
 israelnationalnews.com##.InfoIn
 israelnationalnews.com##.InfoIn2


### PR DESCRIPTION
Ads appear when downloading images from unsplash

![image-2022-04-14-12-31-57-347](https://user-images.githubusercontent.com/45878727/163388659-d4726b84-001c-4bb7-a05b-8336540ce91e.png)
