### PR TITLE
Modrinth ads by Adrinth

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4245,3 +4245,5 @@ bing.com##.pa_sb
 bing.com##.productAd
 bing.com##[id$="adsMvCarousel"]
 bing.com##a[href*="/aclick?ld="]
+! Modrinth
+modrinth.com##.content-wrapper


### PR DESCRIPTION
New element hiding rule to hide ads on Modrinth.com that link to 3rd party sponsors.