### PR TITLE
M: obsolete filter

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -1,5 +1,4 @@
 /messaging.js$domain=computerworld.com|digitalartsonline.co.uk|greenbot.com|itworld.com|macworld.com|networkworld.com|pcwelt.de|pcworld.com|tecchannel.de|techadvisor.co.uk|techadvisor.fr|techhive.com|vkmag.com
-/mms/get_site_data?$domain=bloomberg.com
 /wp-content/blog-plugins/wordads-classes/js/banner.bundle.js
 ||7plus.com.au/js/CookieNotice
 ||agicssecurity.com/Header/ajax/cookie.php


### PR DESCRIPTION
GDPR stuff can't be blocked on `bloomberg.com`, only handled partially through cosmetics.

(I recently made cosmetics for the site: https://github.com/easylist/easylist/pull/12928)