### PR TITLE
A: `https://greyhound-data.com/`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2456,6 +2456,7 @@ thetowner.com##.powered
 thecoinrise.com##.pp_ad_block
 theportugalnews.com##.ppp-banner
 theportugalnews.com##.ppp-inner-banner
+greyhound-data.com##.ppts
 foxbusiness.com##.pre-content
 sassymamahk.com##.pre_header_widget
 vivo.sx##.preload


### PR DESCRIPTION
Hi, 
I would really appreciate if you can add this filter to the list as it was reported as containing ads and although some filters were added after my first request [in here](https://github.com/easylist/easylist/commit/323d7cca8cfd350f238b5d6f17037f1f8d6c4adb) the home page of the websites still has ads, as the proposed earlier filters only hide the ads on subpages. And I was trying to get in touch with author on this regards yet was not able to.
![image](https://user-images.githubusercontent.com/33602691/210393377-b36e26a7-17d0-474c-b152-b610bd17e820.png)

Please note that the filter I am trying to add would hade the ads on both main page and subpages of the same domain. 
Thank you in advance.