### PR TITLE
A: https://support.nfl.com zendesk tracking

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2284,7 +2284,7 @@
 /gweb/analytics/*
 /hash_stat/*
 /hash_stat_bulk/*
-/hc/tracking/*
+/hc/activity
 /hc_pixel.gif?
 /headerpixel.gif?
 /headupstats.gif?


### PR DESCRIPTION
also on https://askfigarorecruteur.zendesk.com, and so on on all zendesk websites

i took the liberty to remove `/hc/tracking/*`, as I don't see it anywhere, I guess it was replaced by this new one.