### PR TITLE
A: crimereads.com

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1018,7 +1018,7 @@ bullettmedia.com###post-footer-nav
 imgur.com###post-jump-container
 ambotv.com,lawandcrime.com,mediaite.com,wired.com###post-nav
 motorauthority.com###postNav
-lithub.com,myfitnesspal.com,securityaffairs.co,theorbital.co.uk###post_more_wrapper
+crimereads.com,lithub.com,myfitnesspal.com,securityaffairs.co,theorbital.co.uk###post_more_wrapper
 daniweb.com###postbit-ad
 the-leader.com###ppslider
 motherjones.com###pre-page


### PR DESCRIPTION
Block #post_more_wrapper on crimereads.com (lithub.com sister site)

e.g. `https://crimereads.com/conspiracy-theory-seth-rich/`

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/110956608/189049213-d58a0db7-36ff-4e5f-9d08-a96325fc751f.png">
