### PR TITLE
A: https://www.courrierinternational.com/

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -171,6 +171,7 @@
 ||boingtv.fr/track_view
 ||cdtm.cdiscount.com^
 ||compteur.developpez.com^
+||courrierinternational.com/it.hal
 ||developpez.com/public/js/track.js
 ||e.m6web.fr/events
 ||easeus.com/default/js/aff_buy_tracking.js


### PR DESCRIPTION
same owner than lemonde.fr, same ATInternet.Tracker calls