### PR TITLE
P: https://wevpn.com/billing/order.php

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -37,4 +37,5 @@
 @@||serving-sys.com/Serving/adServer.bs?$popup,domain=spaargids.be
 @@||vk.com/ads?$popup,domain=vk.com
 @@||www.google.*/search?q=*&oq=*&aqs=chrome.*&sourceid=chrome&$popup,third-party
+@@||wevpn.postaffiliatepro.com/scripts/$popup
 @@||youtube.com/ads/preferences/$popup


### PR DESCRIPTION
EasyList rule: `||postaffiliatepro.com^$popup,third-party` prevents **wevpn.com** links from opening on third-parties.

Sample URL 1 - https://www.vpncompare.co.uk/wevpn-review/ 
click on `Visit WeVPN` buttons
blocked link: https://wevpn.com/billing/order.php?aid=twstdfngrs
<img width="1355" alt="vpncompare" src="https://user-images.githubusercontent.com/57706597/175563811-74e21e2e-d5c2-4785-9d44-93c037ed797a.png">


Sample URL 2 - https://www.youtube.com/watch?v=2AUfYIbuz50
video description > click on https://www.wevpn.com/aff/techlore
blocked link: https://wevpn.com/billing/order.php?aid=techlore
<img width="968" alt="yt" src="https://user-images.githubusercontent.com/57706597/175563823-2b95f058-8c6c-4815-90db-731bac7c9996.png">

