### PR TITLE
M: Remove p.typekit.net as it is breaking websites

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1374,7 +1374,6 @@
 ||outbrain.com^*/widgetStatistics.js
 ||p.delivery.net^$third-party
 ||p.placed.com^
-||p.typekit.net^
 ||p.yotpo.com^
 ||p0.com/1x1
 ||paddle.com^*/analytics.js


### PR DESCRIPTION
See this issue: https://github.com/easylist/easylist/issues/14723

Fonts can be loaded from `p.typekit.net`, so adding it to this list makes little sense and breaks websites. 

Bungie.net was affected and fixed with an allow list, but this is also breaking robertsspaceindustries.com

Rather than adding each site to the allowlist, I would rather remove it from the list, given the justification given in the [PR](https://github.com/easylist/easylist/commit/22a3441fe31e5a5be6d1307026961afe0b2a2b7c) are wrong: resources are not just in use.typekit.net.