### PR TITLE
Add word-boundary check for /pages/ads

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -5229,7 +5229,7 @@
 /pagepeel_
 /pagepeelads.
 /pagepeelpro.
-/pages/ads
+/pages/ads.
 /PageTopAD.
 /paidads/*
 /paidlisting/*


### PR DESCRIPTION
We have a website where its resources are getting blocked due to the rule `/pages/ads`.

I would like to add some form of word-boundary checking for this rule. The resource is getting blocked because `/pages/ads` is a substring of `.../pages/adstod`.

Website: [island.is/adstod](https://island.is/adstod)
Resource: `https://island.is/_next/static/chunks/pages/adstod-<some-hash>.js`