### PR TITLE
A: ask.fm (forced app download / login page)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -16,3 +16,6 @@ nu.nl##body,html:style(height: auto !important; overflow: auto !important)
 phonearena.com###pa-survey-modal
 phonearena.com##.pa-modal-backdrop
 phonearena.com##body:style(overflow: auto !important; position: initial !important;)
+! ask.fm (forced app download / login page) https://github.com/easylist/easylist/pull/12751
+ask.fm##.lightbox_overlay
+ask.fm##body:style(overflow: auto !important)


### PR DESCRIPTION
When viewing a page in `ask.fm`, it shows a dialog that asks to either login or download their mobile app.

Sample page:

https://ask.fm/paivankysymyksia

![kuva](https://user-images.githubusercontent.com/17256841/181915211-f5fe230c-3d2e-4253-b978-2015bb809d94.png)
