### PR TITLE
M: fix bloomberg.com ad selector

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3092,7 +3092,7 @@ antimusic.com##.zerg
 thehackernews.com##.zoho-box
 bellinghamherald.com##.zone-el
 gab.com##[aria-label*="Sponsored:"]
-bloomberg.com##[class$="ad-div"]
+bloomberg.com##[class*="ad-div"]
 barandbench.com##[class*="ad-slot"]
 usnews.com##[class*="ad-spacer"]
 swarajyamag.com##[class*="page-top-adv-wrapper"]


### PR DESCRIPTION
`https://www.bloomberg.com/features/2022-mbs-neom-saudi-arabia/?srnd=businessweek-v2`

Scripts on the page sometimes modify classes of the div, invalidating the selector, so `class*=` is needed here.