### PR TITLE
M: / P: Obsoletes + whitelistings (GDPR, Alma Media)

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -31,7 +31,6 @@
 @@||c.evidon.com/sitenotice/evidon-sitenotice-tag.js$script,domain=crunchyroll.com|southpark.de|southparkstudios.nu
 @@||cafedelapaix.fr/assets/plugins/bwp-minify/min/$script,~third-party
 @@||carport-diagnose.de/script/cookieconsent.min.js$~third-party
-@@||cdn.almamedia.fi/almacmp/$script,domain=iltalehti.fi
 @@||cdn.opencmp.net/tcf-v2/cmp-latest.js$script,domain=foraum.de
 @@||cdn.opencmp.net/tcf-v2/cmp-stub-latest.js$script,domain=idowa.de
 @@||ceramtec-group.com^*/cookieconsent.min.js

--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -847,8 +847,6 @@
 ###allowcookieandthirdparty
 ###allowcookiebanner
 ###allowusecookies
-###alma-cookie-consent
-###alma-data-policy-banner
 ###alp-cookie-container
 ###alsb_CNIL_notice
 ###altea-cookiebox-wrapper
@@ -8633,8 +8631,6 @@
 ##.allowed-cookies
 ##.allreadycookie
 ##.alltricks-CnilRibbon
-##.alma-cookie-disclaimer
-##.alma-data-policy-banner
 ##.als-cookie-button
 ##.altamira-gdpr-cookie-consent
 ##.alternative_cookie_layer_background

--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -69,7 +69,7 @@
 ! ---------- Finnish ----------
 !
 ||a-lehdet.fi^*/cmp.js
-||almamedia.fi/almacmp/$script
+||almamedia.fi/almacmp/$script,domain=~arvopaperi.fi|~iltalehti.fi|~mediuutiset.fi|~mikrobitti.fi|~talouselama.fi|~tekniikkatalous.fi|~tivi.fi|~www.kauppalehti.fi|~www.uusisuomi.fi
 ||browser-consent-front.coco.s-cloud.fi/js/$script
 ||cdn.gravito.net/cmp/$script
 ||cmp.tori.fi^

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -84,7 +84,6 @@ tommy.com##div[class*="ReactModal__Overlay--cookie"]
 ylasatakunta.fi##.ag_cookie_banner
 noriel.ro##.agreementMessage
 noriel.ro##.agreementOverlay
-uusisuomi.fi,vuokraovi.com##.alma-data-policy-banner
 snp.nl##.anwbr-cookie-layer
 swatch.com##.b-modal
 swatch.com##.b-modal_overlay

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -1,7 +1,6 @@
 ||acconsento.click^$third-party
 ||admiral.mgr.consensu.org^$third-party
 ||akamaihd.net/cpmt/
-||alma-cmp.almamedia.io^
 ||analytics-consent-manager.azureedge.net^
 ||app.livemarketshoppers.com^$script,third-party
 ||assetlab.io/consent/

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -182,7 +182,7 @@
 @@||frosmo.com/recoApi/$xmlhttprequest,domain=apu.fi|hobbyhall.fi|lily.fi|meillakotona.fi|terve.fi
 @@||google-analytics.com/analytics.js$script,domain=hobbyhall.fi
 @@||google-analytics.com/gtm/js$script,domain=hobbyhall.fi
-@@||googletagmanager.com/gtm.js$script,domain=cdon.fi|como.fi|episodi.fi|fum.fi|hobbyhall.fi|iltalehti.fi|inferno.fi|rumba.fi|soundi.fi|tilt.fi|veho.fi
+@@||googletagmanager.com/gtm.js$script,domain=arvopaperi.fi|cdon.fi|como.fi|episodi.fi|fum.fi|hobbyhall.fi|iltalehti.fi|inferno.fi|mediuutiset.fi|mikrobitti.fi|rumba.fi|soundi.fi|talouselama.fi|tekniikkatalous.fi|tilt.fi|tivi.fi|veho.fi|www.kauppalehti.fi|www.uusisuomi.fi
 @@||high.auriro.net/http/600x400/$image,domain=afterdawn.com|dawn.fi|hardware.fi
 @@||images.sprinklecontent.com^$image,domain=como.fi|episodi.fi|fum.fi|inferno.fi|kaaoszine.fi|rumba.fi|soundi.fi|tilt.fi
 @@||inpref.s3.amazonaws.com/frosmo.easy.js$domain=elisa.fi|kauppahalli24.fi


### PR DESCRIPTION
On Alma Media's news websites, tweets won't work without accepting cookies. So I'm making Alma Media related GDPR blocking rule to exclude their news websites and also remove obsolete cosmetics / block rules. Also googletagmanager has to be whitelisted as well as it prevents GDPR stuff from loading. (Easyprivacy).

I'm later going to make selective blocking rules for these domains (hide GDPR dialog only if there are no embedded content). But making it after this PR is handled. Otherwise it will get too complicated.

Samples:
https://www.iltalehti.fi/digiuutiset/a/d2af6105-d363-47b2-9a21-5a07fcee22ba (already whitelisted, but just mentioning it as it relates to these other sites)

https://www.kauppalehti.fi/uutiset/suomen-kylat-ilahtui-keskustan-edistamasta-kokeilusta-kannustaisi-koulutettuja-nuoria-muuttamaan-tunturikyliin/3a60106f-42bb-4301-9781-ec2564e266cb

https://www.talouselama.fi/uutiset/twitter-julkaisi-uuden-ominaisuuden-nyt-kayttaja-voi-poistaa-itsensa-epamiellyttavista-keskusteluista/8b8bbedf-85d9-416d-b268-4959fde6ca8d

https://www.arvopaperi.fi/uutiset/nain-elon-musk-ja-twitter-valmistautuvat-oikeustaisteluun-kovan-tason-juristit-palkattu-mukaan/fa0396f2-2ed0-4ddc-b3f8-f70f4bf7ad55

https://www.mikrobitti.fi/uutiset/sosiaalinen-media-kohahti-mark-zuckerbergin-metaversumiselfiesta-tahanko-meta-pumppasi-miljardeja/76df6394-448e-4234-b763-d84559b2c106

https://www.mediuutiset.fi/uutiset/yksi-toisensa-jalkeen-palkansaajajarjestot-hylkasivat-sopimusehdotuksen-25-000-hoitajan-lakko-alkaa-perjantaina/72fc6fd7-313a-4a75-ba0d-097984c8bdf8

https://www.tivi.fi/uutiset/venaja-hehkutti-kranaatinheittimella-varustetun-taistelurobotin-kykyja-kiinalaisilta-painava-vastalause/5f498073-8a1b-456c-be36-db1a25346735

https://www.tekniikkatalous.fi/uutiset/venaja-ylistaa-kiinalaisen-tappajarobotin-taitoja-ampuu-ja-kantaa-rahtia-varusteena-jopa-kranaatinheitin-video-kiinalaiset-hermostuivat/70d4dbaa-093c-4864-a7d9-3c91b6fc4897

https://www.uusisuomi.fi/uutiset/twitter-kauppa-elon-muskin-ideologisten-tavoitteiden-pohja-on-hatara/5137a6ff-93cd-4ad6-8bb8-9c98a0ed22b1

Unfortunately, some of these sites are eager to paywall their articles so finding non-paywalled samples wasn't always possible. (I have browser addon that unlocks those articles for me which is why I can see them https://addons.mozilla.org/fi/firefox/addon/bypass-paywalls-clean/)

Alma Media GDPR script can be blocked for other than their news websites. All their sites are listed at the bottom of this this link:
https://www.almamedia.fi/

Samples of non-news pages:
https://www.ampparit.com/
https://www.vuokraovi.com/

Some domains are www.-prefixed in order not to match their subdomains.