### PR TITLE
P: https://www.pch.com/games/minute-mania/mahjongg-minute/gameplay

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -143,7 +143,7 @@
 @@||imasdk.googleapis.com/js/core/bridge*.html$subdocument,domain=~spotify.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=247sports.com|api.screen9.com|bbc.com|blastingnews.com|bloomberg.com|cbsnews.com|cbssports.com|chicagotribune.com|cnet.com|crhoy.com|distro.tv|einthusan.tv|embed.comicbook.com|etonline.com|games.usatoday.com|howstuffworks.com|iheart.com|insideedition.com|metacritic.com|missoulian.com|newsweek.com|paralympic.org|player.abacast.net|player.earthtv.com|player.performgroup.com|popculture.com|scrippsdigital.com|sonyliv.com|tdn.com|truvid.com|tubitv.com|zdnet.com|zeebiz.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3_dai.js$domain=247sports.com|bloomberg.co.jp|bloomberg.com|cbc.ca|embed.comicbook.com|sbs.com.au
-@@||imasdk.googleapis.com/js/sdkloader/ima3_debug.js$domain=abcnews.go.com|brightcove.net
+@@||imasdk.googleapis.com/js/sdkloader/ima3_debug.js$domain=abcnews.go.com|brightcove.net|pch.com
 @@||img-cdn.mediaplex.com^$image,domain=betfair.com
 @@||improvedigital.com/pbw/headerlift.min.js$domain=games.co.uk
 @@||infotel.ca/images/ads/$image,~third-party


### PR DESCRIPTION
Video lagging issue at pch.com. It takes about 1 min for the **Play Now!** option to show up. 
In the meanwhile a black box displays message: "Please watch a message from our sponsor while your game is loading".

**Website:** pch.com (Publishers Clearing House)
**Sample URL:** https://www.pch.com/games/minute-mania/mahjongg-minute/gameplay

**EasyList filter causing the issue:** `||imasdk.googleapis.com^`
 
**Script blocked:** https://imasdk.googleapis.com/js/sdkloader/ima3_debug.js

<img width="1080" alt="pch_b" src="https://user-images.githubusercontent.com/57706597/163467554-8f3bda4b-6b32-4a91-bf0c-9ad494a630eb.png">

**Suggested filter: add domain to existing rule:**
`@@||imasdk.googleapis.com/js/sdkloader/ima3_debug.js$domain=abcnews.go.com|brightcove.net|pch.com`
<img width="1215" alt="pch_al" src="https://user-images.githubusercontent.com/57706597/163467549-630b5a9c-caa9-4f89-b58f-657c3e9073ff.png">

