### PR TITLE
A: https://www.lemonde.fr/

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -197,6 +197,7 @@
 ||lecho.be/track/
 ||lefigaro.fr/ext/analytics
 ||lefigaro.fr/ext/figanalytics
+||lemonde.fr/*&ptag=
 ||lemonde.fr/bucket/*/tagistan.
 ||leparking-moto.fr/jsV155/Tracker.js
 ||leparking.fr/*/Tracker.js


### PR DESCRIPTION
function that does this call is named ATInternet.Tracker... linked to cookiewall

that was not present few weeks ago when i looked at this site, that's alive! so let's block all ATInternet calls instead of this single path that will probably change soon