### PR TITLE
`clinch.co` (tracking)

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -973,6 +973,7 @@
 ||tredir.go.com^
 ||tripadvisor.com/data/2.0/rum
 ||trivago.com/tracking/
+||trk.clinch.co^
 ||trx3.famousfix.com^
 ||ts.delfi.lt^
 ||tspmagic.tumblr.com^


### PR DESCRIPTION
Was found on `united.com` airline website after ticket purchase