### PR TITLE
A: `https://adops.gr/`

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -988,7 +988,7 @@
 /adocean.
 /adometry.
 /adometry?
-/adops.$domain=~adops.co.il
+/adops.$domain=~adops.gr|~adops.co.il
 /adopspush-
 /ados.js
 /ados?


### PR DESCRIPTION
Hi, please add the exception for `https://adops.gr/` on the existing filter `/adops.$domain=`. The page content it’s being blocked by EasyList and the page maintainer said this: "We're an Ad Operations agency based in Greece and our website is for presentation purposes only. There are no ads included. Our site has a problem when the adblock is active, the filter which blocks us is 'easylist' list. Domain with problem is: `https://adops.gr/`"
![image](https://user-images.githubusercontent.com/33602691/217474150-358864c2-4431-4b8a-a209-f5f0fef6c30b.png)
Thank you