### PR TITLE
P: https://www.google.*/maps/* (Brave-specific CNAME issue)

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -212,7 +212,7 @@
 ||groupon.com/javascripts/common/affiliate_widget/
 ||grscty.com/images/banner/
 ||gsniper.com/images/
-||gstaticadssl.l.google.com^$~font,third-party,~xmlhttprequest
+||gstaticadssl.l.google.com^$~font,third-party,~xmlhttprequest,domain=~google.ae|~google.at|~google.be|~google.bg|~google.by|~google.ca|~google.ch|~google.cl|~google.co.id|~google.co.il|~google.co.in|~google.co.jp|~google.co.ke|~google.co.kr|~google.co.nz|~google.co.th|~google.co.uk|~google.co.ve|~google.co.za|~google.com|~google.com.ar|~google.com.au|~google.com.br|~google.com.co|~google.com.ec|~google.com.eg|~google.com.hk|~google.com.mx|~google.com.my|~google.com.pe|~google.com.ph|~google.com.pk|~google.com.py|~google.com.sa|~google.com.sg|~google.com.tr|~google.com.tw|~google.com.ua|~google.com.uy|~google.com.vn|~google.cz|~google.de|~google.dk|~google.dz|~google.ee|~google.es|~google.fi|~google.fr|~google.gr|~google.hr|~google.hu|~google.ie|~google.it|~google.lt|~google.lv|~google.nl|~google.no|~google.pl|~google.pt|~google.ro|~google.rs|~google.ru|~google.se|~google.sk
 ||handango.com/marketing/affiliate/
 ||hbid.ams3.cdn.digitaloceanspaces.com^
 ||hide-my-ip.com/promo/

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -212,7 +212,6 @@
 ||groupon.com/javascripts/common/affiliate_widget/
 ||grscty.com/images/banner/
 ||gsniper.com/images/
-||gstaticadssl.l.google.com^$~font,third-party,~xmlhttprequest,domain=~google.ae|~google.at|~google.be|~google.bg|~google.by|~google.ca|~google.ch|~google.cl|~google.co.id|~google.co.il|~google.co.in|~google.co.jp|~google.co.ke|~google.co.kr|~google.co.nz|~google.co.th|~google.co.uk|~google.co.ve|~google.co.za|~google.com|~google.com.ar|~google.com.au|~google.com.br|~google.com.co|~google.com.ec|~google.com.eg|~google.com.hk|~google.com.mx|~google.com.my|~google.com.pe|~google.com.ph|~google.com.pk|~google.com.py|~google.com.sa|~google.com.sg|~google.com.tr|~google.com.tw|~google.com.ua|~google.com.uy|~google.com.vn|~google.cz|~google.de|~google.dk|~google.dz|~google.ee|~google.es|~google.fi|~google.fr|~google.gr|~google.hr|~google.hu|~google.ie|~google.it|~google.lt|~google.lv|~google.nl|~google.no|~google.pl|~google.pt|~google.ro|~google.rs|~google.ru|~google.se|~google.sk
 ||handango.com/marketing/affiliate/
 ||hbid.ams3.cdn.digitaloceanspaces.com^
 ||hide-my-ip.com/promo/


### PR DESCRIPTION
On Google map click bottom-left Layers => More and Globe view will be partly broken:

![map](https://user-images.githubusercontent.com/58900598/167086171-1b36f0bd-f18d-4b2a-bf16-0b32b7f1ed83.png)

![map1](https://user-images.githubusercontent.com/58900598/167085974-ae45db00-eab4-4de9-8b3b-6e0d3a106d99.png)

This seems to be a CNAME issue by Brave's uncloak, adding `@@||gstaticadssl.l.google.com^$domain=google.co.jp|google.com` to custom filter fixes it on my end. The responsible rule is `||gstaticadssl.l.google.com^$~font,third-party,~xmlhttprequest` and `third-party` doesn't help due to cname uncloaking:

![cname](https://user-images.githubusercontent.com/58900598/167085453-92776ae6-2c0e-49bb-83ac-01f12a080b03.png)

On uBO + Firefox it doesn't happen thx to `@@||google.*^$cname` in Unbreak, but apparently Brave can't interpret `$cname`. @pes10k is there a plan to support the modifier?
