### PR TITLE
M: Update

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -23799,6 +23799,7 @@
 ##a[href^="https://www.sheetmusicplus.com/?aff_id="]
 ##a[href^="https://www.spyoff.com/"]
 ##a[href^="https://www.sugarinstant.com/?partner_id="]
+##a[href^="https://www.sweetdeals.com"]
 ##a[href^="https://www.travelzoo.com/oascampaignclick/"]
 ##a[href^="https://www.vfreecams.com/in/?track="]
 ##a[href^="https://www.what-sexdating.com/"]

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3582,7 +3582,6 @@ macworld.co.uk##.videoContainer
 consequence.net##.video_container
 consequence.net##.wasp-video-player
 wlevradio.com##a[href^="https://omny.fm/shows/just-start-the-conversation"]
-wlevradio.com,wncv.com,wskz.com,wxbm.com,wzpl.com,xtrasports1300.com##a[href^="https://www.sweetdeals.com"]
 firstforwomen.com##div[class^="article-content__www_ex_co_video_player_"]
 ! Google https://forums.lanik.us/viewtopic.php?f=62&t=45153
 ##.section-subheader > .section-hotel-prices-header


### PR DESCRIPTION
Suggesting to make rule generic to hide sweetdeals menu link.

Besides: **wlevradio.com, wncv.com, wskz.com, wxbm.com, wzpl.com, xtrasports1300.com** below domains also have the sweetdeals menu link.

https://www.92kqrs.com/
https://www.92profm.com/
https://www.93x.com/
https://www.949radiojondeek.com/
https://www.957kpur.com/
https://www.95x.com/
https://www.96kzel.com/
https://www.975wabd.com/
https://www.979nashfm.com/
https://www.985kissfm.net/
https://www.997wpro.com/
https://www.bxr.com/
https://www.catcountry941.com/
https://www.catcountry96.com/
https://www.cbssportsharrisburg.com/
https://www.classy100.com/
https://www.gospel900.com/
https://www.coast973.com/
https://www.hot1025.net/
https://www.hot1033.com/
https://www.hot1063.com/
https://www.hot1067fm.com/
https://www.indysmix.com/
https://www.k929fm.com/
https://www.katm.com/
https://www.katt.com/
https://www.kboi.com/
https://www.kbull93.com/
https://www.khop.com/
https://www.kizn.com/
https://www.kkfm.com/
https://www.kkgb.com/
https://www.kyis.com/
https://www.lite105.com/
https://www.love105fm.com/
https://www.magic1069.com/
https://www.nashfm100.com/
https://www.nashfm1065.com/
https://www.power923.com/
https://www.rock103rocks.com/
https://www.thescore1260.com/
https://www.thesportsanimal.com/
https://www.warm98.com/
https://www.wbnq.com/
https://www.wbwn.com/
https://www.wedg.com/
https://www.wgowam.com/
https://www.wgrr.com/
https://www.wild1049hd.com/
https://www.wjbc.com/ 
http://www.wky930am.com/

<img width="1111" alt="sdb" src="https://user-images.githubusercontent.com/57706597/176493690-b3496a95-ec99-4d37-a604-ba05a9a8c172.png">




