### PR TITLE
M: nytimes.com (removing cookie banner whitelistings)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -201,7 +201,6 @@ seguro.elespanol.com#@#.didomi-notice-banner
 ouest-france.fr,strefabiznesu.pl#@#.didomi-screen-xlarge
 myrobotcenter.at,myrobotcenter.co.uk,myrobotcenter.de#@#.ec-gtm-cookie-directive
 aida64.com,nvidia.com,vchaspik.ua#@#.eu-cookie-compliance-popup-open
-nytimes.com#@#.expanded.gdpr
 verivox.de#@#.gdpr-button
 washingtonpost.com#@#.gdpr-consent
 washingtonpost.com#@#.gdpr-consent-container
@@ -255,7 +254,7 @@ autohaus24.de#@#div.cookie-banner
 dovoba.de#@#div.cookie-consent
 calameo.com#@#div.cookie-content
 altenberg-dom.de#@#div.cookieHolder
-booking.pobeda.aero,coastalliving.com,commercialtrucktrader.com,cookinglight.com,efarma.com,esselunga.it,essence.com,ew.com,food.com,fortune.com,gct.com,golf.com,health.com,hellogiggles.com,instyle.com,metallica.com,mirjan24.pl,my.games,nytimes.com,ochotnicy.waw.pl,people.com,realsimple.com,ria.com,si.com,slovnaftludom.sk,smooth-on.com,southernliving.com,time.com,touchnote.com,travelandleisure.com,zulily.com#@#div.gdpr
+booking.pobeda.aero,coastalliving.com,commercialtrucktrader.com,cookinglight.com,efarma.com,esselunga.it,essence.com,ew.com,food.com,fortune.com,gct.com,golf.com,health.com,hellogiggles.com,instyle.com,metallica.com,mirjan24.pl,my.games,ochotnicy.waw.pl,people.com,realsimple.com,ria.com,si.com,slovnaftludom.sk,smooth-on.com,southernliving.com,time.com,touchnote.com,travelandleisure.com,zulily.com#@#div.gdpr
 skfbearingselect.com#@#div.privacy-notice
 what3words.com#@#div[class^="CookieNotice"]
 etsy.com#@#div[data-gdpr-consent-prompt]


### PR DESCRIPTION
I think these rules aren't necessary anymore. I don't see any issues in blocking the banner.

Video works: https://www.nytimes.com/video/us/100000008467540/kentucky-flood-death-toll.html?playlistId=video/latest-video

And embedded tweet appears in the article: https://www.nytimes.com/2022/07/12/technology/twitter-lawsuit-musk-acquisition.html 