### PR TITLE
Remove Kinesis API Request URL

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1062,7 +1062,6 @@
 ||kbb.com/partner/$third-party
 ||kelkoogroup.net/st?
 ||key4web.com^*/set_cookie_by_referer/
-||kinesis.eu-west-1.amazonaws.com^
 ||kiwari.com^*/impressions.asp?
 ||kiwi.mdldb.net^
 ||kiwisizing.com/api/log


### PR DESCRIPTION
"kinesis.eu-west-1.amazonaws.com" is the URL for AWS Kinesis Data Streams service in eu-west-1 region. See: https://docs.aws.amazon.com/general/latest/gr/ak.html

Blocking this URL breaks the Kinesis Data Streams console. https://eu-west-1.console.aws.amazon.com/kinesis/home?region=eu-west-1#/dashboard