### PR TITLE
A: https://group.accor.com/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1377,6 +1377,7 @@
 ||outbrain.com^*/widgetStatistics.js
 ||p.delivery.net^$third-party
 ||p.placed.com^
+||p.typekit.net^
 ||p.yotpo.com^
 ||p0.com/1x1
 ||paddle.com^*/analytics.js


### PR DESCRIPTION
this p.typekit.net domain seams to serve exclusively trackers, ie. empty pixel on https://crypto.com/fr (already blocked) and empty css on https://group.accor.com/ (not blocked). Real resources are on use.typekit.net.