### PR TITLE
A: cumulus and gasbuddy banner ads

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -472,6 +472,7 @@ dispatchtribunal.com,thelincolnianonline.com###mb-bar
 active.com###med_rec_bottom
 active.com###med_rec_top
 wakingtimes.com###media_image-2
+wbap.com###media_image-3
 palestinechronicle.com###media_image-4
 mostlyblogging.com###media_image-5
 linuxbabe.com###media_image-6

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -38,6 +38,9 @@ calculatorsoup.com###RightSidebar
 soapcalc.net###SidebarLeft
 daringfireball.net###SidebarMartini
 soapcalc.net###SidebarRight
+newcountry963.com,wbap.com,995thewolf.com###simpleimage-3
+hot933hits.com,newcountry963.com,995thewolf.com###simpleimage-4
+hot933hits.com###simpleimage-5
 imcdb.org###SiteLifeSupport
 roblox.com###Skyscraper-Abp-Left
 roblox.com###Skyscraper-Abp-Right


### PR DESCRIPTION
Banner ads on the following domains:
https://www.newcountry963.com/
https://www.wbap.com/
https://www.995thewolf.com/  
https://www.hot933hits.com/

Look for: 
https://www.gasbuddy.com/gasprices/texas/dallas
And https://www.cumulusmedia.com/careers/

<img width="1365" alt="995w" src="https://user-images.githubusercontent.com/57706597/173788720-1381543e-fdf7-4d93-98e8-e409392eb2cf.png">

I did not add only `.widget_simpleimage` because it would hide the banner below the main gallery: `CLICK HERE FOR COVID-19 VACCINATION LOCATIONS & INFORMATION`
