### PR TITLE
block /api/log? only for original discovered domain

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -780,7 +780,6 @@
 /api/ComScorePageView
 /api/drpStats
 /api/ipv4check?
-/api/log?
 /api/lt/ref?
 /api/metrics$other
 /api/pageactivity

--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -328,6 +328,7 @@
 ||gia.jd.com^
 ||gk.sina.cn^
 ||h5log.zongheng.com^
+||hatena.ne.jp/api/log?
 ||hdslb.com/images/isptrack.js
 ||hhytrace.sogoucdn.com^
 ||his.tv.sohu.com/his/ping.do?


### PR DESCRIPTION
/api/log? was orginally blocked in commit 12fa204, because of a request to hatena.ne.jp/api/log? on the website https://shikabane.hatenadiary.com/entry/2017/03/21/005452

The block is pretty generic even though only this specific website does somehting sketchy in this request.

On the other hand, it can easyly break valid applications using that route in their REST API.