### PR TITLE
A: / M: ign.com (cookie dialog block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -77,8 +77,7 @@
 ||yimg.com^*/guce.js
 ! cmp.quantcast.com specifics
 ||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|eurheilu.org|foreca.fi|ilmainensanakirja.fi|irc-galleria.net|nylon.com|suomi24.fi|telsu.fi|testeri.fi|tilannehuone.fi|timeanddate.com
-! cookielaw specifics
-||cookielaw.org/opt-out/otCCPAiab.js$domain=rollingstone.com
-||cookielaw.org/scripttemplates/otsdkstub.js$domain=rollingstone.com
+! cookielaw.org specifics
+||cookielaw.org^$domain=ign.com|rollingstone.com
 ! fundingchoicesmessages (consents)
 ||fundingchoicesmessages.google.com^


### PR DESCRIPTION
When blocking `cookielaw.org` related requests, wouldn't it be better to block the whole domain instead of one or two scripts?

`cookielaw.org` gives partially different requests for different sites:

rollingstone.com
![kuva](https://user-images.githubusercontent.com/17256841/181578043-8a8ad2de-9a43-4e12-ad77-e801c6f5ab1d.png)

ign.com
![kuva](https://user-images.githubusercontent.com/17256841/181578158-c2946975-e100-41e4-8e4d-96dda810d6ae.png)

`ign.com` doesn't have `otCCPAiab.js` or `otsdkstub.js`.

Videos work fine on `ign.com` so it's safe to block. Sample link: https://www.ign.com/articles/backbone-one-playstation-controller-announced