### PR TITLE
Fix signup flow on posthog.slack.com

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5384,7 +5384,7 @@
 ://metrika.*/analytics.
 ://mint.*/?js
 ://piwik.$domain=~matomo.org|~piwik.pro
-://posthog.$domain=~posthog.com
+://posthog.$domain=~posthog.com|~posthog.slack.com
 ://segment-api.
 ://segment-cdn.
 ://stats.*/index.js


### PR DESCRIPTION
Hello folks!

[This rule](https://github.com/easylist/easylist/blob/b7e4f1f53deb12808cf086d35f3624755d2c6bad/easyprivacy/easyprivacy_general.txt#L5387) is too greedy and breaks the XHR requests on their Slack instance.

![image](https://user-images.githubusercontent.com/6241083/194373304-e4885e5c-9259-4720-a69f-6a0ffdd81b8e.png)

While I have experience with cosmetic filters, I don't have much knowledge of the network filter list. My intent here is to whitelist requests to posthog.slack.com from posthog.slack.com, is that what will happen?
