### PR TITLE
A: Hide item on respawnfirst.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1098,6 +1098,7 @@ news12.com##.banner-sidebar-area
 vedantu.com##.banner-text
 news12.com,pwinsider.com,usahealthcareguide.com##.banner-top
 wpneon.com##.banner-week
+respawnfirst.com###post-consent-ui
 depositfiles.com,depositfiles.org,dfiles.eu,dfiles.ru##.banner1
 gsprating.com##.banner2
 novinite.com##.banner300x250


### PR DESCRIPTION

<img width="1225" alt="Screenshot 2022-05-24 at 12 52 57" src="https://user-images.githubusercontent.com/45878727/170019384-7589fee0-2218-40e4-898f-536282da3964.png">


VPN to US, EL + ABP
Go to https://respawnfirst.com/best-amd-rx-6950-xt-graphics-cards/
There is small element on the left ([id="post-consent-ui"]). It is unclickable and covers the content.