### PR TITLE
A: elisa.fi (+others) (cookie dialog block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -78,6 +78,6 @@
 ! cmp.quantcast.com specifics
 ||cmp.quantcast.com^$script,domain=auto1.fi|blogit.fi|eurheilu.org|foreca.fi|ilmainensanakirja.fi|irc-galleria.net|nylon.com|suomi24.fi|telsu.fi|testeri.fi|tilannehuone.fi|timeanddate.com
 ! cookielaw.org specifics
-||cookielaw.org^$domain=ign.com|rollingstone.com
+||cookielaw.org^$domain=elisa.fi|elisaviihde.fi|ign.com|maaseuduntulevaisuus.fi|rollingstone.com
 ! fundingchoicesmessages (consents)
 ||fundingchoicesmessages.google.com^

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -167,7 +167,6 @@ gamersgate.com##.popup-gdpr.popup
 ionos.fr,ionos.de##.privacy-consent--backdrop
 ionos.fr,ionos.de##.privacy-consent--modal
 myabandonware.com##.qc-cmp2-container
-elisa.fi##.react-navi-ea-cookie-disclaimer
 openfoodnetwork.org.uk##.reveal-modal-bg
 pronovabkk.de,reidl.de##.reveal-overlay
 depop.com##.sc-ezzafa


### PR DESCRIPTION
https://elisa.fi/

https://elisaviihde.fi/

https://www.maaseuduntulevaisuus.fi/uutiset/84084a42-be65-48ff-a5ed-6eba564b6083 (this is the only news website, this link contains a video, that works fine if consent script is blocked.