### PR TITLE
P: https://ad-maven.com/advertisers

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -297,6 +297,7 @@
 @@||recaptcha.net/recaptcha/$script
 ! Webcompat Generichide fixes (Avoid any potential filters being applied to non-ad domains)
 @@||accounts.google.com^$generichide
+@@||ad-maven.com^$generichide
 @@||apple.com^$generichide
 @@||bitbucket.org^$generichide
 @@||calendar.google.com^$generichide

--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -38,23 +38,19 @@ gamingcools.com#@#.Adsense
 m.motonet.fi#@#.ProductAd
 hach.de#@#.ad-active
 job.inshokuten.com#@#.ad-area
-ad-maven.com#@#.ad-banner
 kincho.co.jp#@#.ad-block
 job.inshokuten.com,sexgr.net#@#.ad-box
-ad-maven.com#@#.ad-btn
 dmkt-sp.jp#@#.ad-button
 livedoorblogstyle.jp#@#.ad-center
 pokeminers.com#@#.ad-container
 flat-ads.com,job.inshokuten.com#@#.ad-content
 dmkt-sp.jp#@#.ad-cover
-ad-maven.com#@#.ad-full
 transparencyreport.google.com#@#.ad-icon
-ad-maven.com,flat-ads.com,lastpass.com#@#.ad-img
+flat-ads.com,lastpass.com#@#.ad-img
 dmkt-sp.jp#@#.ad-label
 guloggratis.dk#@#.ad-links
 so-net.ne.jp#@#.ad-notice
 so-net.ne.jp#@#.ad-outside
-ad-maven.com#@#.ad-push
 hulu.com#@#.ad-root
 wiki.fextralife.com#@#.ad-sidebar
 wegotads.co.za#@#.ad-source
@@ -191,7 +187,6 @@ outinthepaddock.com.au#@#.topads
 codedevstuff.blogspot.com,hassiweb-programming.blogspot.com#@#.vertical-ads
 youtube.com#@#.video-ads
 javynow.com#@#.videos-ad
-ad-maven.com#@#.widget-ads
 globsads.com#@#[href^="http://globsads.com/"]
 mypillow.com#@#[href^="https://mypillow.com/"] > img
 techradar.com#@#[href^="https://www.hostg.xyz/aff_c"]

--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -38,19 +38,23 @@ gamingcools.com#@#.Adsense
 m.motonet.fi#@#.ProductAd
 hach.de#@#.ad-active
 job.inshokuten.com#@#.ad-area
+ad-maven.com#@#.ad-banner
 kincho.co.jp#@#.ad-block
 job.inshokuten.com,sexgr.net#@#.ad-box
+ad-maven.com#@#.ad-btn
 dmkt-sp.jp#@#.ad-button
 livedoorblogstyle.jp#@#.ad-center
 pokeminers.com#@#.ad-container
 flat-ads.com,job.inshokuten.com#@#.ad-content
 dmkt-sp.jp#@#.ad-cover
+ad-maven.com#@#.ad-full
 transparencyreport.google.com#@#.ad-icon
-flat-ads.com,lastpass.com#@#.ad-img
+ad-maven.com,flat-ads.com,lastpass.com#@#.ad-img
 dmkt-sp.jp#@#.ad-label
 guloggratis.dk#@#.ad-links
 so-net.ne.jp#@#.ad-notice
 so-net.ne.jp#@#.ad-outside
+ad-maven.com#@#.ad-push
 hulu.com#@#.ad-root
 wiki.fextralife.com#@#.ad-sidebar
 wegotads.co.za#@#.ad-source
@@ -187,6 +191,7 @@ outinthepaddock.com.au#@#.topads
 codedevstuff.blogspot.com,hassiweb-programming.blogspot.com#@#.vertical-ads
 youtube.com#@#.video-ads
 javynow.com#@#.videos-ad
+ad-maven.com#@#.widget-ads
 globsads.com#@#[href^="http://globsads.com/"]
 mypillow.com#@#[href^="https://mypillow.com/"] > img
 techradar.com#@#[href^="https://www.hostg.xyz/aff_c"]

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3063,7 +3063,7 @@
 /advertisements?
 /advertisements_
 /advertisers.$image,script,subdocument,domain=~advertisers.adgoal.de|~advertisers.adversense.com|~advertisers.careerone.com.au|~advertisers.ch|~advertisers.dk|~advertisers.easyweddings.com.au|~advertisers.io|~advertisers.leadia.ru|~advertisers.ypfboost.ph|~panel.rightflow.com
-/advertisers/*$domain=~ads.pinterest.com|~datalift360.com|~home.tapjoy.com|~panel.rightflow.com|~propelmedia.com|~publisuites.com|~qubeslate.com
+/advertisers/*$domain=~ads.pinterest.com|~datalift360.com|~home.tapjoy.com|~panel.rightflow.com|~propelmedia.com|~publisuites.com|~qubeslate.com|~ad-maven.com
 /advertiserwidget.
 /advertises/*
 /advertising-$image,domain=~abramarketing.com|~advertising-direct.com|~advertising-excellence.com|~advertising-factory.de|~advertising-stands.com.ua|~advertising.amazon.com|~deals-italy.com|~microsoft.com|~outbrain.com|~yellowimages.com

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -329,6 +329,7 @@ gptoday.net###gptoday_ros_echo_leaderboard-billboard
 gptoday.net###gptoday_ros_echo_rectangle-halfpage
 proboards.com###gravity-stories-1
 spellcheck.net###grmrl_one
+apotelyt.com###heDoCon
 girlswithmuscle.com###hb-banner-outer
 streamingrant.com###hb-strip
 cadenaazul.com,lapoderosa.com###hcAdd


### PR DESCRIPTION
1 - EasyList rule blocks image icons
`/advertisers/*$domain=~ads.pinterest.com|~datalift360.com|~home.tapjoy.com|~panel.rightflow.com|~propelmedia.com|~publisuites.com|~qubeslate.com`

<img width="1364" alt="images" src="https://user-images.githubusercontent.com/57706597/168633562-8ccadf2b-eb72-42bc-a5a9-dd90d2a82de0.png">

2 - EasyList rules hide widget under **Multiple Ad Formats**
```
##.widget-ads
##.ad-push
##.ad-btn
##.ad-banner
##.ad-full
##.ad-img
```
<img width="1176" alt="widget" src="https://user-images.githubusercontent.com/57706597/168633594-4cad6084-956f-4f1a-a99b-c9fcd98ba79e.png">

