### PR TITLE
M: redundant rule

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -19942,7 +19942,6 @@
 ##.p-ad-block
 ##.p-ad-dfp-banner
 ##.p-ad-dfp-middle-rec
-##.p-ad-feature-pr.p-ad-thumbnail-txt
 ##.p-ad-outbreak
 ##.p-ad-rectangle
 ##.p-ad-thumbnail-txt


### PR DESCRIPTION
Redundant because of `##.p-ad-thumbnail-txt`