### PR TITLE
A: https://www.marketwatch.com/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2820,6 +2820,7 @@ theblock.co,thekitchn.com##.stickyFooter
 independant.co.uk##.stickyFooterRoot
 cnet.com##.stickySkyboxSpacing
 sfgate.com##.stickyWrapper
+marketwatch.com##.sticky__innards
 pcgamesn.com,theloadout.com##.sticky_rail600
 minecraftlist.org##.stickywrapper
 romsie.com##.stksht


### PR DESCRIPTION
Hide **Dianomi** sticky ad on https://www.marketwatch.com/
**Note: ad visible on ABP with ACCEPTABLE ADS list enabled**

<img width="1232" alt="m94" src="https://user-images.githubusercontent.com/57706597/187207069-2bc5d4b1-9a1a-486c-922c-b96b5f4b9761.png">

<img width="980" alt="m95" src="https://user-images.githubusercontent.com/57706597/187207088-f77e3154-f5dd-4065-9ddb-ddf3654e6a58.png">