### PR TITLE
F: Hidden Footer on thedriven.io

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2691,7 +2691,7 @@ greatis.com##.sing
 metalsucks.net##.single-300-insert
 inoreader.com##.sinner_inner
 deshdoaba.com##.site-branding
-thedriven.io##.site-footer
+thedriven.io###solarchoice_banner_1
 punchng.com##.site-header-placeholder
 sassyhongkong.com##.site-leaderboard
 wahcricket.com##.site-mainhead


### PR DESCRIPTION
The footer of thedriven.com has been hidden after [this filter](https://github.com/easylist/easylist/commit/ce7f2a4b9cca95709faa9163d39257e36a728164) was added. 
I assume that the idea was to block the banner ad below. I have added a suggestion to replace the class with an id.
![Screenshot 2022-08-24 at 09 44 32](https://user-images.githubusercontent.com/45878727/186361168-5f5a3e60-3019-4af8-9b4a-df9e7a2f8a9c.png)

