### PR TITLE
A: google.com (activity paused nag)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_block.txt
+++ b/fanboy-addon/fanboy_notifications_specific_block.txt
@@ -20,6 +20,7 @@
 ||seattletimes.com/wp-content/plugins/st-user-messaging/$script
 ||sportskeeda.com/service-workers/helpers/push-notifications
 ||ultimedia.com/js/common/notification.js
+||ogs.google.*/u/0/widget/callout/sid?
 ||yahoo.com/manifest_desktop_
 ! International
 ||0564.ua/assets/d6ade384/js/alertsWidget.js


### PR DESCRIPTION
When I set a setting on my Google account not to save my web activity, they have started to show this nag all the time:

![image](https://user-images.githubusercontent.com/17256841/197298324-f43cf122-a287-4d62-845d-73b34aa44c35.png)

When I click "got it" and refresh the page, the nag just appears again.

"Learn more" link leads to this page: https://myactivity.google.com/activitycontrols/webandapp?pli=1

So, Google wants me to set my account to save my web activities to a log, otherwise they keep spamming me with that nag :)...

(On my PR I changed `.com` -> `*` because this nag uses different TLD's depending what language version of Google is being used.)