### PR TITLE
P: https://www.buzzfeed.com/jp/ryosukekamba/lisa4?ref=hpsplash

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -24042,7 +24042,6 @@
 ##a[onmousedown^="this.href='https://paid.outbrain.com/network/redir?"][target="_blank"]
 ##a[onmousedown^="this.href='https://paid.outbrain.com/network/redir?"][target="_blank"] + .ob_source
 ##a[target="_blank"][onmousedown="this.href^='http://paid.outbrain.com/network/redir?"]
-##section[class^="recirclist_recircList__"]
 ! Taboola
 ###block-boxes-taboola
 ###component-taboola-below-article-feed


### PR DESCRIPTION
Noticed that filter: `##section[class^="recirclist_recircList__"]` added on [commit](https://github.com/easylist/easylist/commit/6bd03eb) blocks the section called **もっと読む** below Outbrain widget (with ABP disabled) on https://www.buzzfeed.com/jp/ryosukekamba/lisa4?ref=hpsplash

Removed the rule as it could be affecting other sites as well but please let me know if an exception for this particular domain would be better.

Steps to reproduce: 
ABP Lists:  ABP filters + EasyList
VPN location: Japan and US

<img width="1207" alt="bzf1" src="https://user-images.githubusercontent.com/57706597/173844455-b3331b3e-7111-425d-84db-2b3b77275769.png">


