### PR TITLE
A: https://bucksco.today/

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -14899,6 +14899,7 @@
 ##.aol-twist-flyout-ad
 ##.aolSponsoredLinks
 ##.aopsadvert
+##.ap-ad-block
 ##.ap_str_ad
 ##.apadam-ads
 ##.apexAd

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -817,6 +817,7 @@ tvtv.us##.MuiPaper-elevation2
 ahaan.co.uk##.MuiSnackbar-anchorOriginBottomCenter
 news18.com##.NAT_add
 ask.com##.PartialKelkooResults
+bucksco.today##.placeholder-block
 snopes.com##.PlacementWrapper
 tumblr.com##.Qrht9
 lbcgroup.tv##.ScriptDiv
@@ -992,6 +993,7 @@ androidauthority.com##.andro-mid-article-placement
 foreca.com##.anlu8i5
 ttgmedia.com##.ao-creative-bg
 yts.mx##.aoiwjs
+bucksco.today##.ap-ad-block
 motor1.com##.ap
 motor1.com##.apb
 ebay.com##.app-rtm-pid-wrapper

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -993,7 +993,6 @@ androidauthority.com##.andro-mid-article-placement
 foreca.com##.anlu8i5
 ttgmedia.com##.ao-creative-bg
 yts.mx##.aoiwjs
-bucksco.today##.ap-ad-block
 motor1.com##.ap
 motor1.com##.apb
 ebay.com##.app-rtm-pid-wrapper


### PR DESCRIPTION
**1 - Hide image slider (.gif) under Affiliate Partners**
_Please let me me know if it should be added to Annoyance List instead_

<img width="1413" alt="slider1" src="https://user-images.githubusercontent.com/57706597/168278986-ca98fb7a-007a-45db-b391-6b2f822e63aa.png">

<img width="1419" alt="slider2" src="https://user-images.githubusercontent.com/57706597/168278997-bb0e171b-3822-432d-9e33-5b1216db5a80.png">

**2 - Hide ad labels throughout out the page** 
<img width="1407" alt="adlabels" src="https://user-images.githubusercontent.com/57706597/168278966-cbb10081-a01c-4a62-91fc-b5177b19051c.png">

