### PR TITLE
M: cleanup old SNCF websites

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1106,7 +1106,6 @@
 ||walmart.com/client/api/logs
 ||walmart.com/client/api/metrics
 ||walmartimages.com^*/cdn-perf.min.js$domain=walmart.com
-||wblt.oui.sncf^
 ||wc.yahoodns.net^$image
 ||wccftech.com/cnt7vfDVvWa3.js
 ||web-t.9gag.com^

--- a/easyprivacy/easyprivacy_specific_cname.txt
+++ b/easyprivacy/easyprivacy_specific_cname.txt
@@ -8147,6 +8147,7 @@
 ||tr.nl.2wls.net^
 ||tr.nl.ardennes.cci.fr^
 ||tr.nl.mondo-shop.fr^
+||tr.nl.services-sncf.com^
 ||tr.nl2.sncf-fidelite.com^
 ||tr.notification-gdpr.bnpparibas-personalfinance.fr^
 ||tr.notification-gdpr.bnpparibas-pf.fr^

--- a/easyprivacy/easyprivacy_specific_cname.txt
+++ b/easyprivacy/easyprivacy_specific_cname.txt
@@ -4386,7 +4386,6 @@
 ||stats.tdameritrade.com^
 ||stats.tou.tv^
 ||stats.vattenfall.se^
-||stats.voyages-sncf.com^
 ||stats.winsim.de^
 ||stats.wired.com^
 ||stats.yourfone.de^
@@ -8148,7 +8147,6 @@
 ||tr.nl.2wls.net^
 ||tr.nl.ardennes.cci.fr^
 ||tr.nl.mondo-shop.fr^
-||tr.nl.services-sncf.com^
 ||tr.nl2.sncf-fidelite.com^
 ||tr.notification-gdpr.bnpparibas-personalfinance.fr^
 ||tr.notification-gdpr.bnpparibas-pf.fr^
@@ -10431,7 +10429,6 @@
 ||fbu8.montecarloseasonalsale.com^
 ||fbu8.ticket-online.montecarlolive.com^
 ||fkwc.sfr.fr^
-||fl5dpe.oui.sncf^
 ||fpb8.esce.fr^
 ||fsz1.francoisesaget.com^
 ||fzb5.laboratoire-giphar.fr^
@@ -10449,7 +10446,6 @@
 ||hk2d.tourismemauricie.com^
 ||hkj8.evobanco.com^
 ||idg1.idgarages.com^
-||inv3te.oui.sncf^
 ||jcr3.onlyyouhotels.com^
 ||jelr1.dili.fr^
 ||jfp6.destinia.de^
@@ -10461,7 +10457,6 @@
 ||kep6.destinia.ie^
 ||kux5.raileurope.com^
 ||kvt5.blesscollectionhotels.com^
-||kwsjy9.oui.sncf^
 ||leo1.leon-de-bruxelles.fr^
 ||let1.devialet.com^
 ||lio8.destinia.com.pa^
@@ -10544,7 +10539,6 @@
 ||quk9.destinia.com.ar^
 ||qyn6.ofertastelecable.es^
 ||qzl8.destinia.fi^
-||r1ztni.oui.sncf^
 ||r4nds.absorba.com^
 ||rqz4.supdigital.fr^
 ||rup5.destinia.ru^
@@ -10572,7 +10566,6 @@
 ||t.locasun.it^
 ||t.locasun.nl^
 ||t.pmu.fr^
-||t.voyages-sncf.com^
 ||t0y.toyota.ca^
 ||t9h2.ricardocuisine.com^
 ||t9k3a.jeanpaulfortin.com^
@@ -10595,7 +10588,6 @@
 ||uue2.destinia.ir^
 ||uwy4.aegon.es^
 ||uzd1.madeindesign.com^
-||v.oui.sncf^
 ||vbe.voyage-prive.be^
 ||vch.voyage-prive.ch^
 ||vde1.voyage-prive.de^
@@ -10629,7 +10621,6 @@
 ||znq9.destinia.mx^
 ||zrw1.destinia.jp^
 ||zsi7.destinia.do^
-||zum7cc.oui.sncf^
 ||zyq2.destinia.sk^
 !
 ! aca.ca-eulerian.net disguised trackers

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -2405,7 +2405,7 @@ dailymail.co.uk##.mobile-gallery-instruction
 trendhunter.com##.mobile-open
 nytimes.com##.mobilePromo
 nola.com##.mobile_lrg
-bournemouthecho.co.uk,jobomas.com,patient.info,tuaw.com,voyages-sncf.com##.modal
+bournemouthecho.co.uk,jobomas.com,patient.info,tuaw.com##.modal
 allkpop.com,aplus.com,bournemouthecho.co.uk,decalgirl.com,eurocheapo.com,jobomas.com,kevinmd.com,pbsamerica.co.uk,police.uk,publish0x.com,younow.com##.modal-backdrop
 popdust.com##.modal-close
 narrative.ly,timesofindia.indiatimes.com##.modal-content


### PR DESCRIPTION
voyages-sncf.com was replaced by oui.sncf, that was itself replaced  by sncf-connect.com
The two old websites are eaither down or a redirection to the new domain sncf-connect.com
I don't see removed domains in my navigation on the company website