### PR TITLE
A: https://www.thejournal.ie/

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -603,6 +603,7 @@
 ||brid.tv^$script,domain=67hailhail.com|deepdaledigest.com|forevergeek.com|geordiebootboys.com|hammers.news|hitc.com|molineux.news|nottinghamforest.news|rangersnews.uk|realitytitbit.com|spin.com|tbrfootball.com|thechelseachronicle.com|thefocus.news|thewrap.com|washingtonexaminer.com
 ||c.jsrdn.com^$script,domain=muscleandfitness.com
 ||cdn.ex.co/player/
+||cdn.thejournal.ie/media/hpto/*.jpg$image,domain=thejournal.ie
 ||channelexco.com/player/$third-party
 ||connatix.com^$third-party
 ||delivery.vidible.tv/jsonp/

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -603,7 +603,7 @@
 ||brid.tv^$script,domain=67hailhail.com|deepdaledigest.com|forevergeek.com|geordiebootboys.com|hammers.news|hitc.com|molineux.news|nottinghamforest.news|rangersnews.uk|realitytitbit.com|spin.com|tbrfootball.com|thechelseachronicle.com|thefocus.news|thewrap.com|washingtonexaminer.com
 ||c.jsrdn.com^$script,domain=muscleandfitness.com
 ||cdn.ex.co/player/
-||cdn.thejournal.ie/media/hpto/*.jpg$image,domain=thejournal.ie
+||cdn.thejournal.ie/media/hpto/$image
 ||channelexco.com/player/$third-party
 ||connatix.com^$third-party
 ||delivery.vidible.tv/jsonp/


### PR DESCRIPTION
Image backgrounds ad on thejournal.ie
 
The links is blocked by EL rule: `||doubleclick.net^$third-party` but image background remains unblocked.

<img width="1373" alt="tjie" src="https://user-images.githubusercontent.com/57706597/185645953-7a2058dc-5ed2-4513-8153-23daf4b04293.png">

