### PR TITLE
 A: opensubtitles.org (specific ad hide)

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3328,6 +3328,7 @@ kitguru.net##a[id^="href-ad-"]
 tetris.com##a[onclick*="open"]
 himovies.to,home-barista.com,rarpc.co,shtfplan.com,warecracks.com,washingtontimes.com##a[onclick]
 onetransistor.eu##a[onclick][target="_blank"]
+opensubtitles.org##a[target="_blank"][href^="https://www.amazon.com/gp/search"]
 earlygame.com##a[rel*="sponsored"]
 mcrypto.club,themoviesflix.io##a[rel="noopener"]
 unsplash.com##a[rel^="sponsored"][target="_blank"]
@@ -3646,6 +3647,7 @@ planetinsane.com,radiosurvivor.com##text-18
 trademe.co.nz##tm-display-ad
 rarbg.to,rarbgaccess.org,rarbgmirror.com,rarbgmirror.org,rarbgproxy.com,rarbgproxy.org,rarbgunblock.com,rarbgunblocked.org##tr > td + td[style*="height:"]
 titantv.com##tr.gridRow > td > [id] > div:first-child
+opensubtitles.org##tr[style="height:115px;text-align:center;margin:0px;padding:0px;background-color:#DFEBF9;"]
 tripadvisor.at,tripadvisor.be,tripadvisor.ca,tripadvisor.ch,tripadvisor.cl,tripadvisor.cn,tripadvisor.co,tripadvisor.co.id,tripadvisor.co.il,tripadvisor.co.kr,tripadvisor.co.nz,tripadvisor.co.uk,tripadvisor.co.za,tripadvisor.com,tripadvisor.com.ar,tripadvisor.com.au,tripadvisor.com.br,tripadvisor.com.eg,tripadvisor.com.gr,tripadvisor.com.hk,tripadvisor.com.mx,tripadvisor.com.my,tripadvisor.com.pe,tripadvisor.com.ph,tripadvisor.com.sg,tripadvisor.com.tr,tripadvisor.com.tw,tripadvisor.com.ve,tripadvisor.com.vn,tripadvisor.de,tripadvisor.dk,tripadvisor.es,tripadvisor.fr,tripadvisor.ie,tripadvisor.in,tripadvisor.it,tripadvisor.jp,tripadvisor.nl,tripadvisor.pt,tripadvisor.ru,tripadvisor.se#?#.listItem:-abp-has(.sponsored_v2)
 ! Adcompanies
 adspyglass.com##HTML


### PR DESCRIPTION
"Buy at Amazon" link ad.

Sample link: https://www.opensubtitles.org/en/subtitles/5639181/a-nightmare-on-elm-street-5-the-dream-child-en

![kuva](https://user-images.githubusercontent.com/17256841/111205823-54f58380-85d0-11eb-8315-b36ee78aed81.png)

Also, on the search page https://www.opensubtitles.org/en/search2/sublanguageid-all/moviename-street, there are ad container remnants:

![kuva](https://user-images.githubusercontent.com/17256841/182002929-432ab5be-3855-48c7-90c4-4030b674d3ab.png)


This is partially a re-open of this old PR: https://github.com/easylist/easylist/pull/7435 - all specific rules concerning `opensubtitles.org` that are currenly in EL, are relevant.

These current rules in EL:
`opensubtitles.org###watch_online`
`opensubtitles.org##div[itemscope=""][itemtype="http://schema.org/Movie"] > fieldset`
Are both active in https://www.opensubtitles.org/en/subtitles/5639181/a-nightmare-on-elm-street-5-the-dream-child-en

This rule:
`opensubtitles.org##.a_1.a.p`
is active on the search page:
https://www.opensubtitles.org/en/search2/sublanguageid-all/moviename-street