### PR TITLE
A: https://genshin-impact-map.appsample.com/

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -19049,6 +19049,8 @@
 ##.manual-ad
 ##.map-ad
 ##.mapAdvertising
+##.MapLayout_BottomAd
+##.MapLayout_BottomMobiAd
 ##.map_google_ad
 ##.map_media_banner_ad
 ##.mapped-ad


### PR DESCRIPTION
Hide leftover video ad overlay.
Video ad is blocked by `||nitropay.com^$third-party` added on commit: https://github.com/easylist/easylist/commit/9f27e28

<img width="1164" alt="gns" src="https://user-images.githubusercontent.com/57706597/175519598-dbcc704f-01ef-412c-87ea-567e945688a7.png">

