### PR TITLE
P: Channel Messenger Event Tracker

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -719,9 +719,9 @@
 ! Korean
 ||ad-log.dable.io^
 ||aem-collector.daumkakao.io^
-||api.channel.io/front/v5/channels/1/events
 ||auction.co.kr/ad/log.js
 ||auction.co.kr/montelena.js
+||channel.io/front/v5/channels/1/events
 ||chosun.com/hitlog/
 ||count.munhwa.com^
 ||daumcdn.net^*/awsa.js

--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -719,6 +719,7 @@
 ! Korean
 ||ad-log.dable.io^
 ||aem-collector.daumkakao.io^
+||api.channel.io/front/v5/channels/1/events
 ||auction.co.kr/ad/log.js
 ||auction.co.kr/montelena.js
 ||chosun.com/hitlog/


### PR DESCRIPTION
This commit prevents channel.io from getting event data.
It doesn't break the original functionality.

URL: api.channel.io/front/v5/channels/1/events

Sample form data:
name=PageView&property=%7B%22title%22%3A%22%EA%B3%A0%EA%B0%9D%20%ED%9A%8D%EB%93%9D%20%EB%A9%94%EC%8B%A0%EC%A0%80%20-%20%EC%B1%84%EB%84%90%ED%86%A1%22%2C%22url%22%3A%22https%3A%2F%2Fchannel.io%2Fko%22%2C%22page%22%3A%22https%3A%2F%2Fchannel.io%2Fko%22%2C%22referrer%22%3A%22%22%7D&sessionJWT=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzZXMiLCJrZXkiOiIxLTYyODUxNDU5ZjAxNGMzNDE1YmQ3IiwiaWF0IjoxNjUyOTk4MTcyLCJleHAiOjE2NTU1OTAxNzJ9.k8cqBVw0A9E-CUJq43Mi11TRh_bDUK37cgdWvGto_LE

Sample URLs:
https://channel.io/en
https://channel.io/ko