### PR TITLE
M: Allow p.typekit.net/p.css for business.untappd.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -373,7 +373,7 @@
 @@||orginio.com/api/analytics/$~third-party,xmlhttprequest
 @@||ots.webtrends-optimize.com/$xmlhttprequest,domain=tvlicensing.co.uk
 @@||oyster.com/wp-content/plugins/smartertravel-shared/assets/js/tracking.min.js$~third-party
-@@||p.typekit.net/p.css$stylesheet,domain=browserstack.com|bungie.net|robertsspaceindustries.com
+@@||p.typekit.net/p.css$stylesheet,domain=browserstack.com|bungie.net|robertsspaceindustries.com|business.untappd.com
 @@||packagetrackr.com/api/v1/track/detecting.json$~third-party
 @@||pagure.io/static/issues_stats.js$~third-party
 @@||palmettostatearmory.com/static/$script,~third-party


### PR DESCRIPTION
Adding business.untappd.com to the allow list for p.typekit.net/p.css

The current impact is our menu builder that is used by our customers stops functioning and hangs indefinitely. Same situation as https://github.com/easylist/easylist/issues/14723#issuecomment-1400797333