### PR TITLE
A: https://unblockedstreaming.net/

### DIFF
--- a/easylist/easylist_specific_block_popup.txt
+++ b/easylist/easylist_specific_block_popup.txt
@@ -22,12 +22,16 @@ $popup,third-party,domain=1337x.buzz|720pstream.tv|9anime.id​|adblockstreamtap
 ||mp3-convert.org/p$popup
 ||notube.website/p/$popup
 ||pinoymovies.es/links/$popup
+||piraproxy.info/hkz2^$popup
+||piraproxy.info/&^$popup
 ||player.tabooporns.com^$popup
 ||qontent.pouvideo.cc^$popup
 ||sendspace.com/defaults/sendspace-pop.html$popup
 ||skycheats.com^$popup,domain=elitepvpers.com
 ||t.co^$popup,domain=hltv.org
 ||topeuropix.site/svop4/$popup
+||unblockedstreaming.net/&^$popup
+||unblockedstreaming.net/hkz^$popup
 ||vidxhot.net/out.php$popup
 ||vpnfortorrents.*?$popup
 ||waaw.to/out.php$popup


### PR DESCRIPTION
Block popups at all the subdomains of https://unblockedstreaming.net/ and https://piraproxy.info/

Example: 
http://gogoanime.unblockedstreaming.net/
<img width="872" alt="Screenshot 2022-04-26 at 10 53 05" src="https://user-images.githubusercontent.com/65717387/165262014-0fcd5807-3cd1-4cdd-844d-263a5219ccb9.png">

http://1337x.piraproxy.info/
<img width="1252" alt="Screenshot 2022-04-26 at 10 52 23" src="https://user-images.githubusercontent.com/65717387/165261875-6447fc8f-2015-4e97-98eb-78b87b77ecdf.png">

Could also be an option:
```
/hkz*^$popup,domain=
/&*^$popup,domain=
```