### PR TITLE
A: https://www.wetter.com/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -375,6 +375,7 @@
 @@||ps.w.org/google-analytics-dashboard-for-wp/assets/
 @@||ps.w.org/wp-slimstat/$domain=wordpress.org
 @@||puch-ersatzteile.at^*/google-analytics.min.js
+@@||pushwoosh.com^$third-party,domain=wetter.com
 @@||px-cdn.net/api/v2/collector/ocaptcha$xmlhttprequest
 @@||quantcast.com/wp-content/themes/quantcast/$domain=quantcast.com
 @@||rasset.ie/dotie/js/tracker.js$domain=rte.ie


### PR DESCRIPTION
Notification missing on https://www.wetter.com/ when ABP is active caused by EasyPrivacy blocking pushwoosh.com^$third-party