### PR TITLE
A: elisa.fi (GDPR specific block)

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -73,6 +73,8 @@
 ||browser-consent-front.coco.s-cloud.fi/js/$script
 ||cdn.gravito.net/cmp/$script
 ||cmp.tori.fi^
+||cookielaw.org/scripttemplates/*/assets/*.json$xmlhttprequest,domain=elisa.fi
+||cookielaw.org/scripttemplates/*/assets/otCommonStyles.css$xmlhttprequest,domain=elisa.fi
 ||vaikuttajamedia.fi^*/markuk_evastevaroitus.js
 ||vpd.fi/datalayer/index/cookieContent/$xmlhttprequest,domain=vpd.fi
 !


### PR DESCRIPTION
On `elisa.fi` GDPR script cannot be blocked as it causes content loading issues on this link:

https://elisa.fi/kauppa/puhelinliittymat

But blocking these xmlhttprequests won't cause issues - also blocking them will also prevent the banner from loading.