### PR TITLE
Placeholder on pixwox.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -986,6 +986,8 @@ venea.net##.ag_line
 nexusmods.com##.agroup
 pixwox.com##.ah-box-i-w
 pixwox.com##.ah-box-n-w
+pixwox.com##.tce-box-i-w
+pixwox.com##.tce-box-n-w
 surfwap.com##.ahblock2
 journeybytes.com,techpp.com##.ai-attributes
 onlineradious.com##.ai-placement


### PR DESCRIPTION
Two ad placeholders on pixwox.com are hiding the majority of the content. 
<img width="1314" alt="Screenshot 2022-05-31 at 11 06 19" src="https://user-images.githubusercontent.com/45878727/171137586-aac3360e-8bb0-4e2d-a1fa-9da96a00d61e.png">

