### PR TITLE
A: Hotwire widget

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -237,6 +237,7 @@
 ||hostsearch.com/creative/
 ||hotstar.com^*/midroll?
 ||hotstar.com^*/preroll?
+||hotwire-widget.dailywire.com/widget/js/$script,third-party
 ||howtogeek.com/emv2/
 ||howtogermany.com/images/bnr-
 ||hubgifs.info/adsusd/


### PR DESCRIPTION
Hide Hotwire/dailywire widget on the following domains:

https://www.kaok.com/
https://www.kboi.com/
https://www.kcmotalkradio.com/
https://www.kkoh.com/
https://www.klif.com/
https://www.kmjnow.com/
https://www.kvor.com/
https://www.pensacolasjet.com/
**https://www.wbap.com/**
https://www.wgow.com/
https://www.wmal.com/
https://www.wxbm.com/
https://www.xtrasports1300.com/

<img width="982" alt="dww" src="https://user-images.githubusercontent.com/57706597/174303219-54a062ab-edaa-4987-8c12-b7b4ba7c1a13.png">
