### PR TITLE
A: https://digg.com/

### DIFF
--- a/easylist/easylist_specific_hide_abp.txt
+++ b/easylist/easylist_specific_hide_abp.txt
@@ -1,5 +1,6 @@
 ! Advanced element hiding rules for Adblock Plus
 bleachernation.com#?#.code-block:-abp-has(span:-abp-contains(ADVERTISEMENT))
+digg.com#?#article.fp-vertical-story:-abp-has(a[href="/channel/digg-pick"])
 digg.com#?#article.fp-vertical-story:-abp-has(a[href="/channel/promotion"])
 digg.com#?#article.fp-vertical-story:-abp-has(div:-abp-contains(SPONSORED))
 digg.com#?#.tracking-widest:-abp-contains(Sponsored)


### PR DESCRIPTION
Unlabelled sponsored ad on https://digg.com/

Element is not labelled as **Sponsored** on the home page but once you click on it you will see the label `WITH LARQ | SPONSORED` 
Link: https://digg.com/larq/link/larq-filter-purevis-microplastics-GtLNeNxEeR?utm_source=digg and has
<img width="1234" alt="sdg1" src="https://user-images.githubusercontent.com/57706597/176198368-e3cbd7f5-1248-4bf8-b205-922474df7268.png">

<img width="1015" alt="sdg2" src="https://user-images.githubusercontent.com/57706597/176198385-9d2c9677-ccb7-47b1-a732-e4ccb2d7be4b.png">
