### PR TITLE
M: removed problematic rule (fixes https://github.com/AdguardTeam/Adg…

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -262,7 +262,6 @@
 !---------- Japanese ----------
 !
 @@||a8.net/svt/$image,domain=samplefan.com
-@@||ad.pr.ameba.jp/tpc/list/$xmlhttprequest
 @@||adobedtm.com^*-libraryCode_source.min.js$script,domain=disneyplus.disney.co.jp
 @@||adobedtm.com^*/mbox-contents-$script,domain=fcbarcelona.jp|sony.jp
 @@||adobedtm.com^*/satelliteLib-$script,domain=fcbarcelona.jp|radiko.jp|sony.jp|support.nec-lavie.jp

--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -651,7 +651,6 @@
 ||nhk.or.jp^*/bc.js
 ||nikkei.com/.resources/tracking/
 ||ppf.rakuten.co.jp^$~script
-||pr.ameba.jp^
 ||pvtag.yahoo.co.jp^
 ||pw.gigazine.net^
 ||rakuten.co.jp/gw.js


### PR DESCRIPTION
…uardFilters/issues/118196)
https://github.com/AdguardTeam/AdguardFilters/issues/118196
If you prefer exception it's `@@||ad.pr.ameba.jp/own/adc/$xmlhttprequest` but tracker (?) is covered by `/meas.ad.pr.` and I wonder what else the rule blocks.