### PR TITLE
A: https://plus.nhk.jp/watch/ch/g1

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1930,6 +1930,7 @@ majorgeeks.com##.highlight.content > center > font
 duckduckgo.com##.highlight_sponsored
 48hills.org##.hills-adlabel
 highwayradio.com##.hiway-widget
+plus.nhk.jp##.hls-player_message
 ndtv.com##.hmpage_rhs
 cryptorank.io##.hofjwZ
 bizarrepedia.com##.holder


### PR DESCRIPTION
This change adds a new filter to Easylist's specific hide list to hide the large sign-in overlay on the NHK Plus player.

For reviewers: Please note that NHK Plus is only available in Japan and may require a VPN to access from outside the country. It also only supports Microsoft Edge, Google Chrome (or other Chromium-based browsers), and Safari, and requires DRM to be enabled for playback.