### PR TITLE
A: tiktok.com (verify element)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -55,3 +55,6 @@ m.economictimes.com##body,html:style(overflow: auto !important; position: initia
 ! m.yelp.com
 m.yelp.com##.overlay__09f24__ApBaK
 m.yelp.com##body,html:style(overflow: auto !important; position: initial !important;)
+! tiktok.com
+tiktok.com###tiktok-verify-ele
+tiktok.com##body.captcha-disable-scroll:style(overflow: auto !important)


### PR DESCRIPTION
When browsing https://www.tiktok.com/@cnetdotcom?language=en the page a while, it shows a needless verify element. I don't see any good reason for it / it doesn't state it's purpose or reason. When I solve it, clear cookies and open the page again, it appears again. No need to do anything peculiar, just browse the page a short while.

![kuva](https://user-images.githubusercontent.com/17256841/184914003-a7431ee6-1b76-45ec-9db8-ca0d1fbc3721.png)


