### PR TITLE
A: ebay.* (cookie banner hide, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -210,7 +210,7 @@ queer.pl##.box-rodo
 imagia.ro##.gdpr-privacy-bar
 enen.eu##.popup-display
 7r6.com###banner-cookie
-de-baystars.doorblog.jp###gdpr-banner
+de-baystars.doorblog.jp,ebay.*###gdpr-banner
 lumiafirmware.com###cookiesdirective
 nvidia.com###cookiePolicy-layer
 aa.com.tr###cookiepolicy


### PR DESCRIPTION
Used with generichide. uBO's internal Unbreak list has this rule:

`@@*$ghide,domain=ebay.*`
