### PR TITLE
A: hide banner on urbanartassociation.com

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -219,6 +219,7 @@
 ||highepcoffer.com/images/banners/
 ||hitleap.com/assets/banner
 ||hostmonster.com/src/js/$third-party
+||hosting.photobucket.com$domain=urbanartassociation.com
 ||hoteltravel.com/partner/$third-party
 ||hotlink.cc/promo/
 ||httpslink.com/EdgeOfTheFire

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -219,7 +219,7 @@
 ||highepcoffer.com/images/banners/
 ||hitleap.com/assets/banner
 ||hostmonster.com/src/js/$third-party
-||hosting.photobucket.com$domain=urbanartassociation.com
+||hosting.photobucket.com^$image,domain=urbanartassociation.com
 ||hoteltravel.com/partner/$third-party
 ||hotlink.cc/promo/
 ||httpslink.com/EdgeOfTheFire


### PR DESCRIPTION
![Screenshot 2022-04-21 at 13 35 41](https://user-images.githubusercontent.com/45878727/164449807-f50273a1-fb07-4707-9693-f17a38313e0c.png)

- banners (top & bottom) ([src^="https://hosting.photobucket.com/images/f369/"])