### PR TITLE
Deactivate fanboy_notifications_specific_uBO.txt again due to uBO/AG breakage

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -285,4 +285,4 @@ mobile.twitter.com##header[role="banner"] > ._3oxnid3o._3f2NsD-H
 voicy.jp##v-sp-download
 reddit.com##xpromo-top-button
 ! uBO-specific fixes
-!#include fanboy_notifications_specific_uBO.txt
+!!! !#include fanboy_notifications_specific_uBO.txt (Incompatible with the easylist-downloads hosting.)


### PR DESCRIPTION
When trying to load https://easylist-downloads.adblockplus.org/fanboy-notifications.txt in uBlock Origin or AdGuard, it tries to fetch the `!#include` file from https://easylist-downloads.adblockplus.org/fanboy_notifications_specific_uBO.txt, which doesn't exist and which doesn't seem to ever have existed, causing the two adblockers to refuse to sync the list.