### PR TITLE
Add Jscrambler email tracking pixel host

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5671,6 +5671,7 @@ cgi-bin/counter
 /notifications/beacon/*
 /open.aspx?
 /open.html?$image
+/opens.jscrambler.com/*$image
 /p/rp/*?mi_u=*=&sap_id=$image
 /p1x1.gif
 /page.bsigroup.com/*


### PR DESCRIPTION
This classic tracking pixel is added to emails, example:
```
<div class="tracking"><img alt="" height="0" src="
https://opens.jscrambler.com/home/index/?token=XXX" width="0"></div>
```