### PR TITLE
A: synonyymit.fi (generic ad server)

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -16380,6 +16380,7 @@
 ||watchingthat.net^
 ||watchtaro.com^
 ||waterproofsparkle.com^
+||watwait.com^
 ||waugique.net^
 ||waust.at^
 ||wauthaik.net^


### PR DESCRIPTION
Sample link: https://www.synonyymit.fi/audienssi

`watwait.com` loads ads:

![kuva](https://user-images.githubusercontent.com/17256841/184675659-e2480604-571a-480b-b114-6bce2a928b3f.png)

Not solely Finnish related:
https://www.nerdydata.com/reports/watwait-com/e76469c6-af15-4af2-8d0a-6bbe57df1f40