### PR TITLE
A: https://sports.caracoltv.com

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -9369,6 +9369,7 @@
 ##.GoogleDfpAd
 ##.GoogleDfpAd-Content
 ##.GoogleDfpAd-container
+##.GoogleDfpAd-Float
 ##.GoogleDfpAd-wrap
 ##.GoogleDfpAd-wrapper
 ##.GoogleDfpAdModule


### PR DESCRIPTION
Add rule from EasyList Spanish: `bluradio.com,caracoltv.com,shock.co##.GoogleDfpAd-Float` to EasyList  as generic, so it could more sites.

PR to remove the specific filter from EasyList Spanish and avoid redundancy: https://github.com/easylist/easylistspanish/pull/280


Rule hides sticky ads.
Sample URLs:
https://sports.caracoltv.com/
https://gol.caracoltv.com/

<img width="1438" alt="scr" src="https://user-images.githubusercontent.com/57706597/185443897-7c3e0a08-e08b-4d5a-94cc-f637b50c330d.png">

