### PR TITLE
Add 14 Thai Websites to easylist cookie

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1836,6 +1836,18 @@ itab.se##div[style^="position: fixed; left: 0px; top: 0px;"]
 sanook.com##.Pdpa
 glo.or.th##.cookie-wapper
 pantip.com##.pt-snackbar__surface
+becteroradio.com,teroradio.com##.policy
+bnn.in.th##.the-pdpa-consent-bar
+classic.set.or.th,settrade.com###pdpa-policy
+komchadluek.net###accept-cookie-footer
+nipa.co.th###cookie-con-head
+posttoday.com###box-policy
+punpro.com##div[class^="CookieSession"]
+set.or.th##.cookies-pdpa
+siamsport.co.th###popup-ss
+techsauce.co##.cwc-cookie-banner-ui-sdk
+thaiza.com##.ck-acpt-container
+vroom.truevirtualworld.com##.card-cookie
 !
 ! ---------- Turkish ----------
 !


### PR DESCRIPTION
http://becteroradio.com/
https://teroradio.com/
https://www.bnn.in.th/
https://classic.set.or.th/
https://www.settrade.com/
https://www.komchadluek.net/
https://nipa.co.th/
https://www.posttoday.com/
https://www.punpro.com/
https://www.set.or.th/
https://www.siamsport.co.th/
https://techsauce.co/
https://thaiza.com/
https://vroom.truevirtualworld.com/