### PR TITLE
A: maaseuduntulevaisuus.fi (specific for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -230,7 +230,7 @@ europa.eu###cookie-consent-banner
 analog.com###cookie-consent-container.modal
 iseic.cz,epag.de,steelprofi.lv,polygon.pt,sportslegend.us,tcbc.us###cookie-law-info-bar
 chelseafc.com,kabum.com.br,fundacaolacaixa.pt,discord.com,attica-group.gr,uefa.com,coca-cola.se,coca-cola.be,coca-cola.no,cocacolanederland.nl,cocacolaep.com,pocketbook.de,cnn.com,blaklader.se,klimatechniker.net,eternit.co.uk,autocar.co.uk,cbre.fi,rexel.com,bab.la,wella.ru,geizhals.de,tripsavvy.com###onetrust-banner-sdk
-nhl.com,chelseafc.com,kabum.com.br,fundacaolacaixa.pt,discord.com,attica-group.gr,uefa.com,coca-cola.se,coca-cola.be,coca-cola.no,cocacolanederland.nl,cocacolaep.com,pocketbook.de,cnn.com,blaklader.se,klimatechniker.net,eternit.co.uk,autocar.co.uk,cbre.fi,rexel.com,bab.la,wella.ru,geizhals.de,tripsavvy.com###onetrust-consent-sdk
+maaseuduntulevaisuus.fi,nhl.com,chelseafc.com,kabum.com.br,fundacaolacaixa.pt,discord.com,attica-group.gr,uefa.com,coca-cola.se,coca-cola.be,coca-cola.no,cocacolanederland.nl,cocacolaep.com,pocketbook.de,cnn.com,blaklader.se,klimatechniker.net,eternit.co.uk,autocar.co.uk,cbre.fi,rexel.com,bab.la,wella.ru,geizhals.de,tripsavvy.com###onetrust-consent-sdk
 patient.info###cookie-policy
 patient.info###cookie-policy-overlay
 ideait.ru###cookie_notification


### PR DESCRIPTION
Added a specific cookie hiding filter for uBO, because the generic filter for this site is too slow on uBO (the dialog window quickly appears and then disappears). Specific filter works perfectly.

https://www.maaseuduntulevaisuus.fi/