### PR TITLE
M: unbreak popIn widgets, update #6009

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -5397,6 +5397,8 @@
 ##._ciw-betterAds
 ##._fullsquaread
 ##._has-ads
+##._popIn_recommend_article_ad
+##._popIn_recommend_article_ad_reserved
 ##._table_ad_div_wide
 ##._top_ad_wrapper
 ##.a-ad

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -287,7 +287,6 @@
 ||pntra.com^$image,script
 ||pntrac.com^$image,script
 ||pntrs.com^$image,script
-||popin.cc/popin_discovery
 ||popmog.com^
 ||post.rmbn.ru^$third-party
 ||press-start.com/affgames/

--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -576,7 +576,11 @@
 ||panda.kasika.io^
 ||pia.jp/akam/$script
 ||pia.jp/images/pt.gif$image
-||popin.cc/td_js_
+||popin.cc/iframe/piuid.html
+||popin.cc/PopinService/Logs/
+||popin.cc/retarget/
+||popin.cc/test/popin_img_m.js
+||popin.cc/test/popin_send_cookie_set_fail.js
 ||quant.jp/track/
 ||rakuten-static.com/com/rat/
 ||rasin.tech/heatmap-

--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -791,6 +791,8 @@ trend-online.com##div[style="display:flex;padding:10px;background:#efefef;border
 ! ---------- Japanese Site Specific Rules ----------
 !
 yahoo.co.jp###RSAB
+kakakumag.com###_popIn_recommend
+otekomachi.yomiuri.co.jp###_popIn_right
 tv-tokyo.co.jp###bangumi_page_top
 jti.co.jp###footer-pagetop
 meiji.com###ftr-pagetop
@@ -809,13 +811,17 @@ diamond.jp###top-btn
 japanpost.jp###topBtn
 j-wave.co.jp###totop
 yahoo.co.jp##.ScrollButton
+mbs.jp##.common-wrap--ranking
 diners.co.jp##.dc__pagetop
 webtsc.com##.footer-totop
 allnightnippon.com##.footer_pagetop
 toyota.jp##.global-footer-pagetop-href
+media.moneyforward.com##.home-ranking
 nomuraholdings.com##.l-Footer__pagetop
 so-net.ne.jp##.link-top
 gazoo.com##.mailmag_link
+media.moneyforward.com##.mp-popin-analytics
+media.moneyforward.com##.mp-recommends
 video.laxd.com##.noLoginSticker
 ntv.co.jp##.ntv-pageTop
 nikkei.com##.nui-footer-newman__to-top
@@ -828,6 +834,7 @@ okjapan.jp##.scroller
 harpersbazaar.jp##.subModuleMailMagazine
 sports.yahoo.co.jp##.topPage
 bloomberg.co.jp##BB-MINI-PLAYER
+||api.popin.cc^$third-party
 ||diners.co.jp^*/icon_pagetop_
 ||gamespark.jp^*/pagetop.
 ||girlsheaven-job.net^*/pagetop.


### PR DESCRIPTION
After https://github.com/easylist/easylist/commit/f5454f43fe82f77984f7025024360feb4a3b9e8f all popIn staff was working fine, but these two rules added later have been breaking all popIn widgets (e.g. `https://otekomachi.yomiuri.co.jp/lifestyle/20220126-OKT8T329272/`). This PR fixes them while still blocks their tracking staff and ads. OTOH blocks popIn more aggressively as annoyances and cosmetically cleaned them up by rules taken from AG Annoyances.