### PR TITLE
A: maaseuduntulevaisuus.fi + koneviesti.fi

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -777,6 +777,7 @@
 /api/analytics|
 /api/cmp_tracker
 /api/ComScorePageView
+/api/drpStats
 /api/ipv4check?
 /api/log?
 /api/lt/ref?


### PR DESCRIPTION
`https://www.maaseuduntulevaisuus.fi`
`https://www.koneviesti.fi/`

Tracks articles you read.