### PR TITLE
A: https://crashchance.com tracker

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -43,6 +43,7 @@
 ||cloudwp.io^
 ||clrt.ai^
 ||cpx.to^
+||crashchance.com^
 ||crsspxl.com^
 ||crwdcntrl.net^
 ||cvlb.dev^


### PR DESCRIPTION
According to the website itself, that has an explanation page: "This domain is used by digital publishers to control access to copyrighted content in accordance with the Digital Millennium Copyright Act and understand how visitors are accessing their copyrighted content."

Seen in the wild in https://www.presse-citron.net/