### PR TITLE
Remove Firefox promo popup

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -957,6 +957,7 @@ medievalists.net##.Mnet_TopLeft_970x250
 metservice.com##.Mrec-min-height
 tvtv.us##.MuiPaper-root.jss12
 ahaan.co.uk##.MuiSnackbar-anchorOriginBottomCenter
+mozilla.org##.mzp-c-sticky-promo
 news18.com##.NAT_add
 naturalnews.com##.PCUMLBEXSWOV
 ask.com##.PartialKelkooResults


### PR DESCRIPTION
It's a popup on the download page.
![image](https://user-images.githubusercontent.com/85389871/191567689-67d04557-41ad-4774-9f5c-82c82b853e02.png)