### PR TITLE
A: https://unsplash.com/t/history

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -813,7 +813,8 @@ afkgaming.com##.Wkf_t
 this.org##.Wrap-leaderboard
 tumblr.com##.XJ7bf
 tumblr.com##.Yc2Sp
-unsplash.com##.Z9B2b
+unsplash.com##a[rel^="sponsored"][target="_blank"]
+unsplash.com##.eziW_
 afar.com##.ZZAilYOLYlkw-Hv02mHW8
 olympics.com##.\-partners
 afkgaming.com##._1Qdz9


### PR DESCRIPTION
Hide ads at https://unsplash.com/t/history AND https://unsplash.com/photos/tSp5_w9h5TQ

Related commits: 
https://github.com/easylist/easylist/commit/103f783
https://github.com/easylist/easylist/commit/e5e76ce

**Suggestion:**

1. Remove: `unsplash.com##.Z9B2b`

2. Add `unsplash.com##a[rel^="sponsored"][target="_blank"]` instead: 
2.1. To hide ads when you click on the **Download free** button  + **iStock images** at https://unsplash.com/photos/tSp5_w9h5TQ 
<img width="1431" alt="dwd1" src="https://user-images.githubusercontent.com/57706597/164061880-a50d816e-8a5a-40c0-903a-06e2ccbee855.png">

<img width="1299" alt="iStock" src="https://user-images.githubusercontent.com/57706597/164064011-4a974e43-4a9e-49a8-b5f6-920aa695456b.png">



2.2. To also hide banner ads at https://unsplash.com/t/history 
<img width="1217" alt="ifvads4" src="https://user-images.githubusercontent.com/57706597/164064300-2fc46ac8-6447-4fea-9980-22b2e5379dd6.png">

3. Add `unsplash.com##.eziW_` to hide remaining **Ad** label at https://unsplash.com/t/history

<img width="763" alt="AdLabel" src="https://user-images.githubusercontent.com/57706597/164065142-a92c0a20-13b6-4433-9bb5-5d67f456d8b6.png">

