### PR TITLE
M: Update

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1499,7 +1499,6 @@ eviemagazine.com##.css-9n98hk
 eviemagazine.com##.css-ipk9pc
 eviemagazine.com##.css-re7z9l
 healthline.com##.css-rjh5b
-instacart.com##.css-uf7278
 healthline.com##.css-umsscj
 izismile.com##.css-widget-item-wrap
 comparitech.com##.ct_popup_modal


### PR DESCRIPTION
Class name has changed from `data-sp-badge` to `data-spp-badge`
and class `##.css-uf7278` is no longer avalaible

Reference commit: https://github.com/easylist/easylist/pull/12441/files

<img width="1240" alt="ic" src="https://user-images.githubusercontent.com/57706597/176865870-90565f57-8333-4a81-8e1b-b6dbba1689b0.png">

