### PR TITLE
M: Fixes https://www.techrepublic.com/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1834,8 +1834,6 @@ india.com##.iwplhdbanner-wrap
 psypost.org##.jeg_midbar
 romania-insider.com##.job-item
 johncodeos.com##.johnc-widget
-techrepublic.com##.jotform-top-story-of-the-day
-techrepublic.com##.jotform-twenty-pro-tips
 marinelink.com,maritimejobs.com,maritimepropulsion.com,yachtingjournal.com##.jq-banner
 demonslayermanga.com,readjujutsukaisen.com##.js-a-container
 ultimate-guitar.com##.js-ab-regular

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -598,6 +598,7 @@ braindecoder.com##.join-widget
 thedodo.com##.join-widget-container
 authoritynutrition.com##.joinus
 plough.com##.jotform-feedback-link
+techrepublic.com##.jotform-top-story-of-the-day
 techrepublic.com##.jotform-twenty-pro-tips
 wired.com##.journey-template--in-content
 newatlas.com##.jqmOverlay


### PR DESCRIPTION
Reference [commit](https://github.com/easylist/easylist/commit/2910858)

**Fixes:** 
1 - Delete `techrepublic.com##.jotform-twenty-pro-tips` since is already on **fanboy-addon/fanboy_newsletter_specific_hide.txt**

2 - Move `techrepublic.com##.jotform-top-story-of-the-day` to **fanboy-addon/fanboy_newsletter_specific_hide.txt** since it hides Top Story of the Day newsletter.

<img width="1317" alt="techrepublic" src="https://user-images.githubusercontent.com/57706597/172348459-1587163c-7986-4b98-a085-6ab7846e0411.png">
