### PR TITLE
A: https://www.linforme.com/abonnements

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1181,6 +1181,7 @@
 ||lunametrics.wpengine.netdna-cdn.com^
 ||lycos.com/hb.js
 ||m.addthisedge.com^
+||m.stripe.com^
 ||ma.logsss.com^
 ||magnify.net/decor/track/
 ||mail-app.com/pvtracker/
@@ -1517,6 +1518,7 @@
 ||qzzr.com/_uid.gif
 ||r.mail.ru^$script
 ||r.skimresources.com^
+||r.stripe.com^
 ||rackcdn.com/gate.js
 ||rackcdn.com/stf.js
 ||radiotime.com/Report.ashx?


### PR DESCRIPTION
enter a dummy address on https://www.linforme.com/abonnements then you'll have the  stripe form that sends tracking to both domains.

r.stripe.com receives bunch of tracking data in cleartext, whereas m.stripe.com receives encoded tracking stuff. Payment-related data are sent to other endpoints.

I've tested by clocking both domains and was able to successfully make a payment.