### PR TITLE
M: discord.com: Use empty response instead of error

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -279,7 +279,7 @@
 ||dhresource.com/dhs/fob/js/common/track/$domain=dhgate.com
 ||digg.com/library/tracker.js
 ||digital.flytedesk.com/js/head.js
-||discord.com/api/*/science
+||discord.com/api/*/science$domain=discord.com,rewrite=abp-resource:blank-js
 ||discover-metrics.cloud.seek.com.au^
 ||discover.com/QaiuqHH6L7OpQ2dSZzdDRhs6/
 ||discoveryplus.com/events/


### PR DESCRIPTION
Discord keeps the science around until the /science request succeeds. Pretend it works, it's a memory leak.

This change has no effect in Firefox, due to https://github.com/uBlockOrigin/uBlock-issues/issues/2381. However, it works in Chrome.