### PR TITLE
A: https://orange.fr tracking

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -207,6 +207,7 @@
 ||tracking.bd4travel.com^
 ||unblog.fr/cu.js
 ||wawacity.*/bypass
+||woopic.com/z.gif
 ||wstats.gameblog.fr^
 ||wt.oscaro.com^
 ||yandex.fr/clck/click


### PR DESCRIPTION
https://orange.fr loads https://z.woopic.com/z.gif with tracking values as params. Some other subdomain are used too, but others are already handled by others filters, only this one remains. woopic.com belongs to Orange.