### PR TITLE
Add regex101.com analytics filter

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -82,6 +82,7 @@
 ||analytics.plex.tv^
 ||analytics.productreview.com.au^
 ||analytics.realestate.com.au^
+||analytics.regex101.com^
 ||analytics.send.cm^
 ||analytics.slashdotmedia.com^
 ||analytics.synedat.com^


### PR DESCRIPTION
The domain `analytics.regex101.com` hosts a Plausible Analytics instance
from where analytics scripts are loaded from and metrics sent to.