### PR TITLE
A: https://assets.wogaa.sg/scripts/wogaa.js

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5275,6 +5275,7 @@
 /wmgbeaconcode.
 /wmps_tracker.
 /wmxtracker.js
+/wogaa.js
 /woopra.js
 /worldwide_analytics/*
 /wp-click-track/*


### PR DESCRIPTION
Add WOGAA to blocklist

WOGAA (Whole-of-Government Application Analytics) is the Singapore Government initiative to collect site usage data to monitor performance and user sentiment. 

https://www.developer.tech.gov.sg/products/categories/analytics/wogaa/overview.html
https://wogaa.sg/home/index.html#/

Network requests to https://assets.wogaa.sg/scripts/wogaa.js are made when connecting to most government websites in Singapore such as https://www.imda.gov.sg/