### PR TITLE
P: https://www.linuxjournal.com/content/how-use-block-storage-increase-space-your-nextcloud-instance

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1295,7 +1295,6 @@ autocar.co.uk##.block-autocar-ads-lazyloaded-mpu2
 autocar.co.uk##.block-autocar-ads-mpu-flexible1
 autocar.co.uk##.block-autocar-ads-mpu-flexible2
 autocar.co.uk##.block-autocar-ads-mpu1
-linuxjournal.com##.block-block-content
 thescore1260.com##.block-content > a[href*="sweetdealscumulus.com"]
 indysmix.com,wzpl.com##.block-content > a[href^="https://sweetjack.com/local"]
 stuff.tv##.block-hcm-external-blocks
@@ -3253,6 +3252,8 @@ amsterdamnews.com,sundayworld.co.za,universityaffairs.ca##a[href*="/sponsored-co
 biznews.com,burnabynow.com,businessdailyafrica.com,coastreporter.net,financialexpress.com,irishtimes.com,komonews.com,newwestrecord.ca,nsnews.com,prpeak.com,richmond-news.com,seattletimes.com,spokesman.com##a[href*="/sponsored/"]
 isaidubb.net,orutamil.com##a[href*="/ucdownloader.php?"]
 isaidubb.net,orutamil.com##a[href*="/ucmini.php?"]
+linuxjournal.com##a[href*="?utm_source=linux_journal&utm_medium=banner&utm_campaign="]
+linuxjournal.com##a[href*="?utm_source=linux_journal&utm_medium=display&utm_campaign="]
 distrowatch.com##a[href*="3cx.com"]
 97rock.com,wedg.com##a[href*="716jobfair.com"]
 aliexpress.com##a[href*="aliexpress.com/item/"][href*="&aem_p4p_detail="]


### PR DESCRIPTION
Rule: `linuxjournal.com##.block-block-content` added on commit https://github.com/easylist/easylist/commit/a7a4f81 hides part of the website footer on linuxjournal.com.

Another suggestion would be simply: `linuxjournal.com##a[href*="&utm_campaign="]`

<img width="1131" alt="lno" src="https://user-images.githubusercontent.com/57706597/183028627-701e1043-8286-4fa3-acb2-a628e22e6382.png">

<img width="1144" alt="ljn" src="https://user-images.githubusercontent.com/57706597/183028596-2906ef16-9dd0-4ecb-8c97-a83ad98ab39f.png">
