### PR TITLE
A: Fix issue immersive-fox.com breakage (.share-icon)

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -530,3 +530,4 @@ stumbleupon.com#@#a[href^="https://www.stumbleupon.com/submit?"]
 pinterest.com#@#a[title="Pin it!"]
 techrepublic.com#@#div[class^="article-share-"]
 digg.com#@#div[id^="digg-widget-"]
+immersive-fox.com#@#.share-icon


### PR DESCRIPTION
Add exception to class .share-icon of core functionality of Immersive Fox.

For more info about the issue, check the reference issue below.

Reference Issue: https://github.com/uBlockOrigin/uAssets/issues/15686#issuecomment-1316866287