### PR TITLE
A: https://yts.mx/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5679,10 +5679,12 @@
 /script/ad.$~script
 /script/ads_
 /script/nwsu.js$third-party
+/script/nasu.js$third-party
 /script/oas/*
 /script/suurl4.php?$third-party
 /script/ut.js?cb=$third-party
 /script/wait.php?p=$xmlhttprequest
+/script/wait.php?q=$xmlhttprequest
 /scripts/ad/*
 /scripts/ad_
 /scripts/ads/*


### PR DESCRIPTION
Block redirect popus on yts.mx eztv.tf and eztv.yt

yts.mx - popups come up when you click on any item.

eztv.tf and eztv.yt - popups come up when you click on any item and also on the video controller (try to advance the video for example).

Reference PR: https://github.com/easylist/easylist/pull/11800 seem not enough to block these popups.
Rule:`/script/ut.js?cb=$third-party` is already in EasyList.

https://yts.mx/movies/the-bad-guys-2022
<img width="1210" alt="ytM" src="https://user-images.githubusercontent.com/57706597/166432319-ee6c2a6e-0202-43e8-a87a-220146821acd.png">

https://eztv.tf/ep/1787100/judge-steve-harvey-s01e12-480p-x264-msd/
<img width="1195" alt="ezT" src="https://user-images.githubusercontent.com/57706597/166432292-f43311f6-e233-4ddb-a3a7-940ec7dbe6e6.png">

https://eztv.yt/ep/1785750/61st-street-s01e04-1080p-hevc-x265-megusta/
<img width="1205" alt="ezY" src="https://user-images.githubusercontent.com/57706597/166432306-af179873-1fa8-453f-9e1d-f121bae3af61.png">



