### PR TITLE
Use common header text for all lists

### DIFF
--- a/easylist-cookie-uBO.template
+++ b/easylist-cookie-uBO.template
@@ -2,11 +2,7 @@
 ! Title: Easylist Cookie List (uBO)
 ! Last modified: %timestamp%
 ! Expires: 4 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:easylist_cookie/easylist_cookie_general_block.txt%

--- a/easylist-cookie.template
+++ b/easylist-cookie.template
@@ -2,11 +2,7 @@
 ! Title: Easylist Cookie List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:easylist_cookie/easylist_cookie_general_block.txt%

--- a/easylist.template
+++ b/easylist.template
@@ -2,14 +2,7 @@
 ! Title: EasyList
 ! Last modified: %timestamp%
 ! Expires: 6 days (update frequency)
-! Homepage: https://easylist.to/
-! Licence: https://easylist.to/pages/licence.html
-! !
-! Please report any unblocked adverts or problems
-! in the forums (https://forums.lanik.us/)
-! or via e-mail (easylist@protonmail.com).
-! GitHub issues: https://github.com/easylist/easylist/issues
-! GitHub pull requests: https://github.com/easylist/easylist/pulls
+%include easylist:template_header.txt
 !
 !-----------------------General advert blocking filters-----------------------!
 %include easylist:easylist/easylist_general_block.txt%

--- a/easyprivacy.template
+++ b/easyprivacy.template
@@ -2,12 +2,7 @@
 ! Title: EasyPrivacy
 ! Last modified: %timestamp%
 ! Expires: 6 days (update frequency)
-! Homepage: https://easylist.to/
-! Licence: https://easylist.to/pages/licence.html
-!
-! Please report any unblocked tracking or problems
-! in the forums (https://forums.lanik.us/)
-! or via e-mail (easylist@protonmail.com).
+%include easylist:template_header.txt
 !
 !-----------------General tracking systems-----------------!
 %include easylist:easyprivacy/easyprivacy_general.txt%

--- a/fanboy-annoyance-uBO.template
+++ b/fanboy-annoyance-uBO.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Annoyance List
 ! Last modified: %timestamp%
 ! Expires: 4 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_annoyance_general_block.txt%

--- a/fanboy-annoyance.template
+++ b/fanboy-annoyance.template
@@ -2,12 +2,7 @@
 ! Title: Fanboy's Annoyance List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
-!
+%include easylist:template_header.txt
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_annoyance_general_block.txt%
 %include easylist:fanboy-addon/fanboy_notifications_general_block.txt%

--- a/fanboy-cookie.template
+++ b/fanboy-cookie.template
@@ -2,11 +2,7 @@
 ! Title: Easylist Cookie List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:easylist_cookie/easylist_cookie_general_block.txt%

--- a/fanboy-newsletter-uBO.template
+++ b/fanboy-newsletter-uBO.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Anti-Newsletter List
 ! Last modified: %timestamp%
 ! Expires: 4 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_newsletter_general_block.txt%

--- a/fanboy-newsletter.template
+++ b/fanboy-newsletter.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Anti-Newsletter List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_newsletter_general_block.txt%

--- a/fanboy-notifications-uBO.template
+++ b/fanboy-notifications-uBO.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Notifications Blocking List
 ! Last modified: %timestamp%
 ! Expires: 4 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_notifications_general_block.txt%

--- a/fanboy-notifications.template
+++ b/fanboy-notifications.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Notifications Blocking List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_notifications_general_block.txt%

--- a/fanboy-social-uBO.template
+++ b/fanboy-social-uBO.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Social Blocking List
 ! Last modified: %timestamp%
 ! Expires: 4 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_social_general_block.txt%

--- a/fanboy-social.template
+++ b/fanboy-social.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Social Blocking List
 ! Last modified: %timestamp%
 ! Expires: 7 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !--------------------------General blocking rules-----------------------------!
 %include easylist:fanboy-addon/fanboy_social_general_block.txt%

--- a/fanboy-sounds.template
+++ b/fanboy-sounds.template
@@ -2,11 +2,7 @@
 ! Title: Fanboy's Anti-Sounds List
 ! Last modified: %timestamp%
 ! Expires: 9 days (update frequency)
-! License: http://creativecommons.org/licenses/by/3.0/
-! Please report any unblocked content or problems by email or in our forums
-! Email: easylist@protonmail.com
-! Homepage: https://easylist.to/
-! Forums: https://forums.lanik.us/
+%include easylist:template_header.txt
 !
 !-------------------------Third-party blocking rules--------------------------!
 %include easylist:fanboy-addon/fanboy_sounds_thirdparty.txt%

--- a/template_header.txt
+++ b/template_header.txt
@@ -1,0 +1,9 @@
+!
+! Please report any unblocked adverts or problems
+! in the forums (https://forums.lanik.us/)
+! or via e-mail (easylist@protonmail.com).
+!
+! Homepage: https://easylist.to/
+! Licence: https://easylist.to/pages/licence.html
+! GitHub issues: https://github.com/easylist/easylist/issues
+! GitHub pull requests: https://github.com/easylist/easylist/pulls


### PR DESCRIPTION
Before, many lists had different license information and forum/email links.
Now, all this is included from a single template file.