### PR TITLE
A: areena.yle.fi (pauserecommendations during a video + sharing button)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -43,6 +43,7 @@ aerzteblatt.de###pushy
 formulatv.com###resetUI
 rd.fi###zone-header-wrapper
 romait.it##.alert
+areena.yle.fi##.Cards__PauseRecommendationsBackground-sc-kzqq5f-22
 ziare.com##.modal-backdrop
 tuttoandroid.net,tuttotech.net##.modal-notifiche
 ziare.com##.modal__wp
@@ -99,6 +100,7 @@ imgur.com,sowetanlive.co.za##.smartbanner
 inquisitr.com##.stay-in-touch
 telegram.org##.tg_try_desktop
 reddit.com##.upsell_banner
+areena.yle.fi##button[aria-label="Jaa ohjelma"]
 weatherbug.com##[href="/appdownload"]
 m.timesofindia.com##[href^="https://p23eh.app.goo.gl/"]
 barandbench.com##div[class^="header-two-m__download-links_"]


### PR DESCRIPTION
When pausing a video on `areena.yle.fi`, it shows a slider of "recommended videos" at the top which clutters the video annoyingly.

Also, there's "Jaa ohjelma" (=Share the program) button. It's not social media share but generic sharing button, that appears when howering a mouse over a video.

Sample: https://areena.yle.fi/1-916098

![kuva](https://user-images.githubusercontent.com/17256841/182002432-0a55155f-0790-4eb2-bc95-cd47289fa5bc.png)
