### PR TITLE
A: https://app.slack.com (needs free login)

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -793,6 +793,7 @@
 ||skyscanner.*/slipstream/view
 ||slack.com/beacon/
 ||slack.com/clog/track/
+||slackb.com^
 ||slant.co/js/track.min.js
 ||slashdot.org/country.js
 ||slashdot.org/images/js.gif


### PR DESCRIPTION
this domain sends bulk of fingerprint when i'm looged into a slack workspace. i did did not seen any legit request to it. app looks functional after this domain blocked.

Also there is a https://xxx.slack.com/api/ublockworkaround.history endpoint that has an interesting name :) but no privacy stuff sent today to it for me.