### PR TITLE
A: satshop.fi + others (GDPR script)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -84,3 +84,5 @@
 ||cookiepro.com^$domain=urbandictionary.com
 ! fundingchoicesmessages (consents)
 ||fundingchoicesmessages.google.com^
+! Amasty GDPR script specifics
+/Amasty_GdprFrontendUi/js/*modal$script,domain=abacus-electronics.de|abribatelectromenager.fr|clearchemist.co.uk|megaport.fr|nemesisnow.com|multibazar.be|propulsion-sailing.com|satshop.fi


### PR DESCRIPTION
https://www.satshop.fi/

Amasty GDPR script is used by some sites: https://publicwww.com/websites/%22Amasty_GdprFrontendUi%22/

But better make it specific instead of generic. I once added it as a generic https://github.com/easylist/easylist/pull/7051 but it was later removed (can't find it on ELC anymore), maybe it caused breakages as a generic filter.