### PR TITLE
Update easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3883,7 +3883,6 @@
 ||cttghjfhsw.com^
 ||cubanetestoon.com^
 ||cubaordmvsslr.com^
-||cubics.com^
 ||cucalm.com^
 ||cuckooretire.com^
 ||cuculf.name^


### PR DESCRIPTION
Removing an old domain that keeps getting blacklisted wrongfully. This domain was used for ad tracking by previous owners and is no longer used for anything tracking-related. Kindly remove it from the adservers list.