### PR TITLE
Update easylist_cookie_international_specific_hide.txt

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -901,7 +901,7 @@ picnic-supermarkt.nl###switch2
 bingoal.be###tocmask
 eyescan.nl,socialbrothers.nl##.CookieDialog
 woonfonds.mijnleninginzicht.nl##.ModalCookie
-anwb.nl##.PONCHO-application
+anwb.nl###TRCO-application
 optochtenkalender.nl##.PanelPopUp
 fleurametz.com,schrama.nl##._11ca_
 alex-soze.nl,almar-products.nl,leyuzu.nl,vanbeekkappers.nl##._12d97


### PR DESCRIPTION
Currently every occurrence of classname `PONCHO-application` on the `anwb.nl` domain is being blocked. This is however a classname that stems from a component (`application`) in our design system (titled Poncho) which is being used as an application wrapper around every preact/react application.

Thus, the current block not only hinders the cookie bar, it breaks the functionality of every application that uses this component from our design system.

To make sure you can still block just the cookiebar, we have added an unique ID `TRCO-application` to block just the cookiebar.

See issue https://github.com/easylist/easylist/issues/14265