### PR TITLE
M: block eacdn.com family

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -3060,6 +3060,7 @@
 ||camiocw.com^
 ||camisagrieko.com^
 ||cammpaign.com^
+||campaigns.williamhill.com^
 ||campjupiterjul.com^
 ||camplacecash.com^
 ||campongprecant.com^
@@ -6717,6 +6718,7 @@
 ||gmads.net^
 ||gme-trking.com^
 ||gmediarelati.biz^
+||gml-grp.com^
 ||gmnzaneslia.com^
 ||gmyze.com^
 ||gmzdaily.com^
@@ -15365,6 +15367,7 @@
 ||tracepath.cc^
 ||tracespore.com^
 ||track-victoriadates.com^
+||track.10bet.com^
 ||track4ref.com^
 ||trackad2.com^
 ||trackapi.net^

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5648,6 +5648,7 @@
 /rsads/*
 /rsc_ad_
 /rss/ads/*
+/S.ashx?btag
 /s_ad.aspx?
 /sadasds.js
 /safead/*


### PR DESCRIPTION
`gml-grp.com` e.g. `https://vovoteca.com`
`campaigns.williamhill.com` e.g. `https://forthegamblers.com` Note: `williamhill.com` can not be blocked
`track.10bet.com` e.g. `https://www.profittipsters.com` Note: `10bet.com` can not be blocked