### PR TITLE
A: AWS logging system

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -795,7 +795,6 @@
 ||fiorenetwork.com/aparatvast/log.php?
 ||firebaselogging-pa.googleapis.com^
 ||firecrux.com/track/$xmlhttprequest
-||firehose.*.amazonaws.com^
 ||fitanalytics.com/metrics/
 ||fkrkkmxsqeb5bj9r.s3.amazonaws.com^
 ||flashstats.libsyn.com^
@@ -1157,7 +1156,6 @@
 ||loggingapi.spingo.com^
 ||loglady.skypicker.com^
 ||logs-api.shoprunner.com^
-||logs.*.amazonaws.com^
 ||logs.animaapp.com^
 ||logs.datadoghq.com^$third-party
 ||logs.datadoghq.eu^$third-party

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -795,6 +795,7 @@
 ||fiorenetwork.com/aparatvast/log.php?
 ||firebaselogging-pa.googleapis.com^
 ||firecrux.com/track/$xmlhttprequest
+||firehose.*.amazonaws.com^
 ||fitanalytics.com/metrics/
 ||fkrkkmxsqeb5bj9r.s3.amazonaws.com^
 ||flashstats.libsyn.com^
@@ -1057,6 +1058,7 @@
 ||kbb.com/partner/$third-party
 ||kelkoogroup.net/st?
 ||key4web.com^*/set_cookie_by_referer/
+||kinesis.*.amazonaws.com^
 ||kiwari.com^*/impressions.asp?
 ||kiwi.mdldb.net^
 ||kiwisizing.com/api/log
@@ -1155,6 +1157,7 @@
 ||loggingapi.spingo.com^
 ||loglady.skypicker.com^
 ||logs-api.shoprunner.com^
+||logs.*.amazonaws.com^
 ||logs.animaapp.com^
 ||logs.datadoghq.com^$third-party
 ||logs.datadoghq.eu^$third-party

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -89,7 +89,6 @@
 ||fastgull.io^
 ||fasttiger.io^
 ||fixel.ai^
-||firehose.*.amazonaws.com^
 ||fleraprt.com^
 ||fn-pz.com^
 ||fpapi.io^
@@ -1527,7 +1526,6 @@
 ||kieden.com^$third-party
 ||killerwebstats.com^$third-party
 ||kilometrix.de^$third-party
-||kinesis.*.amazonaws.com^
 ||kissmetrics.com^$third-party
 ||kissmetrics.io^$third-party
 ||kitbit.net^$third-party
@@ -1621,7 +1619,6 @@
 ||lognormal.net^$third-party
 ||logrocket.com^$third-party
 ||logrocket.io^$third-party
-||logs.*.amazonaws.com^
 ||logz.io^$third-party
 ||lookery.com^$third-party
 ||loopa.net.au^$third-party

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -89,6 +89,7 @@
 ||fastgull.io^
 ||fasttiger.io^
 ||fixel.ai^
+||firehose.*.amazonaws.com^
 ||fleraprt.com^
 ||fn-pz.com^
 ||fpapi.io^
@@ -1526,6 +1527,7 @@
 ||kieden.com^$third-party
 ||killerwebstats.com^$third-party
 ||kilometrix.de^$third-party
+||kinesis.*.amazonaws.com^
 ||kissmetrics.com^$third-party
 ||kissmetrics.io^$third-party
 ||kitbit.net^$third-party
@@ -1619,6 +1621,7 @@
 ||lognormal.net^$third-party
 ||logrocket.com^$third-party
 ||logrocket.io^$third-party
+||logs.*.amazonaws.com^
 ||logz.io^$third-party
 ||lookery.com^$third-party
 ||loopa.net.au^$third-party


### PR DESCRIPTION
Seen sending base64ed fingerprint stuff in https://www.midilibre.fr/2022/09/21/nimes-stationnement-circulation-la-police-peut-verbaliser-a-distance-grace-aux-cameras-10558178.php

kinesis - Amazon Kinesis Data Streams
firehose - Amazon Kinesis Data Firehose
logs - Amazon CloudWatch

I guess this addition would break stuff somewhere (actually not so much AdguardTeam/AdGuardSDNSFilter/issues/702 ) but its goal is to send tracking data to amazon, so...