### PR TITLE
A: lielahdenapteekki.fi (generic cookie banner hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -6428,6 +6428,7 @@
 ###pricacy_popup
 ###pricepirates-cookie-accept
 ###prihvacamKolacice
+###primus-cc
 ###privacy-advise
 ###privacy-alert
 ###privacy-alert-blur


### PR DESCRIPTION
https://www.lielahdenapteekki.fi/

Other sites use as well:
https://www.nerdydata.com/reports/primus-cc/2e50a905-57ff-415d-8baa-4e41e7d6cf26
https://publicwww.com/websites/%22primus-cc%22/