### PR TITLE
 A: stadium.fi (specific cookie banner filter for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -233,7 +233,7 @@ radissonhotels.com###__tealiumGDPRecModal
 piadinalumbro.gr##.cookie-message
 ft.com##.o-cookie-message
 onlyfans.com##.b-cookies-informer
-github.io###cookie-bar
+github.io,stadium.fi###cookie-bar
 dogemate.com###cconsent-bar
 europa.eu###cookie-consent-banner
 analog.com###cookie-consent-container.modal


### PR DESCRIPTION
https://www.stadium.fi/

A specific filter to overcome blinking issues on uBO with the generic filter.