### PR TITLE
A: https://exportfromnigeria.info/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -73,6 +73,7 @@ snewscms.com,yokogames.com###advertisment
 apkonline.net###adxx
 thebugle.co.za###adz
 apkonline.net###adzz
+exportfromnigeria.info###affs
 purplepainforums.com###affiliates
 systutorials.com###after-content-1
 amgreatness.com###ag-lead


### PR DESCRIPTION
Hide affiliate animated banners on https://exportfromnigeria.info/

Reference commit: https://github.com/easylist/easylist/commit/a62baca
 _Note: Please let me know whether it would be better to hide the entire affiliate table instead `###easy_aff_table`_

<img width="1198" alt="aff1" src="https://user-images.githubusercontent.com/57706597/166720947-5d052b10-db4a-4175-b76a-4250a084b5b1.png">

