### PR TITLE
Remove uk-notify class from easylist cookies

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -15784,7 +15784,6 @@
 ##.uk-flex-center.uk-grid-collapse
 ##.uk-notification-bottom-center
 ##.uk-notification-bottom-left
-##.uk-notify-message
 ##.uk-notify-message-info
 ##.uk-position-fixed.cookies
 ##.ukCookiePolicy


### PR DESCRIPTION
Remove uk-notify, as it is breaks some webpages.

Our developers could not see any error messages (`class="uk-notify-message uk-notify-message-danger"`) due to the blocked popup.

I am not familiar to how easylist operates, but I see this annoying, as error messages are blocked. Only blocking `uk-notify-message-info` would be better maybe?

Also I'm failing to understand how a disappearing notification could be a valid cookie form :D Maybe this really is a false positive?