### PR TITLE
Update web3ads.net

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -18536,7 +18536,7 @@
 ||weaveradrenaline.com^
 ||web-guardian.xyz^
 ||web-security.cloud^
-||web3ads.net^
+||app.web3ads.net^
 ||webads.media^
 ||webatam.com^
 ||webcampromo.com^


### PR DESCRIPTION
Under the main domain there is only a landing page and a client panel. All ads are served from subdomain https://app.web3ads.net/ and user context is collected under subdomain https://au.web3ads.net/

You can check test page with all requests https://adshares.net/_test
And docs https://docs.adshares.net/adserver/how-to-start-adserver.html#setup-requirements