### PR TITLE
M: remove obsolete rules

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -572,12 +572,10 @@
 @@||musictrack.jp/a/ad/banner_member.jpg
 @@||mysmth.net/nForum/*/ADAgent_$~third-party
 @@||netmile.co.jp/ad/images/$image
-@@||news24.jp/ad-navi/$domain=search.news24.jp
 @@||nintendo.co.jp/ring/*/adv$~third-party
 @@||nizista.com/api/v1/adbanner$~third-party
 @@||nnmclub.to/forum/misc/html/advert.html$~third-party
 @@||nosh.jp/build/css/chefly/advertisement-$~third-party
-@@||ntv.co.jp/ad-navi/$domain=search.news24.jp
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=games.wkb.jp
 @@||pagead2.googlesyndication.com/pagead/managed/js/*/show_ads_impl_$script,domain=games.wkb.jp
 @@||pia.jp/feature/rss/ad.xml|$~third-party,xmlhttprequest


### PR DESCRIPTION
Blocking rule was removed and thus no longer needed (+ `search.news24.jp` is no more in active use).