### PR TITLE
A: widget.golfscape.com

### DIFF
--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -361,6 +361,7 @@
 ||widget.breakingburner.com^$third-party
 ||widget.clipix.com^$third-party
 ||widget.gleamjs.io^$script,third-party,domain=~gleam.io
+||widget.golfscape.com^$third-party
 ||widget.justwatch.com^
 ||widget.pico.tools^$third-party
 ||widget.trustpilot.com^$third-party


### PR DESCRIPTION
Third Party Widgets

Usage example:
https://sport360.com/article/golf/international-golf/44669/hsbc-extend-abu-dhabi-golf-championship-sponsorship-and-continue-asia
https://www.novostiphuketa.com/v-patonge-nachinaetsya-tretiy-turnir-iz-serii-igr-s-myachom-15138.php

<details>
<summary>Screenshot:</summary>

![a](https://user-images.githubusercontent.com/104679776/168833660-5e7e3467-be1f-4d57-b362-e29021b09774.jpg)
</details>