### PR TITLE
A: eurheilu.org (cookie script)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -75,7 +75,7 @@
 ||windguru.cz/forms/consent.php
 ||yimg.com^*/guce.js
 ! cmp.quantcast.com specifics
-||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|foreca.fi|ilmainensanakirja.fi|irc-galleria.net|nylon.com|suomi24.fi|telsu.fi|testeri.fi|tilannehuone.fi|timeanddate.com
+||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|eurheilu.org|foreca.fi|ilmainensanakirja.fi|irc-galleria.net|nylon.com|suomi24.fi|telsu.fi|testeri.fi|tilannehuone.fi|timeanddate.com
 ! cookielaw specifics
 ||cookielaw.org/opt-out/otCCPAiab.js$domain=rollingstone.com
 ||cookielaw.org/scripttemplates/otsdkstub.js$domain=rollingstone.com


### PR DESCRIPTION
`https://eurheilu.org/oleksandr-s1mple-kostyliev-oli-kolnin-mvp-katso-jaatavat-suoritukset/`

![image](https://user-images.githubusercontent.com/84513173/181361281-2e8840dc-61a0-4a4a-80c0-433da9d35602.png)
