### PR TITLE
M: make it generic

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -15573,6 +15573,7 @@
 ##.block-boxes-ad
 ##.block-boxes-ga_ad
 ##.block-cdw-google-ads
+##.block-content > a[href^="https://www.sweetdeals.com/"]
 ##.block-deca_advertising
 ##.block-dennis-adsense-afc
 ##.block-dfp

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1216,7 +1216,6 @@ autocar.co.uk##.block-autocar-ads-lazyloaded-mpu2
 autocar.co.uk##.block-autocar-ads-mpu-flexible1
 autocar.co.uk##.block-autocar-ads-mpu-flexible2
 autocar.co.uk##.block-autocar-ads-mpu1
-92kqrs.com,93x.com##.block-content > a[href^="https://www.sweetdeals.com/minneapolis/deals"]
 stuff.tv##.block-hcm-external-blocks
 mondoweiss.net##.block-head-c
 newsweek.com##.block-ibtmedia-dfp


### PR DESCRIPTION
Make rule generic since **sweetdeals banner ads** are showing on more domains:
Rule originally added on [commit](https://github.com/easylist/easylist/commit/1fe42dc)

Related open PRs: https://github.com/easylist/easylist/pull/12253/commits/e0e9fa3c122ad7f0b538b32d8313e6de64ea31f0
and https://github.com/easylist/easylist/pull/12239/commits/583c16fba9a43e3e4b41d5caa980acadb50ad059


https://www.gospel900.com/
https://www.magic1069.com/
https://www.rock103rocks.com/
https://www.q1031fm.com/
https://www.92kqrs.com/
https://www.92profm.com/
https://929wxdc.com/
http://93x.com/
http://949kcmo.com/
https://www.975wabd.com/
https://www.981thephantom.com/
https://www.love105fm.com/
