### PR TITLE
M: Fixes https://bossip.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -777,7 +777,6 @@ my.juno.com###usWorldTile
 macworld.co.uk###vTXbybUFn
 nutritioninsight.com###verticlblks
 filmibeat.com,goodreturns.in,mykhel.com,oneindia.com###verticleLinks
-bossip.com###video-expanded
 forums.tomsguide.com###video_ad
 gumtree.com###vipBanner
 playstationtrophies.org,xboxachievements.com###vnt-lb-a
@@ -1642,6 +1641,8 @@ sciencenews.org##.from-nature-index__wrapper___2E2Z9
 tripstodiscover.com##.fs-dynamic
 tripstodiscover.com##.fs-dynamic__label
 alphr.com##.fs-pushdown-sticky
+bossip.com##.fsb-desktop
+bossip.com##.fsb-toggle
 ghacks.net##.ftd-item.home-posts
 lovepanky.com##.full-width.row > .medium-12:first-child
 ptinews.com##.fullstorydivright
@@ -3430,6 +3431,7 @@ gamesradar.com,tomshardware.com,whathifi.com##.jwplayer__widthsetter
 southernliving.com##.karma-sticky-rail
 bestrecipes.com.au,delicious.com.au,taste.com.au##.news-video
 sciencetimes.com##.player
+bossip.com##.player-wrapper-inner
 comicbook.com,popculture.com##.popculture-embed
 kidspot.com.au##.secondary-video
 goal.com##.semantic-player-embed


### PR DESCRIPTION
Reference: https://github.com/easylist/easylist/commit/feca9cb

Sample URL: https://bossip.com/2136035/steve-harvey-lori-michael-b-jordan-split/

1 - Suggest: `bossip.com##.player-wrapper-inner` instead of `bossip.com###video-expanded` as it hides the top title info.
<img width="1108" alt="v24" src="https://user-images.githubusercontent.com/57706597/172360222-19abbef0-fed4-41b6-b6a0-111cb8c1c7de.png">

2 - Suggest:
`bossip.com##.fsb-desktop` to hide the sticky ad overlay
`bossip.com##.fsb-toggle` to hide the close button
<img width="1438" alt="v25" src="https://user-images.githubusercontent.com/57706597/172360421-0115b767-f893-48fc-a0a1-01135b4782ea.png">

