### PR TITLE
A: https://www.wetter.com/

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -234,6 +234,7 @@
 @@||promo.com/embed/$subdocument,third-party
 @@||promo.zendesk.com^$xmlhttprequest,domain=promo.com
 @@||pubads.g.doubleclick.net/ssai/$domain=worldsurfleague.com
+@@||pushwoosh.com^$third-party,domain=wetter.com
 @@||radiotimes.com/static/advertising/$script,~third-party
 @@||redventures.io/lib/dist/prod/bidbarrel-$script,domain=cnet.com|techrepublic.com|zdnet.com
 @@||renewcanceltv.com/porpoiseant/banger.js$script,~third-party


### PR DESCRIPTION
Notification missing on https://www.wetter.com/ when ABP is active caused by EasyPrivacy blocking pushwoosh.com^$third-party