### PR TITLE
M: make it generic

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -6537,6 +6537,7 @@
 ###leadad_2
 ###leader-ad
 ###leader-board-ad
+###leader-companion > a[href]
 ###leaderAd
 ###leaderAdContainer
 ###leaderAdContainerOuter

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -432,7 +432,6 @@ gpsreview.net###lead
 steroid.com###lead_area_opener
 iphonic.tv,kontraband.com,motherproof.com,nutritioncuisine.com,sansabanews.com,thestreet.com###leader
 techrepublic.com###leader-bottom
-1013thebear.com,929wxdc.com,941qzk.com,947welk.com###leader-companion > a[href]
 thepostmillennial.com###leader-mot
 techrepublic.com###leader-plus-top
 corrosionpedia.com,firstnationsvoice.com,pistonheads.com###leaderBoard


### PR DESCRIPTION
Make rule generic since **incentrev ads** are showing on more domains:
Rule originally added on [commit](https://github.com/easylist/easylist/commit/c735eb1)

https://bigdawgfm.com/
https://cumberlandsmagic.com/
https://panhandlenewsnetwork.com/
https://sky1065.com/
https://todays975.com/
https://tristateswolf.com/
https://wajr.com/
https://wchsnetwork.com/
https://wdnefm.com/
https://wfby.com/
https://wjls.com/
https://wjlsam.com/
https://wkkwfm.com/
http://wkmznews.com/
http://www.wky930am.com/
https://wvaq.com/
https://v100.fm/
https://929wxdc.com/
https://941qzk.com/
https://947welk.com/
https://995wdzn.com/
https://961kws.com/
https://987thebeat.com/
**https://1013thebear.com/**


Related open PR: https://github.com/easylist/easylist/pull/12254/commits/724743c3579ae3f2e642c69e6b44a2afacef1be4 -  Duplicate rules: `wkmznews.com##a[href^="https://wvrc.incentrev.com/clarksburg/deals"]`

<img width="1218" alt="incentrev" src="https://user-images.githubusercontent.com/57706597/172865888-585359e4-dfa1-4a0e-82a6-bce4fc296ade.png">
