### PR TITLE
Include uBO specific lists for FA subsections

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1,4 +1,6 @@
 ! fanboy_newsletter_specific_hide.txt
+! Include uBO specific
+!#include fanboy_newsletter_specific_uBO.txt
 e-day.ro,mtlblog.com###CoverPop-cover
 news.yahoo.com###Daily-Ticket-newsletter-promo-8U
 nextshark.com###FbridgeSGWidget

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -1,3 +1,5 @@
+! Include uBO specific
+!#include fanboy_notifications_specific_uBO.txt
 tbsnews.net###___tbspushdiv
 deepl.com###dl_app_banner_popup
 kizi.com###kizi-popover-dialog


### PR DESCRIPTION
When subscribing to FA subsections separately (`newsletter`, `notifications`), their uBO specific fixes won't load automatically. Added a fix for that.