### PR TITLE
A: foreca.fi (cookie banner block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -75,7 +75,7 @@
 ||windguru.cz/forms/consent.php
 ||yimg.com^*/guce.js
 ! cmp.quantcast.com specifics
-||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|ilmainensanakirja.fi|suomi24.fi|telsu.fi|testeri.fi
+||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|foreca.fi|ilmainensanakirja.fi|suomi24.fi|telsu.fi|testeri.fi
 ! cookielaw specifics
 ||cookielaw.org/opt-out/otCCPAiab.js$domain=rollingstone.com
 ||cookielaw.org/scripttemplates/otsdkstub.js$domain=rollingstone.com


### PR DESCRIPTION
https://www.foreca.fi/

Requesting this entry to be added back. It was removed because it was thought that it causes issues by blocking scrolling. But after investigating this thoroughly, the culprit was Easyprivacy list after all, it was not caused by blocking this cmp script.

Before testing this out, please disable EP list or add this to your filters temporarily:

`@@||survey.userneeds.com^$subdocument,domain=foreca.fi`

Also, the page has to be loaded in incognito mode. Then press F5 and you can reliably test this out. If testing this again after that, close the browser window, open incognito again, load the page and then press F5. Note that only the first page refresh by F5 gives a reliable result.

https://github.com/easylist/easylist/pull/12490#issuecomment-1177795097
https://github.com/easylist/easylist/issues/12507