### PR TITLE
A: attr-2p.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -789,6 +789,7 @@
 ||2performant.com^$third-party
 ||aghtag.tech^$third-party
 ||agorahtag.tech^$third-party
+||attr-2p.com^$third-party
 ||best-top.ro^$third-party
 ||gtop.ro^$third-party
 ||hit100.ro^$third-party


### PR DESCRIPTION
attr-2p.com domain is related with 2Performant affiliate network and is used for tracking.

<img width="750" src="https://user-images.githubusercontent.com/116159045/196653789-05c7b2f5-437b-461c-8c40-afad8c5f7870.png">
