### PR TITLE
Moved altruja.de from tracking_servers to specific

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -49,6 +49,7 @@
 ||alljapanesepass.com/ascripts/gcu.js
 ||alljapanesepass.com/rstat
 ||als-svc.nytimes.com^
+||altruja.de/js/micro/integration-ga.js
 ||amazon.*/action-impressions/
 ||amazon.*/ajax/counter?
 ||amazon.com/1/events/$domain=~aws.amazon.com

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -17,7 +17,6 @@
 ||adrank24.de^$third-party
 ||adtraxx.de^$third-party
 ||adtriba.com^$third-party
-||altruja.de^$third-party
 ||amunx.de^$third-party
 ||analytics.rechtslupe.org^
 ||andyhoppe.com^$third-party


### PR DESCRIPTION
Removed the blocking of the whole altruja.de domain and added a specific script to specific.txt.
This script contains all "tracking related" code as discussed here: https://forums.lanik.us/viewtopic.php?p=164754-altruja-de#p164754