### PR TITLE
A: https://www.caravaning.de/zubehoer/dachzelt-dometic-trt-120-e/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -36,7 +36,9 @@
 @@||lzstatic.com^*/gdpr/consentHandler/google_analytics.js$domain=ladenzeile.de
 @@||lzstatic.com^*/gdpr/consentHandler/optimizely.js$domain=ladenzeile.de
 @@||online.mps-gba.de/praeludium/ams.js?$domain=auto-motor-und-sport.de
-@@||online.mps-gba.de/praeludium_src/fix_addons/noJump.js$domain=auto-motor-und-sport.de
+@@||online.mps-gba.de/praeludium/carav*.js?$domain=caravaning.de
+@@||online.mps-gba.de/praeludium_src/addons/query*.js$domain=caravaning.de
+@@||online.mps-gba.de/praeludium_src/fix_addons/noJump.js$domain=auto-motor-und-sport.de|caravaning.de
 @@||optimizely.com^$script,domain=kabeleins.de|prosieben.de|prosiebenmaxx.de|ran.de|sat1.de|sixx.de
 @@||orginio.de/api/analytics/$~third-party,xmlhttprequest
 @@||rtl.de^*/videotracking.min.js$domain=rtl.de


### PR DESCRIPTION
Hi @Khrin I've noticed now that even after removing **metatag** rule from EasyListGermany: https://github.com/easylist/easylistgermany/commit/08c458b and EasyPrivacy: https://github.com/easylist/easylist/commit/b14ee9e video frame is still blocked by EasyPrivacy rule: `||mps-gba.de^$third-party` 

Sample URL: https://www.caravaning.de/zubehoer/dachzelt-dometic-trt-120-e/ 

<img width="1334" alt="cr1" src="https://user-images.githubusercontent.com/57706597/169517867-e104becb-0b45-41ac-9277-da1f3f3b226d.png">

<img width="1331" alt="cr2" src="https://user-images.githubusercontent.com/57706597/169517878-5ae272ce-0ca2-48e9-b89d-79f121f1356f.png">