### PR TITLE
A: etsy.com (cookie dialog hide, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1261,8 +1261,10 @@ watt.sg##body:style(overflow: auto !important; position: initial !important;)
 ! allfunds.sg
 allfunds.sg##.afb-CookiesDark
 allfunds.sg##body:style(overflow: auto !important; position: initial !important;)
-! etsy.com (scroll only, dialog needs to show.)
+! etsy.com
 etsy.com##body,html:style(overflow: auto !important; position: initial !important;)
+etsy.com###gdpr-single-choice-overlay
+etsy.com##body:style(padding-right: 0 !important)
 ! ing
 ing.jobs##.ui-widget-overlay
 ! dsj.de


### PR DESCRIPTION
In https://github.com/easylist/easylist/tree/master/easylist_cookie there's a warning that hiding the dialog prevents zooming of products.

That depends what element is being hid. Using this rule to hide the dialog, zooming in product images work just fine:
`etsy.com###gdpr-single-choice-overlay`

In addition to that, also this rule is required:
`etsy.com##body:style(padding-right: 0 !important)`

Reason: when opening and closing a product image, the body element shifts to the left a bit. If a product image is opened and closed many times, the body shifts even more to the left. This is caused by the cookie dialog: every time it tries to show itself, it shifts the page to the left. But this rule prevents the shifting.

Sample link to test these rules with:
https://www.etsy.com/fi-en/listing/751174027/55140-cm-wide-light-grey-linen-curtain?sts=1

Everything works fine. Product images open and zooming works. Even a product video plays.