### PR TITLE
M: https://www.apotelyt.com/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -346,7 +346,6 @@ girlswithmuscle.com###hb-banner-outer
 streamingrant.com###hb-strip
 cadenaazul.com,lapoderosa.com###hcAdd
 castanet.net###hdad
-apotelyt.com###heDoCon
 flashgot.net###head a[target="_blаnk"]
 inventorspot.com,mothering.com,wordfind.com,yokogames.com###header
 aeroexpo.online,agriexpo.online,directindustry.com,fonearena.com,frontlinesoffreedom.com,stakingrewards.com,winemag.com###header-banner
@@ -781,7 +780,6 @@ santacruzsentinel.com###weeklybar2
 webfail.com###wf-d-300x250
 theregister.com###whitepapers
 itnews.com.au###whitepapers-container
-apotelyt.com###wiDoCon
 gomapper.com###wideSkyScraper
 tribunnews.com###wideskyscraper
 wallpapersmania.com###wm_cpa
@@ -3052,6 +3050,8 @@ hqq.tv##a[title="Free money easy"]
 facebook.com,facebookcorewwwi.onion##article[data-ft*="\"ei\":\""]
 greatist.com##aside
 dictionary.com,thesaurus.com##aside[id$="728x90"]
+apotelyt.com##aside[id^="hedoApp"]
+apotelyt.com##aside[id^="widoApp"]
 psycom.net##center > .vh-quiz-qborder
 osbot.org##custom > a[href]
 readonepiece.com##div > b


### PR DESCRIPTION
Hide sticky ads on https://www.apotelyt.com/


I've made the following changes:
**1 - Removed** 
`apotelyt.com###heDoCon` (https://github.com/easylist/easylist/commit/816284c) and `apotelyt.com###wiDoCon` (https://github.com/easylist/easylist/commit/607c897) as they no longer hide these sticky ads.

**2 - Added** instead:
`apotelyt.com##aside[id^="hedoApp"]`
`apotelyt.com##aside[id^="widoApp"]`

<img width="1379" alt="429r" src="https://user-images.githubusercontent.com/57706597/171161572-d6b3ac76-be26-4137-ae8e-37a30795c444.png">