### PR TITLE
P: https://ipinfo.io/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -2841,7 +2841,7 @@
 /adtaily_
 /adtaobao.
 /adTargeting.$domain=~adtargeting.com
-/adtech.$~script,domain=~adtech.co.uk|~adtech.io|~adtech.md
+/adtech.$~script,domain=~adtech.co.uk|~adtech.io|~adtech.md|~ipinfo.io
 /adtech/*
 /adtech;
 /adtech_$domain=~adtech.co.uk


### PR DESCRIPTION
`/adtech.$~script,domain=~adtech.co.uk|~adtech.io|~adtech.md` blocks one of the image gif labeled as `Advertising Technology` on https://ipinfo.io/

Search for: `Create reliable use cases in whatever industry you choose`
Blocked image: https://ipinfo.io/static/images/use-cases/adtech.jpg

<img width="1167" alt="adT2" src="https://user-images.githubusercontent.com/57706597/171022672-6dc233b2-ccdb-44b5-8a2d-e17b2ea05286.png">

<img width="1163" alt="adT1" src="https://user-images.githubusercontent.com/57706597/171022683-52149cf4-17e7-45df-98ca-ede96295e031.png">

