### PR TITLE
P: https://m.bilibili.com/dynamic/686058310439272488 (fixes https://g…

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -19,6 +19,7 @@ newsbreak.com##.bottom-10.fixed
 tmz.com##.browser-notifications-prompt
 caixinglobal.com##.caixinAPP
 manutd.com##.custom-popup
+m.bilibili.com##.fe-ui-open-app-btn
 ft.com##.instant-alert-cta
 nidcd.nih.gov##.isf--container
 chicagotribune.com##.met-flyout
@@ -149,16 +150,16 @@ independent.co.uk##.inline-prompt
 trip.com##.install-bottom
 terabox.com##.introduce-sticky-btn
 duckduckgo.com##.js-open-in-app
-m.bilibili.com##.launch-app-btn
 m.gearbest.com##.layui-m-layershade
 gayemagazine.com##.lvMF7
+m.bilibili.com##.m-video2-awaken-btn
 castbox.fm##.main-body-banner > .box
 merckmanuals.com,msdmanuals.com##.marketing-block-wrapper
 usbair.com##.mobile-app
 speedtest.net##.mobile-pretest
 malaysiaairlines.com##.mobileapp
 airtelkenya.com##.modal-content-popup
-m.bilibili.com##.nav-open-app-img
+m.bilibili.com##.mplayer-widescreen-callapp
 mobile.here.com##.newbanner
 france24.com##.o-pwa-ah2s
 linkedin.com##.omnibanner
@@ -202,6 +203,7 @@ weatherbug.com##[href="/appdownload"]
 m.timesofindia.com##[href^="https://p23eh.app.goo.gl/"]
 sammyfans.com##[href^="https://play.google.com/store/apps/"]
 areena.yle.fi##button[aria-label="Jaa ohjelma"]
+m.bilibili.com##div[class*="-openapp"]
 genius.com##div[class*="AndroidBannermobile_"]
 thescore.com##div[class*="GetTheAppModal_"]
 giphy.com##div[class*="OpenInAppContainer-"]


### PR DESCRIPTION
…ithub.com/AdguardTeam/AdguardFilters/issues/127192)
The whole complex site, I only hope these rules to be safe.
`https://m.bilibili.com/dynamic/686058310439272488`, `https://m.bilibili.com/` => `##div[class*="-openapp"]` it covers `##.nav-open-app-img`'s parent so removed.

<details>
<summary>Screenshots</summary>

![bilibili1](https://user-images.githubusercontent.com/58900598/184680969-27573d7e-0703-4609-a56d-c3f8efb629fa.png)

![bilibili2](https://user-images.githubusercontent.com/58900598/184681036-73a5ebf8-a851-4b02-a2a0-3bcb2232220d.png)

![bilibili3](https://user-images.githubusercontent.com/58900598/184681428-3f36740c-33a1-419c-85c9-8e888a97b74a.png)

</details>

`https://m.bilibili.com/video/BV1Yv4y1c7gF` => `m.bilibili.com##.m-video2-awaken-btn` avoided `##.m-video-main-launchapp` as breaks layout (kind of).

<details>
<summary>Screenshot</summary>

![bilibili4](https://user-images.githubusercontent.com/58900598/184681699-bc3acba9-5da8-4ea2-829d-0e1da699f689.png)
</details>

`https://m.bilibili.com/bangumi/play/ep480174` => `##.fe-ui-open-app-btn`

<details>
<summary>Screenshot</summary>

![bilibili5](https://user-images.githubusercontent.com/58900598/184681812-94b47cf9-6dac-4454-a239-ccbd36b296df.png)
</details>

`##.mplayer-widescreen-callapp` is if you choose fullscreen on `https://m.bilibili.com/video/BV1Yv4y1c7gF`.