### PR TITLE
A: https://mamasuncut.com/dale-earnhardt-jr-s-wife-speaks-out/

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -24106,6 +24106,7 @@
 ###content > #right > .dose > .dosesingle
 ###header + #content > #left > #rlblock_left
 ! PubExchange
+###pubexchange_below_content
 ##.pubexchange_module .pe-external
 ! Outbrain
 ###adv_outbrain_SB_1_sidebar

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -613,7 +613,7 @@
 ||vms-players.minutemediaservices.com^$script,third-party
 ||voqally.com/hub/app/
 ||vplayer.newseveryday.com^
-||widgets.outbrain.com^$domain=cnn.com
+||widgets.outbrain.com^$domain=cnn.com|mamasuncut.com
 ||www-idm.com/wp-content/uploads/2022/02/bitcoin.png
 ||zype.com^$third-party,domain=bossip.com|hiphopwired.com|madamenoire.com
 ! streamplay


### PR DESCRIPTION
Block outbrain and pubexchange widget label

Looks like rules: `##.pubexchange_module .pe-external` and `##.ob-p.ob-dynamic-rec-container` are not enough to hide the widget labels.

<img width="1293" alt="ob_o" src="https://user-images.githubusercontent.com/57706597/176731130-6b1d1888-839f-430e-b95f-cf998dad8d92.png">
