### PR TITLE
M: redundant rule

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3301,7 +3301,6 @@
 /amazon_widget.cms
 /ame-dfp/*
 /amp-ad-
-/amp-auto-ads-
 /amp-connatix-
 /amp4ads-
 /anchorad.


### PR DESCRIPTION
Because of:

https://github.com/easylist/easylist/blob/ee23e100c14a7dd419f02f12d4802fcaae46fd07/easylist/easylist_general_block.txt#L209