### PR TITLE
A: https://www.amazon.fr/gp/buy/spc/handlers/display.html

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1860,6 +1860,7 @@ rogerebert.com##.mailing-list
 hereisthecity.com##.mailing-lists
 everymantheatre.org.uk##.mailingList
 amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##.maple-banner
+amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg###revieworder .prime-popover-link #spc-container
 ninemsn.com.au##.marketing-strap__top-strap
 discovermagazine.com##.marketingCallouts
 thenextweb.com##.mb-1


### PR DESCRIPTION
I suggest following to hide the annoying big Subscribe to Amazon prime banner. Note that numbers of customers have fallen in the trap of this page, I know few ones that subscribed to Prime during checkout without having noticed it.

I've tried to block only this one and not all other Prime links on the page that use same kind of class, that explain the 3 selectors.

Even if it sounds good to me it would be nice to have a second tester due to the impact :-)

Before
![Screenshot 2023-02-11 at 01-18-01 Processus de paiement Amazon com](https://user-images.githubusercontent.com/111613844/218226076-3e5d08a4-ccf8-4c06-a1ab-a7cc116eb75e.png)

After
![Screenshot 2023-02-11 at 01-18-18 Processus de paiement Amazon com](https://user-images.githubusercontent.com/111613844/218226083-aaa944a7-8a70-436b-a543-288cb7acf15f.png)
