### PR TITLE
P: teams.microsoft.com (scrolling blocked)

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_uBO.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_uBO.txt
@@ -95,9 +95,9 @@ theblock.co##body.overflow-hidden:style(overflow: auto !important;)
 ! cryptobriefing.com (newsletter scroll fix)
 cryptobriefing.com##body,html:style(overflow: auto !important; position: initial !important;)
 ! https://www.microsoft.com/en-gb/d/surface-laptop-4/946627fb12t1?activetab=pivot:overviewtab (popup)
-microsoft.com###modalsRenderedAfterPageLoad
-microsoft.com##.modal-backdrop
-microsoft.com##body,html:style(overflow: auto !important; position: initial !important;)
+www.microsoft.com###modalsRenderedAfterPageLoad
+www.microsoft.com##.modal-backdrop
+www.microsoft.com##body,html:style(overflow: auto !important; position: initial !important;)
 ! readtangle.com (newsletter intro)
 readtangle.com##.intro
 readtangle.com##body,html:style(overflow: auto !important; position: initial !important;)


### PR DESCRIPTION
Made this rule more domain specific. It prevents scrolling if used on Teams Web (teams.microsoft.com).

Better to have www-prefix in order to avoid other potential issues with Microsoft web apps.
