### PR TITLE
P: tietoevry.com (scrolling not working, uBO fix)

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_uBO.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_uBO.txt
@@ -117,3 +117,5 @@ yesmagazine.org##.fajardo-campaign
 yesmagazine.org##body:style(overflow: auto !important; position: initial !important;)
 ! thebfd.co.nz (newsletter)
 thebfd.co.nz##body:style(overflow: auto !important; position: initial !important;)
+! tietoevry.com
+tietoevry.com##body:style(overflow: auto !important)


### PR DESCRIPTION
https://www.tietoevry.com/fi/toimialat/sosiaali-ja-terveydenhuolto/terveydenhuolto/perusterveydenhuolto-ja-erikoissairaanhoito/

After scrolling the page a while and waiting 30 secs, scrolling will be locked. It's because of a newsletter dialog (which is hidden by FA already).