### PR TITLE
M: properly escape in regex rules

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -21173,7 +21173,7 @@
 ||lgsmartad.com^
 ||samsungacr.com^
 ! anime47.com / nettruyen.com
-/(https?:\/\/)\w{30,}.me\/\w{30,}\./$script,third-party
+/(https?:\/\/)\w{30,}\.me\/\w{30,}\./$script,third-party
 ! IP addresses
 /(https?:\/\/)104\.154\..{100,}/
 /(https?:\/\/)104\.197\..{100,}/

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -674,7 +674,7 @@
 /^https?:\/\/.*bit(ly)?\.(com|ly)\//$domain=1337x.to|cryptobriefing.com|eztv.io|eztv.tf|eztv.yt|fmovies.taxi|fmovies.world|limetorrents.info|megaup.net|mrunlock.kim|newser.com|sendit.cloud|torlock.com|uiz.io|userscloud.com|vev.red|vidbull.tv|vidop.icu|vidup.io|yourbittorrent2.com
 ! Torrent/Pirate sites /sw.js
 /^https?:\/\/.*\/.*(sw[0-9a-z._-]{1,6}|\.notify\.).*/$script,domain=123films.cc|123proxy.biz|1337x.to|animekisa.tv|anonfiles.com|aparat.cam|bdupload.asia|bitfly.io|cashurl.in|clicknupload.to|clk.ink|cloudvideo.tv|cocomanhua.com|downloadpirate.com|filmix.co|filmlinks4u.is|flashx.pw|fmovies.taxi|fmovies.world|getlink.pro|hurawatch.at|igg-games.com|indishare.org|katflys.com|linksly.co|megaup.net|mixdrop.ch|mixdrop.co|mp3-convert.org|nutritioninsight.com|ouo.press|pcgamestorrents.com|pcgamestorrents.org|pouvideo.cc|powvideo.net|powvldeo.cc|primewire.sc|proxyer.org|sendit.cloud|sendspace.com|shrinke.me|shrinkhere.xyz|solarmovie.to|theproxy.ws|uiz.io|up-load.io|upload.ac|uploadever.com|uploadproper.net|uploadrive.com|uplovd.com|upstream.to|userscloud.com|v96-surf.com|vev.red|vidbull.tv|videobin.co|vidlox.me|vidop.icu|vidoza.co|vidoza.net|vidtomp3.com|vidup.io|vumoo.life|watchtvseries.video|xtgem.com|xtits.com|yourbittorrent2.com|ziperto.com|zippyshare.com
-/^https?:\/\/.*\/sw.js?.[a-zA-Z0-9%]{50,}/$script,~third-party
+/^https?:\/\/.*\/sw\.js\?[a-zA-Z0-9%]{50,}/$script,~third-party
 ! https://ww1.123watchmovies.co/episode/euphoria-season-2-episode-6/
 ! vidoza.net
 $image,script,subdocument,third-party,xmlhttprequest,domain=heapfiles.com|vidoza.co|vidoza.net


### PR DESCRIPTION
I'm pretty sure the target of `/^https?:\/\/.*\/sw.js?.[a-zA-Z0-9%]{50,}/$script,~third-party` is these: `https://apkmaven.io/sw.js?TTJPNUUWEHYDdn8CdhdpbxBjF3Z7CnwCdXgFYgUjfQdiAXcsVmJXI39XYg0mKFZ%2EVnN0C3wHd28ebQN1Lgt5AXd7H38HfC8fewF2fB8tAnV%2EH3cGJnpXegBwKFcqUWdhEDxCZ2EQPVwmKEUuQSA%2EWiBAazVLNRdpbwN%2EG3BvHilUKT5XY1MkIUEqGSMsXjxQGA` so removed unneeded period after `?`.