### PR TITLE
P: https://www.labartt.com/detail-nemovitosti/pronajem/komercni-prostor/pronajem-obchodniho-prostoru-58-m-670916

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -114,6 +114,7 @@ dobro.systems#@#.adv-box
 dobro.systems#@#.adv-list
 dobro.systems#@#.advBox
 bigcommerce.com#@#.advert-container
+labartt.com#@#.advert-detail
 jamesedition.com#@#.advert2
 rupors.com#@#.advertSlider
 browsershots.org#@#.advert_list


### PR DESCRIPTION
EL blocking content on labartt.com
**Sample URL:** https://www.labartt.com/detail-nemovitosti/pronajem/komercni-prostor/pronajem-obchodniho-prostoru-58-m-670916

Another way to reproduce the issue is to go to https://www.labartt.com/nabidka-nemovitosti/ search for some property, choose one of the available options and you will get a page with missing content such as picture and text.

<img width="1360" alt="c53" src="https://user-images.githubusercontent.com/57706597/188201510-5b36cfe2-7f33-45a7-92b3-bca6b807040c.png">

<img width="1107" alt="c54" src="https://user-images.githubusercontent.com/57706597/188201516-6b2713f4-1914-4c23-a32f-54a118c059ec.png">
