### PR TITLE
A: chrome.google.com (switch to Chrome nag)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -37,6 +37,7 @@ gadgets360.com##.web_dialog
 startpage.com##.widget-install-privacy-protect-container
 waze.com##.wz-downloadbar
 reddit.com##.xPromoAppStoreFooter
+chrome.google.com##[role="banner"] > div[class][role="dialog"][aria-labelledby="promo-header"]
 ! International
 hesport.com###notification_pp
 aerzteblatt.de###pushy


### PR DESCRIPTION
When browsing Chrome's addon store on a different browser, they show a nag whether you want to switch to Chrome.

https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm

![kuva](https://user-images.githubusercontent.com/17256841/182190120-3c8425a9-0f4f-433a-a675-686e7011414f.png)
