### PR TITLE
P: https://www.galaopublicidade.com/

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -38,6 +38,7 @@ memytutaj.pl#@##top-ad
 soundandvision.com,stereophile.com#@##topbannerad
 gamingcools.com#@#.Adsense
 m.motonet.fi#@#.ProductAd
+galaopublicidade.com#@#.publicidade
 job.inshokuten.com#@#.ad-area
 kincho.co.jp#@#.ad-block
 job.inshokuten.com,sexgr.net#@#.ad-box


### PR DESCRIPTION
EL rule: `##.publicidade` is preventing [galaopublicidade.com](https://www.galaopublicidade.com) from loading.

_Please let me know if it's be better to add the exception to [EL Portuguese](https://easylist-downloads.adblockplus.org/easylistportuguese+easylist.txt) instead._

<img width="1362" alt="gl9" src="https://user-images.githubusercontent.com/57706597/183119917-e9535811-aa94-4bbb-a677-616a03dfc925.png">
