### PR TITLE
P: https://www.msn.com/ja-jp/news/national/%E6%9D%BF%E9%87%8E%E5%8F%8…

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -653,7 +653,7 @@
 @@||www.google.com/images/icons/product/adsense-$image
 @@||www.googleadservices.*/aclk?$domain=google.ae|google.at|google.be|google.bg|google.by|google.ca|google.ch|google.cl|google.co.id|google.co.il|google.co.in|google.co.jp|google.co.ke|google.co.kr|google.co.nz|google.co.th|google.co.uk|google.co.ve|google.co.za|google.com|google.com.ar|google.com.au|google.com.br|google.com.co|google.com.ec|google.com.eg|google.com.hk|google.com.mx|google.com.my|google.com.pe|google.com.ph|google.com.pk|google.com.py|google.com.sa|google.com.sg|google.com.tr|google.com.tw|google.com.ua|google.com.uy|google.com.vn|google.cz|google.de|google.dk|google.dz|google.ee|google.es|google.fi|google.fr|google.gr|google.hr|google.hu|google.ie|google.it|google.lt|google.lv|google.nl|google.no|google.pl|google.pt|google.ro|google.rs|google.ru|google.se|google.sk|googleadservices.com
 ! https://github.com/easylist/easylist/issues/12681
-@@||v.fwmrm.net/ad/g/1?*_html5_live
+@@||v.fwmrm.net/ad/g/1?*_html5_live$domain=~msn.com
 ! Quantcast.com
 ! http://forums.lanik.us/viewtopic.php?f=64&t=15116&p=53518
 @@||quantcast.com/advertise$domain=quantcast.com


### PR DESCRIPTION
…B%E7%BE%8E-%E5%83%8D%E3%81%8F%E3%81%8A%E6%AF%8D%E3%81%95%E3%82%93%E3%82%82%E5%A4%9A%E3%81%8F%E3%81%AA%E3%82%8B%E6%99%82%E4%BB%A3%E3%81%AA%E3%81%AE%E3%81%A7-%E3%83%92%E3%83%AD%E3%83%9F%E3%82%82%E6%84%9F%E5%BF%83-%E8%80%83%E3%81%88%E6%96%B9%E3%81%8C%E7%B5%8C%E5%96%B6%E8%80%85/ar-AA12AfEe?cvid=8b9ddbce415b43ff9620d4953ba188c0
Maybe hard to reproduce but the exception rather breaks video playback only on Firefox:

![msn1](https://user-images.githubusercontent.com/58900598/194041564-ede2405e-1ec5-43fb-8065-bea764684672.png)

![msn2](https://user-images.githubusercontent.com/58900598/194041574-19528cd8-60a4-4561-85e7-deb8406f78e6.png)

@Alex-302 Base too has `@@||v.fwmrm.net/ad/g/1?$domain=www.msn.com` and AG Firefox Ext suffers the same trouble. The rule should probably be removed.