### PR TITLE
M: Fixes

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -645,8 +645,7 @@ scotsman.com###sidebarMPU1
 scotsman.com###sidebarMPU2
 ubergizmo.com###sidebar_card_spon
 opendocument.xml.org,trucknetuk.com###sidebarright
-995thewolf.com,newcountry963.com,wbap.com###simpleimage-3
-995thewolf.com,hot933hits.com,newcountry963.com###simpleimage-4
+995thewolf.com,newcountry963.com###simpleimage-3
 hot933hits.com###simpleimage-5
 inoreader.com###sinner_container
 webkinznewz.ganzworld.com###site-description
@@ -2842,7 +2841,7 @@ bestlifeonline.com##.widget_gm_karmaadunit_widget
 extremetech.com##.widget_gptwidget
 faroutmagazine.co.uk##.widget_grv_mpu_widget
 theiphoneappreview.com##.widget_links
-101thefox.net,949kcmo.com,appleworld.today,closerweekly.com,deshdoaba.com,foreverconscious.com,intouchweekly.com,kkfm.com,lifeandstylemag.com,magic1069.com,mensjournal.com,patriotfetch.com,pctechmag.com,rok.guide,rsbnetwork.com,therebelrocks.com,thescore1260.com,washingtonmonthly.com,wbnq.com,wbwn.com,wgow.com,wgowam.com,wjbc.com,wlevradio.com##.widget_media_image
+appleworld.today,closerweekly.com,deshdoaba.com,foreverconscious.com,intouchweekly.com,kkfm.com,lifeandstylemag.com,mensjournal.com,patriotfetch.com,pctechmag.com,rok.guide,rsbnetwork.com,washingtonmonthly.com,wbnq.com,wbwn.com,wgow.com,wgowam.com,wjbc.com,wlevradio.com##.widget_media_image
 nypost.com##.widget_nypost_dfp_ad_widget
 dailynewsegypt.com##.widget_rotatingbanners
 twistedsifter.com##.widget_sifter_ad_bigbox_widget
@@ -3020,6 +3019,7 @@ seganerds.com##[href^="https://www.casinonic.com/"]
 thelibertydaily.com##[href^="https://www.dismecoins.com/"]
 elitepvpers.com##[href^="https://www.elitepvpers.com/123/"]
 seganerds.com##[href^="https://www.ewinracing.com/"]
+magic1069.com##a[href^="https://www.fetchahouse.com/"]
 copytechnet.com##[href^="https://www.idrive.com/"]
 unknowncheats.me##[href^="https://www.iwantcheats.net/"]
 gamecopyworld.com,gamecopyworld.eu##[href^="https://www.kinguin.net/"]
@@ -3145,6 +3145,7 @@ etherscan.io##a[href^="https://goto.etherscan.com/"]
 forkast.news##a[href^="https://h5.whalefin.com/landing2/"]
 disasterscans.com##a[href^="https://martialscanssoulland.onelink.me/"]
 emalm.com##a[href^="https://offer.alibaba.com/"]
+957thevibe.com,101thefox.net##a[href^="https://parisicoffee.com/"]
 qwant.com##a[href^="https://qwa.qwant.com/ck.php"]
 richardvigilantebooks.com##a[href^="https://rebrand.ly/"]
 disasterscans.com##a[href^="https://recall-email.onelink.me/"]


### PR DESCRIPTION
1 - Remove some domains from EL rules: `##.widget_media_image` | `simpleimage-3` and `simpleimage-4` because the hide **cumulus** banner which is actually a self-promo (see attached that cumulus name is also present on the website footer).

2 - Added below hiding rules for the leftover banner ads.
`magic1069.com##a[href^="https://www.fetchahouse.com/"]`
`957thevibe.com,101thefox.net##a[href^="https://parisicoffee.com/"]`

<img width="1033" alt="cm1" src="https://user-images.githubusercontent.com/57706597/175622877-17d12aa7-aaba-4425-ab60-d89804fa3adb.png">
<img width="1131" alt="cm2" src="https://user-images.githubusercontent.com/57706597/175622931-3d958df6-e7f2-471a-8f0e-52e2567155ac.png">
