### PR TITLE
P: https://news24online.com/news/world/peace-talk-between-ttp-pakistani-govt-concludes-kabul-be9c87ba/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1365,6 +1365,7 @@ thefastmode.com##.channel_small
 kaotic.com##.chaturbate
 sevenforums.com##.chill
 stackoverflow.com##.clc-cp-lb
+news24online.com##.clearfix.db_shw_mb_blk
 businessinsider.in##.clmb_eoa
 kissanime.com.ru##.close_ad_button
 brmangas.com##.closebf
@@ -1522,7 +1523,6 @@ smartprix.com##.dadow-box
 webuser.co.uk##.dart-tag
 sportshub.stream##.db783ekndd812sdz-ads
 foobar2000.org##.db_link
-news24online.com##.db_shw_mb_blk
 startups.co.uk##.dc-leaderboard
 dailycaller.com##.dc-sticky
 ohiostatebuckeyes.com##.dcad


### PR DESCRIPTION
Rule: `news24online.com##.db_shw_mb_blk ` meant to hide ad labels also hides the website footer.
Sample URL: https://news24online.com/news/world/peace-talk-between-ttp-pakistani-govt-concludes-kabul-be9c87ba/

Rule added on commit: https://github.com/easylist/easylist/commit/26bd9bd
Reference: https://github.com/easylist/easylist/commit/2a39117

<img width="1307" alt="n24_a" src="https://user-images.githubusercontent.com/57706597/174564506-b91a4e1b-e36d-4a15-8cda-d9ea8173fd9a.png">

