### PR TITLE
P: https://adx.solutionshill.com/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3186,7 +3186,7 @@
 /adwrapperiframe.
 /adwriter2.
 /adx-exchange.
-/adx.$domain=~adx.business|~adx.co.nz|~adx.cx|~adx.nz|~adx.rs|~adx.ru|~adx.traveledge.com|~adx.tribefire.com|~adx.uk.com|~adx.world|~adx.wowfi.com|~journals.uchicago.edu
+/adx.$domain=~adx.business|~adx.co.nz|~adx.cx|~adx.nz|~adx.rs|~adx.ru|~adx.traveledge.com|~adx.tribefire.com|~adx.uk.com|~adx.world|~adx.wowfi.com|~journals.uchicago.edu|~solutionshill.com
 /adx/ads?
 /adx/iframe.
 /adx/js/*


### PR DESCRIPTION
Website blocked by EasyList rule: 
`/adx.$domain=~adx.business|~adx.co.nz|~adx.cx|~adx.nz|~adx.rs|~adx.ru|~adx.traveledge.com|~adx.tribefire.com|~adx.uk.com|~adx.world|~adx.wowfi.com|~journals.uchicago.edu`

https://adx.solutionshill.com/
<img width="1243" alt="as12" src="https://user-images.githubusercontent.com/57706597/167107881-37e658de-d715-44da-aff2-94e8523dfdfe.png">

https://solutionshill.com/
<img width="1249" alt="as13" src="https://user-images.githubusercontent.com/57706597/167107883-95401a74-c198-4b25-8bcc-d9a0aef2ddfb.png">
