### PR TITLE
D: `##.quads-location `

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -14091,7 +14091,6 @@
 ##.pw-in-article-relevant-container
 ##.pz-ad-box
 ##.quads-bg-ad
-##.quads-location
 ##.queue_ad
 ##.queued-ad
 ##.quickadsense


### PR DESCRIPTION
Hi, please remove filter from the generic it's breaking this page 'https://subsbr.net/' appears absolutely blank and the users cant access it.