### PR TITLE
Fix quantamagazine.org cookie notice removal

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -255,7 +255,7 @@ seatgeek.com##[class^="withGDPRBanner__Wrapper-"]
 yourstorebox.com##.layout > .react-cookie-law-dialog
 taloon.com##[id="gdprpopup"]
 ! removeclass
-quantamagazine.org##+js(rc, cookie-not-accepted, #app)
+quantamagazine.org##+js(rc, cookie-not-accepted, , stay)
 foxracingshox.de##+js(rc, cookie--not-set, , stay)
 crt.hr##+js(rc, bg-gray, , stay)
 yourstorebox.com##+js(rc, cookie-active, , stay)

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -255,6 +255,7 @@ seatgeek.com##[class^="withGDPRBanner__Wrapper-"]
 yourstorebox.com##.layout > .react-cookie-law-dialog
 taloon.com##[id="gdprpopup"]
 ! removeclass
+quantamagazine.org##+js(rc, cookie-not-accepted, #app)
 foxracingshox.de##+js(rc, cookie--not-set, , stay)
 crt.hr##+js(rc, bg-gray, , stay)
 yourstorebox.com##+js(rc, cookie-active, , stay)


### PR DESCRIPTION
<!-- 

Easyprivacy requests:
** If a site implements any tracking or monitoring, UA/IP/Geo checks, browser detection, analytics, telemetry, linking to third-partys, pixels, referrers, fingerprinting, event/perf logging etc. Regardless how helpful or needed the script(s) are, it will be blocked in Easyprivacy. Privacy comes first and the block on these scripts will remain in place.


Any additions, changes or removals is at the Authors discretion. 
You're free to counterargue (to a certain point) if you disagree with the decision. 
To avoid being banned, don't constantly re-open or create new (related) issue reports.
-->

<!-- Just include the website URL in the Title line of this issue report -->

### List the website(s) you're having issues:

<!-- URL(s) for issue on a specific site are **mandatory** -->
<!-- To prevent tracking, wrap the website URL in a Code tag please. **mandatory** -->

- `https://www.quantamagazine.org/`

### What happens?

<!-- Just a description of the issue when you visit the site. Or steps on reproducing this  -->

- There is white space above header due to cookie removal. It can be fixed with:
    `quantamagazine.org##+js(rc, cookie-not-accepted, #app)`

### Your settings

<!-- Just to ensure there is no issues or conflicts with other webbrowser extensions. 
     Disable Noscript, Ghostery, Disconnect, HTTPS Everywhere, Privacy Badger before reporting (and re-test with them disabled).
     Just ensure you're running just one Adblock extension only -->

<details><summary>Configuration</summary>

```yaml
uBlock Origin: 1.44.0
Firefox: 103
listset: 
  added:
    fanboy-cookiemonster
  default:
    user-filters
    ublock-filters
    ublock-badware
    ublock-privacy
    ublock-abuse
    ublock-unbreak
    ublock-quick-fixes
    easylist
    easyprivacy
    urlhaus-1
    plowe-0
```
</details>

### Other details:

<!-- If you suspect certain filters (this helps spending time to debug it manually).
If you have a screen shot of the issue or advert, this will help to highlight it. -->

<details><summary>Screenshot 1</summary>

![image](https://user-images.githubusercontent.com/110956608/185792157-938ddf3f-1738-4f55-a483-eca04320a45a.png)

</details>