### PR TITLE
A: arvopaperi.fi + others (GDPR dialog hide)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2158,3 +2158,8 @@ etlehti.fi,gloria.fi,hyvaterveys.fi,kodinkuvalehti.fi,soppa365.fi,tiede.fi,vauva
 bloomberg.com##html.sp-message-open:style(width: initial !important)
 bloomberg.com##html.sp-message-open > body:style(position: unset !important; overflow: unset !important; margin-top: 0 !important)
 bloomberg.com##body:not(:has(div[class*="player" i][class*="_container"], #root .datastrip)) > div[id^="sp_message_container"]
+! Alma Media
+arvopaperi.fi,iltalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,www.kauppalehti.fi,www.uusisuomi.fi###alma-cmpv2-container:style(display: none)
+arvopaperi.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,www.kauppalehti.fi,www.uusisuomi.fi##body:has(.article-body p:has-text(Sisältöä ei voitu ladata.Tämä voi johtua selainlaajennuksesta.)) > .alma-cmpv2-container:style(display: block !important)
+iltalehti.fi##body:has(.consents-checker) > .alma-cmpv2-container:style(display: block !important)
+iltalehti.fi##+js(set, jwAlmaCMPLoaded, true)


### PR DESCRIPTION
This is a continuation for this PR: https://github.com/easylist/easylist/pull/12990

This PR hides the GDPR dialog for these domains, but restores it if the article has embedded content such as tweets. For `iltalehti.fi` it's possible to make videos to work without accepting cookies via scriplet (included) though it doesn't work for tweets. In other domains videos work without accepting cookies, but tweets won't.

Other domains than `iltalehti.fi` show this error text when content couldn't be loaded:

![kuva](https://user-images.githubusercontent.com/17256841/185743383-7c273af1-f4a0-4dbd-a14e-d32fbc1f7d70.png)

It means: `Content couldn't be loaded. This could be due to a browser extension`.

This text doesn't appear immediately so the GDPR dialog won't appear either immediately as it's showing is related to that error text. Before that text appears, there's a colorful loading icon:

![kuva](https://user-images.githubusercontent.com/17256841/185743816-0ba3d0b9-09ad-4ab1-b10c-b4c1b63c176d.png)

It would be possible to make the GDPR dialog to appear immediately via:

`arvopaperi.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,www.kauppalehti.fi,www.uusisuomi.fi##body:has(#article-body > div[class] div[class][color]) > .alma-cmpv2-container:style(display: block !important)`

But I don't see it necessary. (Both this and the error message restore filter would be needed).

Samples:
https://www.iltalehti.fi/digiuutiset/a/d2af6105-d363-47b2-9a21-5a07fcee22ba (already whitelisted, but just mentioning it as it relates to these other sites)

https://www.kauppalehti.fi/uutiset/suomen-kylat-ilahtui-keskustan-edistamasta-kokeilusta-kannustaisi-koulutettuja-nuoria-muuttamaan-tunturikyliin/3a60106f-42bb-4301-9781-ec2564e266cb

https://www.talouselama.fi/uutiset/twitter-julkaisi-uuden-ominaisuuden-nyt-kayttaja-voi-poistaa-itsensa-epamiellyttavista-keskusteluista/8b8bbedf-85d9-416d-b268-4959fde6ca8d

https://www.arvopaperi.fi/uutiset/nain-elon-musk-ja-twitter-valmistautuvat-oikeustaisteluun-kovan-tason-juristit-palkattu-mukaan/fa0396f2-2ed0-4ddc-b3f8-f70f4bf7ad55

https://www.mikrobitti.fi/uutiset/sosiaalinen-media-kohahti-mark-zuckerbergin-metaversumiselfiesta-tahanko-meta-pumppasi-miljardeja/76df6394-448e-4234-b763-d84559b2c106

https://www.mediuutiset.fi/uutiset/yksi-toisensa-jalkeen-palkansaajajarjestot-hylkasivat-sopimusehdotuksen-25-000-hoitajan-lakko-alkaa-perjantaina/72fc6fd7-313a-4a75-ba0d-097984c8bdf8

https://www.tivi.fi/uutiset/venaja-hehkutti-kranaatinheittimella-varustetun-taistelurobotin-kykyja-kiinalaisilta-painava-vastalause/5f498073-8a1b-456c-be36-db1a25346735

https://www.tekniikkatalous.fi/uutiset/venaja-ylistaa-kiinalaisen-tappajarobotin-taitoja-ampuu-ja-kantaa-rahtia-varusteena-jopa-kranaatinheitin-video-kiinalaiset-hermostuivat/70d4dbaa-093c-4864-a7d9-3c91b6fc4897

https://www.uusisuomi.fi/uutiset/twitter-kauppa-elon-muskin-ideologisten-tavoitteiden-pohja-on-hatara/5137a6ff-93cd-4ad6-8bb8-9c98a0ed22b1

Unfortunately, some of these sites are eager to paywall their articles so finding non-paywalled samples wasn't always possible. (I have browser addon that unlocks those articles for me which is why I can see them https://addons.mozilla.org/fi/firefox/addon/bypass-paywalls-clean/)