### PR TITLE
M: programs.sbs.co.kr

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -474,6 +474,7 @@
 @@||90-60-90.in.ua/images/moda/advt/$image,~third-party
 @@||ad-api-v01.uliza.jp^$script,xmlhttprequest,domain=golfnetwork.co.jp|tv-asahi.co.jp
 @@||ad.atown.jp/adserver/$domain=ad.atown.jp
+@@||ad.smartmediarep.com/NetInsight/video/smr$domain=programs.sbs.co.kr
 @@||admanager.clubzebra.se^$image,domain=ripshusvagnar.se
 @@||ads-twitter.com/oct.js$domain=jp.square-enix.com
 @@||ads.instacart.com/admin/$~third-party

--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -474,12 +474,10 @@
 @@||90-60-90.in.ua/images/moda/advt/$image,~third-party
 @@||ad-api-v01.uliza.jp^$script,xmlhttprequest,domain=golfnetwork.co.jp|tv-asahi.co.jp
 @@||ad.atown.jp/adserver/$domain=ad.atown.jp
-@@||ad.smartmediarep.com/NetInsight/$domain=programs.sbs.co.kr
 @@||admanager.clubzebra.se^$image,domain=ripshusvagnar.se
 @@||ads-twitter.com/oct.js$domain=jp.square-enix.com
 @@||ads.instacart.com/admin/$~third-party
 @@||adsafeprotected.com/services/$domain=reuters.com
-@@||adservice.sbs.co.kr/NetInsight/$domain=programs.sbs.co.kr
 @@||adswizz.com/adswizz/js/SynchroClient*.js$script,third-party,domain=esradio.libertaddigital.com
 @@||aff.bstatic.com/static/affiliate_base/js/booking_sp_widget.js$domain=arukikata.co.jp
 @@||afreecatv.com/js/plugin/ad/preroll.js$script,domain=afreecatv.com


### PR DESCRIPTION
Even if The `https://adservice.sbs.co.kr/NetInsight/vast/` request is blocked, any anti-adblock script does not active.

<details>
<summary>Screenshots</summary>

![Screenshot from 2022-10-15 10-34-19](https://user-images.githubusercontent.com/98787049/195982032-2ee892cd-7228-485d-9d36-3cdcab2530e6.png)
![Screenshot from 2022-10-15 10-34-48](https://user-images.githubusercontent.com/98787049/195982038-1bdd22df-698f-4743-9d58-ec4f8bee0714.png)

</details>

The change related to `@@||ad.smartmediarep.com/NetInsight/$domain=programs.sbs.co.kr` improves the  anti-adblock prevention without allowing logging requests.

<details>
<summary>Screenshot</summary>

![Screenshot from 2022-10-15 10-23-47](https://user-images.githubusercontent.com/98787049/195982353-55d47be4-4247-4740-a710-ba2bb76c754a.png)

</details>

The changes that will be updated is added at https://github.com/easylist/easylist/commit/d26456b198f1490e75280ec0f9de5f7e5e842acd.

Related Issue: https://github.com/AdguardTeam/AdguardFilters/issues/132176