### PR TITLE
A: https://atalayar.com/en

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1509,6 +1509,7 @@ jamendo.com##.col_extra
 iamgujarat.com,indiatimes.com,samayam.com,vijaykarnataka.com##.colombia
 businessinsider.in##.colombia-rhs-wdgt
 cricbeamer.com##.colombiatracked
+atalayar.com##.column-content > .megabanner
 rateyourmusic.com##.column_filler
 2pass.co.uk##.column_right
 arcadebomb.com##.colunit1
@@ -2592,6 +2593,7 @@ realitytea.com##.roadblock
 surinenglish.com##.roba
 roblox.com##.roblox-skyscraper
 mdisk.me##.robot
+atalayar.com##.rotulo-publi
 flightconnections.com##.route-display-box
 elnacional.cat##.row-top-banner
 designtaxi.com##.row.displayboard
@@ -2846,7 +2848,7 @@ politico.com##.styles_house-ad-cover__3Fvyy
 troypoint.com##.su-box
 ycuniverse.com##.subheader_container
 monocle.com##.super-leaderboard
-express.co.uk,msn.com##.superbanner
+atalayar.com,express.co.uk,msn.com##.superbanner
 f1gamesetup.com##.supp-footer-banner
 f1gamesetup.com##.supp-header-banner
 f1gamesetup.com##.supp-sense-desk-large


### PR DESCRIPTION
**atalayar.com** has **English**, **Spanish** and **French** versions and filter added on [commit](https://github.com/easylist/easylist/commit/b61e9a4) doesn't seem to hide the top banner in all versions, so I'm suggesting `##.superbanner` to hide this top ad.

Also suggesting `atalayar.com##.column-content > .megabanner` (or simply `atalayar.com##.megabanner`) to hide in-content ads with PUBLICIDAD labels.

And `atalayar.com##.rotulo-publi` to hide PUBLICIDAD labels on the home page and article pages.


<img width="1136" alt="ad1" src="https://user-images.githubusercontent.com/57706597/187663657-353534ba-d2a6-4378-8d7e-74d4d4c45b5d.png">

<img width="1380" alt="ad2" src="https://user-images.githubusercontent.com/57706597/187663679-d89105dd-fcc4-4166-8cf8-107bf5f9e568.png">

<img width="1372" alt="ad3" src="https://user-images.githubusercontent.com/57706597/187663687-be102e4d-212d-49c7-b4a2-3848facb5b4d.png">
