### PR TITLE
M: Allow p.typekit.net/p.css for robertsspaceindustries.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -371,7 +371,7 @@
 @@||orginio.com/api/analytics/$~third-party,xmlhttprequest
 @@||ots.webtrends-optimize.com/$xmlhttprequest,domain=tvlicensing.co.uk
 @@||oyster.com/wp-content/plugins/smartertravel-shared/assets/js/tracking.min.js$~third-party
-@@||p.typekit.net/p.css$stylesheet,domain=browserstack.com|bungie.net
+@@||p.typekit.net/p.css$stylesheet,domain=browserstack.com|bungie.net|robertsspaceindustries.com
 @@||packagetrackr.com/api/v1/track/detecting.json$~third-party
 @@||pagure.io/static/issues_stats.js$~third-party
 @@||palmettostatearmory.com/static/$script,~third-party


### PR DESCRIPTION
Given the typekit rule is here to stay (see https://github.com/easylist/easylist/pull/14759), this is adding robertsspaceindustries.com to the allow list for `p.typekit.net/p.css`.

The current impact is the store is not loading at all with Easylist enabled, see details here: https://github.com/easylist/easylist/issues/14723#issuecomment-1400797333