### PR TITLE
Remove audioeye non-analytics endpoints

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -254,8 +254,6 @@
 ||audience.newscgp.com^
 ||audienceapi.newsdiscover.com.au^$third-party
 ||audienceinsights.net^$third-party
-||audioeye.com/ae.js
-||audioeye.com/frame/cookieStorage.html
 ||audit.303br.net^
 ||audit.median.hu^
 ||aurora-d3.herokuapp.com^
@@ -2188,9 +2186,7 @@
 ||wp.com/i/mu.gif$image
 ||wp.com/wp-content/js/bilmur.min.js
 ||wren.condenastdigital.com^
-||ws.audioeye.com^
 ||ws.sharethis.com^$script
-||wsmcdn.audioeye.com^
 ||wtbevents.pricespider.com^
 ||x.babe.today^
 ||x.disq.us^


### PR DESCRIPTION
The two domains and specific JS bootstrapping code provide accessibility/WCAG compliance services to websites.  These javascript files contain the code necessary to provide these services.  These domains only serve static files necessary to do this work.

The cookiestorage html page supports websites that prefer to leave these services opt-in for users. 

air and analytics domains (already found in this list, left intact) handle all of the reporting and analysis.