### PR TITLE
A: Confection.io wordpress integration

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5208,6 +5208,7 @@
 /worldwide_analytics/*
 /wp-click-track/*
 /wp-clickmap/*
+/wp-content/plugins/confection/bridge.php
 /wp-content/tracker.
 /wp-counter.php
 /wp-js/analytics.


### PR DESCRIPTION
Blocks Confection.io wordpress integration, that is a server-side tracking/proxy service.

Plugin: https://wordpress.org/plugins/confection/

Seen in the wild at https://alllife.co.za/ that calls https://alllife.co.za/wp-content/plugins/confection/bridge.php
Seen https://www.4lifedirect.pl/ that calls https://www.4lifedirect.pl/wp-content/plugins/confection/bridge.php

Confection.io is already partially blocked at https://github.com/easylist/easylist/blob/79dd21808d4cf2ef04def6501753d017c57dca76/easyprivacy/easyprivacy_specific.txt#L1081