### PR TITLE
A: https://yts.mx/movies/turning-red-2022

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5680,6 +5680,7 @@
 /script/oas/*
 /script/suurl4.php?$third-party
 /script/ut.js?cb=$third-party
+/script/nwsu.js$third-party
 /script/wait.php?p=$xmlhttprequest
 /scripts/ad/*
 /scripts/ad_

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2657,6 +2657,7 @@ tekdeeps.com##.zAzfDBzdxq3
 ign.com##.zad
 windows101tricks.com##.zanui-container
 thehackernews.com##.zoho-box
+yts.mx##.aoiwjs
 swarajyamag.com##[class*="page-top-adv-wrapper"]
 thetimes.co.uk##[class*="responsiveweb__NativeAd"]
 zerohedge.com##[class^="Advert_"]

--- a/easylist/easylist_specific_hide_abp.txt
+++ b/easylist/easylist_specific_hide_abp.txt
@@ -6,7 +6,7 @@ limetorrents.pro#?#.torrentinfo div + div:-abp-contains(Fast And Direct Download
 rephrase.info#?#.text-center.my-3:-abp-has(span:-abp-contains(Advertisement))
 walmart.com#?#li.items-center:-abp-has(div[data-ad-component-type="wpa-tile"])
 walmart.com#?#div[class="mb1 ph1 pa0-xl bb b--near-white w-25"]:-abp-has(div[data-ad-component-type="wpa-tile"])
-yts.mx#?#.hidden-xs.hidden-sm:-abp-contains(Warning! Download only with VPN...)
+yts.mx#?#.hidden-xs.hidden-sm:-abp-contains(Warning!‌ Download only with VPN...)
 samsclub.com#?#li[class="sc-carousel-slide sc-carousel-horizontal"]:-abp-has(div.sc-pc-sponsored)
 troyhunt.com#?#.sidebar-featured:-abp-has(a[href^="https://pluralsight.pxf.io/"])
 bing.com#?#li[class="b_algo"]:-abp-has(> h2 + div[class="b_caption"] > p[class])


### PR DESCRIPTION
Block redirect popups at https://yts.mx/movies/turning-red-2022 and also at https://eztv.tf/ + https://eztv.yt/

* Added `/script/nwsu.js$third-party`  to block script serving the ads, since it has changed from: https://factermer.com/script/nwsu.js to https://cernamer.com/script/nwsu.js
Reference commit: https://github.com/easylist/easylist/pull/11722 so maybe is better to make it general as it would also block at **eztv.tf** and **eztv.yt**

* Added`yts.mx##.aoiwjs` to block banner VPN ad

Also adding 
<img width="1006" alt="yts1" src="https://user-images.githubusercontent.com/57706597/165079468-c295be7b-d472-4928-9464-cb33deff9605.png">
<img width="1000" alt="ytsmx" src="https://user-images.githubusercontent.com/57706597/165079473-274b4210-0f0d-4e6d-8d02-e747d28ea433.png">
<img width="1019" alt="eztvTF" src="https://user-images.githubusercontent.com/57706597/165079511-ca28c1ad-1973-4321-aa15-9900ae9de472.png">
<img width="1008" alt="eztvYT" src="https://user-images.githubusercontent.com/57706597/165079516-d188300a-7591-4a43-ba6f-0dc6d0b3afeb.png">

