### PR TITLE
P: https://ads.doordash.com/portal

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -10,6 +10,7 @@
 @@||ads.askgamblers.com^$popup
 @@||ads.com^$popup
 @@||ads.cs.washington.edu^$popup
+@@||ads.doordash.com^$popup
 @@||ads.elevateplatform.co.uk^$popup
 @@||ads.emarketer.com/redirect.spark?$popup,domain=emarketer.com
 @@||ads.finance^$popup


### PR DESCRIPTION
Dashboard table with campaign list seem to be blocked  by EasyList filter `://ads.$popup`

Link is used for the Campaign Manager tool Doordash for advertisers to manage their campaigns.

https://ads.doordash.com/api/reporting/v1/sp/metrics/advertiser?startDate=2012-09-09%2000%3A00%3A00&useTestData=false
https://ads.doordash.com/api/reporting/v1/sp/metrics/campaigns?count=8&startDate=2012-09-09%2000%3A00%3A00&startIndex=0&useTestData=false

<img width="873" alt="21" src="https://user-images.githubusercontent.com/57706597/189616318-c34e6e4d-631d-4c39-82a5-7a67a3d7845c.png">
