### PR TITLE
A: foreca.com (generic survey block, annoyance)

### DIFF
--- a/fanboy-addon/fanboy_notifications_thirdparty.txt
+++ b/fanboy-addon/fanboy_notifications_thirdparty.txt
@@ -6,6 +6,7 @@
 ||centrnotify.com^$third-party
 ||checke.biz^$third-party
 ||checkpost.club^$third-party
+||confirmit.com^$third-party
 ||conforama-push.com^$third-party
 ||contentsitesrv.com/js/push/$third-party
 ||digipush.io^$third-party


### PR DESCRIPTION
Referring to this message: https://github.com/easylist/easylist/issues/12507#issuecomment-1179505506

EP should not block a survey (it's fixed in EP now), but Annoyance list should block it. Blocking the survey this way won't cause issues.