### PR TITLE
Use generic filter rule to match `###iqadtile*`

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -3465,19 +3465,6 @@
 ###iq-AdSkin
 ###iqadcontainer
 ###iqadoverlay
-###iqadtile1
-###iqadtile11
-###iqadtile14
-###iqadtile15
-###iqadtile16
-###iqadtile2
-###iqadtile3
-###iqadtile4
-###iqadtile41
-###iqadtile6
-###iqadtile8
-###iqadtile9
-###iqadtile99
 ###islandAd
 ###islandAdPan
 ###islandAdPane
@@ -16308,6 +16295,7 @@
 ##[id^="ad_slider"]
 ##[id^="div-gpt-ad"]
 ##[id^="google_ads_iframe"]
+##[id^="iqadtile"]
 ##[id^="section-ad-banner"]
 ##[name^="google_ads_iframe"]
 ##[onclick^="location.href='http://www.reimageplus.com"]


### PR DESCRIPTION
Instead of adding yet another rule for `###iqadtile5` (encountered [here](https://www.golem.de/)), use generic cosmetic filter rule matching any `id` attribute beginning with `iqadtile`.