### PR TITLE
M: Update

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -23991,7 +23991,6 @@
 ##div[data-id-advertdfpconf]
 ##div[data-insertion]
 ##div[data-mediatype="advertising"]
-##div[data-module="cookie-manager-dialog"]
 ##div[data-mpu1]
 ##div[data-native-ad]
 ##div[data-native_ad]


### PR DESCRIPTION
Rule added to EL on commit https://github.com/easylist/easylist/commit/ea6c655 hides the cookie consent dialog on https://aok-erleben.de/

Rule is already in `easylist_cookie_general_hide.txt` 

<img width="997" alt="c3i" src="https://user-images.githubusercontent.com/57706597/180727846-7ce56664-38e1-4aac-a49f-ed6235a46634.png">

