### PR TITLE
A: aarrelehti.fi + others (gdpr block)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -79,6 +79,6 @@
 ! cmp.quantcast.com specifics
 ||cmp.quantcast.com^$script,domain=agoravox.tv|auto1.fi|base64encode.org|blogit.fi|buzz.ie|dagospia.com|eurheilu.org|foreca.fi|gekkonen.net|ilmainensanakirja.fi|irc-galleria.net|kilokalori.net|mamaclever.de|nylon.com|reader.gr|riemurasia.net|suomi24.fi|telsu.fi|testeri.fi|tilannehuone.fi|timeanddate.com
 ! cookielaw.org specifics
-||cookielaw.org^$domain=cdon.fi|elisa.fi|elisaviihde.fi|findit.fi|ign.com|ikea.com|maaseuduntulevaisuus.fi|quora.com|rollingstone.com|suomi24.fi|urbandictionary.com
+||cookielaw.org^$domain=aarrelehti.fi|cdon.fi|elisa.fi|elisaviihde.fi|findit.fi|ign.com|ikea.com|koneviesti.fi|maaseuduntulevaisuus.fi|quora.com|rollingstone.com|suomi24.fi|suomela.fi|urbandictionary.com|viestimedia.fi
 ! fundingchoicesmessages (consents)
 ||fundingchoicesmessages.google.com^


### PR DESCRIPTION
https://www.aarrelehti.fi/
https://www.koneviesti.fi/
https://www.suomela.fi/
https://viestimedia.fi/