### PR TITLE
A: `https://adshare.accesdiffusion.com`

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1538,7 +1538,7 @@
 /adsfuse-
 /adshandler.
 /adshandler/*
-/adshare.$domain=~adshare.io|~adshare.tv|~echosign.com
+/adshare.$domain=~accesdiffusion.com|~adshare.io|~adshare.tv|~echosign.com
 /adshare/*$domain=~adshare.io|~adsharetoolbox.com
 /adsheader.
 /adshider.


### PR DESCRIPTION
Hi, Could you please add the exception `~accesdiffusion.com` to the existing filter `/adshare.$domain=` 
The company is  running a website for sharing to technical files with our customers and partners (B2B business). And uses  “adshare” because of our Company name (A)cces (D)iffusion. Therefore their contact form is getting blocked by the existing filter in the list.  
Thank you