### PR TITLE
A: ecoteekki.fi (generic newsletter block)

### DIFF
--- a/fanboy-addon/fanboy_newsletter_thirdparty.txt
+++ b/fanboy-addon/fanboy_newsletter_thirdparty.txt
@@ -2,6 +2,7 @@
 ||api.pico.tools^$third-party
 ||buy-au.piano.io/checkout/template/cacheableShow?*&experienceId=*&widget=template
 ||data.reachplc.com^
+||downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js$script,third-party
 ||joinsubtext.com^$subdocument,third-party
 ||lightboxcdn.com/vendor/$script,third-party
 ||nordiskemedier.dk/remodal/


### PR DESCRIPTION
https://www.ecoteekki.fi/

Mailchimp seems to be a popular newsletter provider. Their script is used very widely:

https://publicwww.com/websites/downloads.mailchimp.com%2Fjs%2Fsignup-forms%2Fpopup%2Funique-methods%2Fembed.js/

I don't feel safe blocking the whole domain so made the rule quite specific. But it will still block widely.