### PR TITLE
A: https://mtaeta.info/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2904,6 +2904,7 @@ twitter.com##a[href*="src=promoted_trend_click"] + div
 unitconversion.org##a[href="../noads.html"]
 1337x.to##a[href="/v-pn2dl-hideip"]
 techporn.ph##a[href][target*="blank"]
+mtaeta.info##a[href][target="_blank"] > img[src^="http://storage2.proboards.com/"]
 rarbg.to,rarbgaccess.org,rarbgmirror.com,rarbgmirror.org,rarbgproxy.com,rarbgproxy.org,rarbgunblock.com,rarbgunblocked.org##a[href][target="_blank"] > button
 flaticon.com##a[href^="//www.flaticon.com/edge/redirect?"]
 linkhub.icu##a[href^="/downloadnow.php?"]


### PR DESCRIPTION
Hide banner ads on https://mtaeta.info/

Reference PR: https://github.com/easylist/easylist/pull/11719
<img width="1006" alt="mtatea" src="https://user-images.githubusercontent.com/57706597/166886801-6f794a78-9f14-4eb2-8215-3d4d5e15f218.png">


Note: Please let me know whether it would be better to hide the entire `Partners table` instead.
 Suggestion: `mtaeta.info##div[class="container"][style="margin-bottom: 0px;"]`


