### PR TITLE
Add Roblox phone verification warnings

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -3314,6 +3314,8 @@ firecold.com##table[style="margin: 30px 0 0 0"]
 briefing.com##table[style="vertical-align: top; text-align: left;\a \9             background-color: White; width: 100%; padding: 10px;"]
 osnews.com##table[width="285"]
 finestdaily.com##table[width="642"]
+roblox.com##.account-field-phone-add-msg.text-error
+roblox.com###phoneVerificationUpsell-container
 ! Self-promo Ads
 thurrott.com###announcment-banner
 wikihow.com###article_courses_banner

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -102,3 +102,5 @@ reddit.com##.upsell_banner
 weatherbug.com##[href="/appdownload"]
 m.timesofindia.com##[href^="https://p23eh.app.goo.gl/"]
 barandbench.com##div[class^="header-two-m__download-links_"]
+roblox.com##.account-field-phone-add-msg.text-error
+roblox.com###phoneVerificationUpsell-container


### PR DESCRIPTION
They are obtrusive, annoying and very distracting. If you havent for example verified your phone, on the home page there is an alert that takes 30% of the webpage asking you to verify your phone number.
Also verifying your phone has no benefits, it's grants you access to nothing. Even worse they make your account vulnerable to SIM jacking, which is a very common attack to compromise high value accounts (commonly referred as "beaming" in the account compromising/hacking community).

And even on top of that, when theres a data breach regarding account info, phone numbers are always included in it. They are not encrypted in any way, all past and current phone numberes are stored forever, and anyone who gains access to the OKTA (the account managment service they use) panel can look at everybodys phone numbers. Even worse, half of the sites users are under 13. It's probably not good if more kids get doxxed because their phone numbers got leaked.
As such I believe these should be added to the privacy filters as it's such a bad privacy risk too.