### PR TITLE
A: https://dropbox.com/s/jtvozx5213xjghy/20220908%20BPEA%20comment.pdf

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -132,6 +132,7 @@
 ||bcbits.com/bundle/bundle/1/analytics-$domain=bandcamp.com
 ||bcbits.com/bundle/bundle/1/impl-$domain=bandcamp.com
 ||bdt.123rf.com^
+||beacon.dropbox.com^
 ||beacon.samsclub.com^
 ||beacon.shazam.com^
 ||beacon.shutterfly.com^
@@ -278,7 +279,9 @@
 ||dp.shoprunner.com^
 ||drop.com/impressionsBeacon
 ||drop.com/statBeacon
+||dropbox.com/2/client_metrics
 ||dropbox.com/alternate_
+||dropbox.com/jse
 ||dropbox.com/log/
 ||dropbox.com/log_
 ||drudgereport.com/204.png


### PR DESCRIPTION
jse is the error reporting stuff, only appears when there is a JS error in the page. Mine was caused by one of my browser extensions, https://addons.mozilla.org/fr/firefox/addon/dark-background-light-text/.