### PR TITLE
Fix: remove false positive

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -17841,7 +17841,6 @@
 ||ctrip.com^$third-party
 ||ctrmanager.com^$third-party
 ||ctxtfl.com^$third-party
-||cubics.com^$third-party
 ||cuelinks.com^$third-party
 ||currentlyobsessed.me^$third-party
 ||cybmas.com^$third-party


### PR DESCRIPTION
This was previously moved from ad-network to third party, however, it is not an ad network in any way. Requests get blocked on Chrome Ad block & Ad block plus, for example requesting to our cdn. This site should not be classified as ad network, neither directly, nor from third parties, since it is none. Kindly remove from the ad servers list completely. Thank you!

@Khrin @ryanbr 
Ref: https://github.com/easylist/easylist/issues/11950