### PR TITLE
P: https://www.gamerevolution.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1620,7 +1620,7 @@ apotelyt.com##.cuPopuCon
 homefinder.com##.cubeContainer
 speedrun.com##.curse
 toolslib.net##.custom
-addictivetips.com,gamerevolution.com##.custom-html-widget
+addictivetips.com##.custom-html-widget
 noqreport.com##.custom-html-widget [href] > [src]
 ehitavada.com##.custom-popup
 101cargames.com##.custom-siteskin


### PR DESCRIPTION
EL rule: `addictivetips.com,gamerevolution.com##.custom-html-widget` hides the website logo

**Note: on addictivetips.com filter works fine; it hids a VPN deal banner on [sampleURL](https://www.addictivetips.com/vpn/instagram-account-hacked/)**

<img width="1239" alt="11" src="https://user-images.githubusercontent.com/57706597/188098227-09202095-28f9-4d42-8430-5f7347759dff.png">


