### PR TITLE
A: https://www.focus.de/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -16,6 +16,7 @@
 @@||cdn.cxense.com/cx.cce.js$domain=businessinsider.de
 @@||cdn.cxense.com/cx.js$domain=businessinsider.de
 @@||cdn.cxense.com/cx.js$script,domain=handelsblatt.com
+@@||chartbeat.com^$third-party,domain=focus.de
 @@||classic.comunio.de/clubImg.phtml/$image,~third-party
 @@||cleverpush.com/channel/loader/$domain=prosieben.de
 @@||cleverpush.com/sdk/$domain=prosieben.de


### PR DESCRIPTION
Could you please add this exception or allowlist the domain focus.de from the Easy Privacy from the tracking list for chartbeat.com.  It blocks the notification push up message.
![image](https://user-images.githubusercontent.com/33602691/205279198-2d991006-883e-42f2-9302-d5d5aabba54f.png)
Thank you.