### PR TITLE
A: myabandonware.com (cookie dialog hide for uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -166,6 +166,7 @@ joingoodcompany.nl##.popup-backdrop
 gamersgate.com##.popup-gdpr.popup
 ionos.fr,ionos.de##.privacy-consent--backdrop
 ionos.fr,ionos.de##.privacy-consent--modal
+myabandonware.com##.qc-cmp2-container
 elisa.fi##.react-navi-ea-cookie-disclaimer
 openfoodnetwork.org.uk##.reveal-modal-bg
 pronovabkk.de,reidl.de##.reveal-overlay


### PR DESCRIPTION
https://www.myabandonware.com/

Needed, because uBO's Unreak list whitelists the script.

![kuva](https://user-images.githubusercontent.com/17256841/181353809-1c3ae92d-a63d-45b9-9225-fb759e2a7c33.png)
