### PR TITLE
M: move to easylist_cookie

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2219,7 +2219,6 @@ qrobe.it##.qad
 revolution935.com##.qt-sponsor
 modernghana.com##.quikr_banner
 surfline.com##.quiver-google-dfp
-abetterrouteplanner.com##.r-145dblm.r-nc4a30
 tgstat.com##.r1-aors
 decoist.com##.r300
 periscopepost.com##.r72890

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1145,6 +1145,7 @@ sdrplugins.com##.px_-h-auto.px_-z-index-10000
 decrypt.co##.py-3.max-w-full
 picarto.tv##.qHsVk
 support.sia.tech##.r-l13dpy
+abetterrouteplanner.com##.r-145dblm.r-nc4a30
 niceareas.co.uk##.rayAlertBox
 blacklimba.com##.recommendation-modal__backdrop
 hazlitt.net##.region-masthead-inner


### PR DESCRIPTION
Filter added on commit https://github.com/easylist/easylist/commit/7e4c3b7 hides the cookie consent on https://abetterrouteplanner.com/
suggesting to move filter to EL cookie instead.

<img width="1329" alt="83nd" src="https://user-images.githubusercontent.com/57706597/170712738-dd809d4a-e4b4-4666-8ada-4918f4bb1bd4.png">
