### PR TITLE
P: kolumbus.fi (visitor counter broken)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -188,6 +188,7 @@
 @@||images.sprinklecontent.com^$image,domain=como.fi|episodi.fi|fum.fi|inferno.fi|kaaoszine.fi|rumba.fi|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/frosmo.easy.js$domain=elisa.fi|kauppahalli24.fi
 @@||inpref.s3.amazonaws.com/sites/$script,domain=kauppahalli24.fi
+@@||kolumbus.fi/cgi-bin/counter.cgi$image,~third-party
 @@||leiki.com/focus/$script,domain=anna.fi|como.fi|episodi.fi|fum.fi|inferno.fi|kaksplus.fi|rumba.fi|seura.fi|soundi.fi|tilt.fi
 @@||lekane.net/lekane/dialogue-tracking.js?$script
 @@||mpsnare.iesnare.com/snare.js$script,domain=power.fi


### PR DESCRIPTION
Original issue report: https://github.com/NanoMeow/QuickReports/issues/1059

Sample site:
http://www.kolumbus.fi/leif.snellman/

Kolumbus.fi is a platform that hosts homepages. So this issue concerns anyone using kolumbus.fi as a homepage.