### PR TITLE
add trafficbass.com to servers list.

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -16714,6 +16714,7 @@
 ||traffic.club^
 ||traffic.name^
 ||trafficad-biz.com^
+||trafficbass.com^
 ||trafficdok.com^
 ||trafficlide.com^
 ||trafficmoon.com^


### PR DESCRIPTION
Block links like it https://z.cdn.trafficbass.com/load?o=v&z=1727922201&random=124124557 to stop playing advertisement video.