### PR TITLE
M: remove obsolete filter for vizcloud

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -526,7 +526,6 @@
 ||vidhdthe.online/mavennofile.js
 ||vidstream.pro/A/
 ||vidzstore.com/popembed.php
-||vizcloud.store/E/
 ||vizcloud.xyz/E/aircraftmighty.com/
 ||vk.com/js/cmodules/web/ads_light.$script
 ||vobium.com/images/banners/


### PR DESCRIPTION
ref: https://github.com/AdguardTeam/AdguardFilters/issues/123169

vizcloud changed TLD to .site and thus the rule is anyway obsolete.