### PR TITLE
healthline.com - remove false positives

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1610,7 +1610,6 @@ mma-core.com##.crec
 thesimsresource.com##.crtv-top-wrapper
 irishtimes.com##.cs-teaser
 c-span.org##.cspan-ad-still-wrapper
-healthline.com##.css-0 + div:not([class]):last-of-type
 healthline.com##.css-12efcmn
 nytimes.com##.css-142l3g4
 sbs.com.au##.css-14lcahw-MuiTypography-root
@@ -3537,7 +3536,6 @@ mangas-raw.com##center > div[style]
 builtbybit.com##center[style="margin-top: 20px"]
 osbot.org##custom > a[href]
 readonepiece.com##div > b
-healthline.com##div.css-0 > div[class]:not([id])
 windows10forums.com##div.message--post.message
 inverse.com##div.zz
 nexusradio.com##div[align=center]


### PR DESCRIPTION
This PR removes false positives that were hiding author info on `healthline.com` articles.

e.g., `https://www.healthline.com/health/acne/definitive-guide-to-acne-everything-you-need-to-know`

Current:

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/110956608/191618496-007160c9-8f41-4e8d-b284-0b2970544fab.png">

With false positives removed:

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/110956608/191618449-3b018ebf-983c-441f-9236-48a0f0caa636.png">
