### PR TITLE
P: ampparit.com (feedback button hid by social media list)

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -373,7 +373,7 @@ randstad.es#@#.social-media-container
 randstad.es#@#.social-media-icon
 telepolis.pl#@#.social-media-icons
 randstad.es#@#.social-media-link
-chorus.co.nz#@#.social-media-links
+ampparit.com,chorus.co.nz#@#.social-media-links
 schuermann.eu#@#.social-media-list
 insideover.com#@#.social-menu
 e-gezondheid.be,e-sante.be,e-sante.fr#@#.social-networks

--- a/fanboy-addon/fanboy_social_international.txt
+++ b/fanboy-addon/fanboy_social_international.txt
@@ -448,6 +448,8 @@ mobiili.fi###text-15
 is.fi##.ab-test-article-sharing
 mobiili.fi##.mobsome_icons
 forssanlehti.fi#?#.herald-single-sticky:-abp-has(.herald-share)
+ampparit.com##.social-media-links > .sidebox-content
+ampparit.com##.social-media-links > h3[class="sidebox-header"]
 ||rd.fi/sites/default/files/vp-fbssa-banner$image
 !
 !---------- Greek Specific Social Media Elements ----------


### PR DESCRIPTION
https://www.ampparit.com/

On ampparit.com, the social media box is hid by `##.social-media-links`, but the issue is that the same box also contains the site's feedback button. ("Anna palautetta").

![kuva](https://user-images.githubusercontent.com/17256841/182046522-13bc1ba9-d06d-4b80-82bd-a02d60e35cce.png)


I constructed the social media box hiding differently. I hid everything else but I'll leave the feedback button there. Looks good to me this way.

![kuva](https://user-images.githubusercontent.com/17256841/182046555-3506fd78-bfce-4d33-bd67-10326f9884a7.png)
