### PR TITLE
P: https://www.bloomberg.com/news/articles/2022-05-18/thousands-shown…

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -24,7 +24,7 @@
 @@||ads.rubiconproject.com/prebid/$script,domain=everydayhealth.com
 @@||ads.viralize.tv/player/$third-party,xmlhttprequest,domain=quotidiano.net
 @@||ads1.atpclick.com/atpClick.aspx?$image,script,domain=jobnet.co.il|jobs-israel.com
-@@||adsafeprotected.com/iasPET.$script,domain=reuters.com
+@@||adsafeprotected.com/iasPET.$script,domain=bloomberg.com|reuters.com
 @@||adsafeprotected.com/vans-adapter-google-ima.js$script,domain=gamingbible.co.uk|ladbible.com|reuters.com
 @@||adsales.snidigital.com/*/ads-config.min.js$script
 @@||adserve.atedra.com/js/$script,domain=repeatmyvids.com


### PR DESCRIPTION
…-being-herded-into-covid-quarantine-in-china?srnd=premium-asia
Video doesn't work. I wonder if these can be blocked without breakage:
```
||bwbx.io/s3/javelin/public/javelin/js/foundation/LeaderboardAd/$domain=bloomberg.com
||bwbx.io/s3/javelin/public/javelin/js/foundation/OverlayAd/$domain=bloomberg.com
||bwbx.io/s3/javelin/public/javelin/js/foundation/SuperburstAd/$domain=bloomberg.com
```
plus for EP `||bwbx.io/s3/javelin/public/hub/js/abba_variants/$script,domain=bloomberg.co.jp|bloomberg.com` as we already have `||bwbx.io/s3/javelin/public/hub/js/abba/$script,domain=bloomberg.co.jp|bloomberg.com`