### PR TITLE
A: puuilo.fi (notification hide, uBO)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -4,6 +4,8 @@ news18.com##+js(acis, serviceworker.register)
 shrinkzzy.link##+js(acis, firebase.initializeApp)
 ! International
 rd.fi##.nivoSlider:remove()
+puuilo.fi##.cf-container-wrapper
+puuilo.fi##body:style(overflow: auto !important)
 ! autoevolution.com
 autoevolution.com###notif_asker_div
 autoevolution.com##body,html:style(height: auto !important; overflow: auto !important)


### PR DESCRIPTION
https://www.puuilo.fi/farmari-aitaverkko-80cm-x-20m

![kuva](https://user-images.githubusercontent.com/17256841/170826560-e1d2fc6d-65e2-4c23-9182-87c38b45de53.png)

Translation of the title:

"Answer the survey and win a € 100 gift card to Puuilo!"

Depending what filter settings you have, it might look like this as well:

![kuva](https://user-images.githubusercontent.com/17256841/170826794-d6cd2fbd-fe62-46d6-a48a-8a30f1e3e7fa.png)

When the page is refreshed, that notification goes away. You'll have to use incognito mode or clear the cache to see it again.