### PR TITLE
A: aamulehti.fi + others (consent dialog hide, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2042,3 +2042,9 @@ autohero.com##body,html:style(overflow: auto !important; position: initial !impo
 ! tallink.com
 tallink.com###cms-web-consent-root
 tallink.com##.cws-modal-open:style(overflow: auto !important; pointer-events: auto !important;)
+! Sanoma Corporation
+aamulehti.fi,etlehti.fi,gloria.fi,hs.fi,hyvaterveys.fi,is.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,kodinkuvalehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,soppa365.fi,suurkeuruu.fi,sydansatakunta.fi,tiede.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi,vauva.fi##html.sp-message-open:style(overflow: auto !important; width: initial !important)
+aamulehti.fi,etlehti.fi,gloria.fi,hs.fi,hyvaterveys.fi,is.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,kodinkuvalehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,soppa365.fi,suurkeuruu.fi,sydansatakunta.fi,tiede.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi,vauva.fi##html.sp-message-open > body:style(position: unset !important; margin-top: 0 !important)
+aamulehti.fi,hs.fi,is.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,suurkeuruu.fi,sydansatakunta.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi##body:not(:has(.embed-cookie-consent-icon)) > div[id^="sp_message_container"]
+etlehti.fi,gloria.fi,hyvaterveys.fi,kodinkuvalehti.fi,soppa365.fi,tiede.fi,vauva.fi##body:not(:has(.consent_required_iframe)) > div[id^="sp_message_container"]
+||cdn.privacy-mgmt.com^*supersaa$xhr,domain=is.fi


### PR DESCRIPTION
All these sites are owned by Sanoma Corporation. On these sites, cookies have to be accepted in order to see embedded content.

This set of filters will unlock the scrolling for each page (via `:style`), and hide the consent dialog only, if the page doesn't have any embedded content.

There are two types of sites on this PR: news websites and magazine/forum based.
For news websites, this rule is being used:
`##body:not(:has(.embed-cookie-consent-icon)) > div[id^="sp_message_container"]`

For magazine/forum based:
`##body:not(:has(.consent_required_iframe)) > div[id^="sp_message_container"]`

Note!
This rule should not be used this time:
`##+js(rc, sp-message-open, html, stay)`

Because it suffers from a glitch: even if the consent dialog is hid, it still tries to disable scrolling, leading to a small, horizontal "bounce" effect, which is annoying. User styles have a precedence over site scripts, which is why they work better against scripts.

Some sample links (the upper one doesn't have embedded stuff (dialog will be hid), the lower one does have embedded stuff (dialog won't be hid)):

https://www.aamulehti.fi/tampere/art-2000008989602.html
https://www.aamulehti.fi/kotimaa/art-2000008984691.html

https://www.etlehti.fi/artikkeli/ihmiset/kohta-elakkeelle-nelja-ihmista-kertoo-milta-tuntuu-jattaa-tyotakki-naulaan
https://www.etlehti.fi/artikkeli/vapaa-aika/katso-suomen-vanhin-varielokuva-talta-naytti-helsingin-kauppatori-vuonna-1936

https://www.gloria.fi/artikkeli/sisusta/malli-vilma-bergenheim-ja-huippukiekkoilija-sean-bergenheim-sisustivat
https://www.gloria.fi/artikkeli/huippumallit_musiikkivideoilla_kymmenen_parasta

https://www.hs.fi/ulkomaat/art-2000008989805.html
https://www.hs.fi/urheilu/art-2000008988784.html

https://www.hyvaterveys.fi/artikkeli/mieli/laulaja-laura-voutilainen-teen-sita-mista-innostun-ja-joskus-vauhtia-liikaa
https://www.hyvaterveys.fi/artikkeli/vanhemmuus/kansa-sekosi-aaro-vauvan-kuvasta-teilla-varsin-hyvantuulisen-nakoinen

https://www.is.fi/kotimaa/art-2000008990209.html
https://www.is.fi/politiikka/art-2000008974427.html

https://www.tiede.fi/artikkeli/uutiset/masennuksen-serotoniinihypoteesi-saa-kritiikkia
https://www.tiede.fi/artikkeli/uutiset/halvaantunut-pystyi-kirjoittamaan-ajatuksen-voimalla

https://www.vauva.fi/keskustelu/4596081/ketju/arsyttavin_fiktiivinen_hahmo_ikina
https://www.vauva.fi/comment/42579908#comment-42579908

Edit: Note!
`is.fi` has a separate weather subpage in which the same `:style` that works for others, doesn't work there:
https://www.is.fi/supersaa/

Managed to make a separate blocking filter for that subpage solely:
`||cdn.privacy-mgmt.com^*supersaa$xhr,domain=is.fi`
That weather subpage doesn't have embedded content so it's ok to block GDPR request.