### PR TITLE
A: coachhuey.com - hide top banner

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1649,6 +1649,7 @@ hd-trailers.net##.header-win
 gelbooru.com##.headerAd
 thelakewoodscoop.com##.headerPromo
 gautengnewspaper.co.za##.header__banner
+coachhuey.com##a[href^="https://www.hudl.com"]
 manofmany.com##.header_banner_wrap
 thenewslens.com##.help-tnl-container-300_250
 thenewslens.com##.help-tnl-container-970_250


### PR DESCRIPTION
Hide "hudlassist" banner on coachhuey.com.
![Screenshot 2022-04-20 at 11 01 29](https://user-images.githubusercontent.com/45878727/164192175-56a149e5-1d1f-4af2-983c-22c0fa5ea69d.png)
 