### PR TITLE
P: tapahtumat.iijokiseutu.fi + more (Fixes popup)

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -52,6 +52,7 @@ dmkt-sp.jp#@#.ad-label
 guloggratis.dk#@#.ad-links
 so-net.ne.jp#@#.ad-notice
 so-net.ne.jp#@#.ad-outside
+tapahtumat.iijokiseutu.fi,tapahtumat.kaleva.fi,tapahtumat.koillissanomat.fi,tapahtumat.lapinkansa.fi,tapahtumat.pyhajokiseutu.fi,tapahtumat.raahenseutu.fi,tapahtumat.rantalakeus.fi,tapahtumat.siikajokilaakso.fi#@#.ad-popup
 hulu.com#@#.ad-root
 wiki.fextralife.com#@#.ad-sidebar
 wegotads.co.za#@#.ad-source


### PR DESCRIPTION
https://tapahtumat.iijokiseutu.fi/fi-FI/page/62c1a9c051cccb6db5d7daf6

`https://tapahtumat.kaleva.fi/`
`https://tapahtumat.koillissanomat.fi/`
`https://tapahtumat.lapinkansa.fi/`
`https://tapahtumat.pyhajokiseutu.fi/`
`https://tapahtumat.raahenseutu.fi/`
`https://tapahtumat.rantalakeus.fi/`
`https://tapahtumat.siikajokilaakso.fi/`


This "MAINOSTA TAPAHTUMAA" button:
![image](https://user-images.githubusercontent.com/84513173/184397505-d57fa1a7-57c6-4305-86aa-06df01f0b73f.png)
should show this popup allowing you to pay to advertise your event:
![image](https://user-images.githubusercontent.com/84513173/184398087-e83e2098-f606-46fd-a279-954e27fca529.png)


but currently EasyList hides it and by clicking it you only get dark overlay and can't do anything after.



