### PR TITLE
F: allow $popup on jolichezvous.com

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -40,3 +40,4 @@
 @@||vk.com/ads?$popup,domain=vk.com
 @@||www.google.*/search?q=*&oq=*&aqs=chrome.*&sourceid=chrome&$popup,third-party
 @@||youtube.com/ads/preferences/$popup
+@@||zenaps.com^$popup,domain=jolichezvous.com


### PR DESCRIPTION
The [website or blog](https://www.jolichezvous.com/canape-dangle/) in question has an article where it compares and refers different products. When clicking on a button below the picture, it's supposed to open a new tab.
`||zenaps.com^$popup` wasn't, therefore, blocking an ad, but an intentional referral to the website of the product in question. 
This is an end-user generated click that opens a new tab, not a PopUp.
