### PR TITLE
M: remove dead service webryblog.biglobe.ne.jp

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -2743,7 +2743,7 @@
 /images-ad/*
 /images.ads.
 /images.adv/*
-/images/ad/*$domain=~webryblog.biglobe.ne.jp
+/images/ad/*
 /images/ad2/*
 /images/ads-$domain=~ads.com
 /images/ads_


### PR DESCRIPTION
`webryblog.biglobe.ne.jp` was EOL today, can safely be removed.