### PR TITLE
A: fandom.com (GDPR dialog hide, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2446,3 +2446,7 @@ whatsapp.com##+js(rc, hasCookieBanner, body, stay)
 seurakuntavaalit.fi##body:style(overflow: auto !important)
 seurakuntavaalit.fi##.is-active.site-overlay
 seurakuntavaalit.fi###cookie-modal
+! fandom.com
+fandom.com##[data-tracking-opt-in-overlay="true"]:style(display: none)
+fandom.com##body:has(.fandom-video__container) [data-tracking-opt-in-overlay="true"]:style(display: block !important)
+fandom.com##body:has(main[class] [class^="CanonicalVideoPlayer"]) [data-tracking-opt-in-overlay="true"]:style(display: block !important)


### PR DESCRIPTION
On `fandom.com`, cookies have to be accepted to get videos to work. Made rules to hide to dialog but restore it if the page has videos on it.

Video pages:
https://www.fandom.com/video/FoKuC1r0/its-a-me-mario-the-loop
https://www.fandom.com/articles/hgt-wow-wrath-of-the-lich-king
https://www.fandom.com/articles/the-weird-wonderful-history-of-maniac-mansion (after the article)

Non-video pages:
https://naruto.fandom.com/wiki/Hashirama_Senju