### PR TITLE
M: make specific

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -331,7 +331,8 @@
 ||equirodi.*/addstat.php
 ||ericdraken.com/a/$script
 ||error-collector.ted.com^
-||error.fc2.com^
+||error.fc2.com/blog/$image
+||error.fc2.com/blog3/$script
 ||et.nytimes.com^
 ||et.tidal.com^
 ||etsy.com/bcn/beacon


### PR DESCRIPTION
The rule is too wide and breaking legitimate transition when user visit non-existing page e.g. `https://nikkanerog.com/blog-entry-21.html`

![fc2](https://user-images.githubusercontent.com/58900598/210157783-86c8f812-f83e-4918-8177-8606aa183c38.png)

See https://github.com/easylist/easylist/commit/d4d17f529677acf1857361ed1979e9c810c309b0#commitcomment-53891583
