### PR TITLE
M: domain name typo

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -880,7 +880,7 @@ br-automation.com###siwa-cookiebar
 alppimatkat.fi,ecosto.fi,kuntarekry.fi###toast-container
 lehtodigital.fi##.__ld_cookies
 americanairlines.fi,batpower.fi##.alert
-hhk.fi##.animate.mask
+hk.fi##.animate.mask
 bellaffair.com##.cc-overlay
 datakauppa.fi##.cli-modal-backdrop
 valotehdas.fi##.cli-popupbar-overlay


### PR DESCRIPTION
Domain `hhk.fi` is not in use but `hk.fi` is in use.