### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock


### PR DESCRIPTION
Override Linguist config, see https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes

I skipped `.template` files due to possible syntax errors (%, etc.)