### PR TITLE
P: www.webmd.com

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -16764,7 +16764,6 @@
 ##.dfp-interstitial
 ##.dfp-leaderboard
 ##.dfp-leaderboard-container
-##.dfp-native
 ##.dfp-panel
 ##.dfp-plugin-advert
 ##.dfp-slot

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2063,6 +2063,7 @@ autoevolution.com##.modeladmid
 finextra.com##.module--sponsor
 webmd.com##.module-f-hs
 pcworld.idg.com.au##.module-rhs-brandpost
+webmd.com##.module-top-picks
 thisismoney.co.uk##.mol-fe-vouchercodes-puff
 dailymail.co.uk##.mol-fe-vouchercodes-redesign
 monsoonjournal.com##.mom-e3lanat-wrap

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1052,6 +1052,7 @@
 ||webengage.sky.com^$xmlhttprequest
 ||weblog.flyasiana.com^
 ||weblog.strawberrynet.com^
+||webmd.com/pixel/
 ||webmd.com/static/v/c?
 ||wellsfargo.com/AIDO/
 ||wellsfargo.com/tracking/


### PR DESCRIPTION
`##.dfp-native` hides contents on top page, replaced by `webmd.com##.module-top-picks` to hide placeholder on articles. `||webmd.com/pixel/` removed by https://github.com/easylist/easylist/commit/8aebd443facdbf8e2f396fcc34cdd6f1e340fd16 is still in use in articles.