### PR TITLE
A: foreca.fi / telsu.fi + others (cookie script block)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -72,6 +72,7 @@
 ||browser-consent-front.coco.s-cloud.fi/js/$script
 ||cdn.gravito.net/cmp/$script
 ||cmp.tori.fi^
+||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|foreca.fi|ilmainensanakirja.fi|suomi24.fi|telsu.fi|testeri.fi
 ||hsy.fi^*/hsycookie.js
 ||sanoma.fi^*/sccm-b.js
 ||sanoma.fi^*/sccm-c.js


### PR DESCRIPTION
https://www.auto1.fi/

https://www.blogit.fi/

https://www.foreca.fi/

https://ilmainensanakirja.fi/

https://www.suomi24.fi/viihde

https://www.telsu.fi/

https://www.testeri.fi/

`||cmp.quantcast.com` not safe as a generic, only safe as domain specific.