### PR TITLE
A: https://discord.bots.gg/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -665,6 +665,7 @@
 ||pixelzirkus.gameforge.com^
 ||pixiedust.buzzfeed.com^
 ||planetradio.co.uk/crystal/log
+||plausible.bots.gg^
 ||plausible.omgapi.org^
 ||player-telemetry.vimeo.com^
 ||pm.dailykos.com^


### PR DESCRIPTION
The domain `plausible.bots.gg` hosts a Plausible instance for loading and sending analytics.