### PR TITLE
Update easyprivacy_trackingservers.txt

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -764,7 +764,6 @@
 ||cookieless-data.com^$third-party
 ||cooladata.com^$third-party
 ||copperegg.com^$third-party
-||coralogix.com^$third-party
 ||core-cen-54.com^$third-party
 ||coremetrics.com^$third-party
 ||coremotives.com^$third-party


### PR DESCRIPTION
coralogix.com is not a tracking company - we're a systems observability company, we don't have a user tracking product