### PR TITLE
A: remove ad from onepagerules.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2621,6 +2621,7 @@ twistedsifter.com##.widget_sifter_ad_bigbox_widget
 acprimetime.com,brigantinenow.com,downbeachbuzz.com##.widget_sp_image
 screenbinge.com,streamingrant.com##.widget_sp_image-image-link
 gamertweak.com##.widget_srlzycxh
+onepagerules.com##.wp-container-6
 lostintechnology.com,ripplecoinnews.com,webkinznewz.ganzworld.com##.widget_text
 nypost.com##.widget_text.no-mobile.box
 helpnetsecurity.com##.widgetized_wrapper


### PR DESCRIPTION
below the article [class="wp-container-6 wp-block-columns alignwide"]

![Screenshot 2022-04-20 at 13 36 09](https://user-images.githubusercontent.com/45878727/164222073-d75068b0-389d-4506-8791-31722249cfd2.png)
 