### PR TITLE
Add a.hcaptcha.com analytics host

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -9,6 +9,7 @@
 ||99widgets.com/counters/
 ||9w2zed1szg.execute-api.us-east-1.amazonaws.com^
 ||a.getflowbox.com^
+||a.hcaptcha.com^
 ||a.mobify.com^
 ||a2z.com/sping?
 ||aan.amazon.com^$third-party


### PR DESCRIPTION
Example URL: `https://www.hcaptcha.com`
Example analytics request (simplified):
```
POST /api/event

{"n":"pageview","u":"https://www.hcaptcha.com/","d":null,"r":null,"w":1337}
```