### PR TITLE
A: https://www.lepoint.fr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -201,6 +201,7 @@
 ||lemonde.fr/bucket/*/tagistan.
 ||leparking-moto.fr/jsV155/Tracker.js
 ||leparking.fr/*/Tracker.js
+||lepoint.fr/img-l/$image
 ||liberation.fr/newsite/js/cmp/
 ||logstash-3.radio-canada.ca^
 ||ma-petite-recette.fr/visites


### PR DESCRIPTION
The path `lepoint.fr/img-l/*` only contains 1*1px images hidden with `position:absolute; top:-50000px;`

![image](https://user-images.githubusercontent.com/2971470/218562888-2817e5e3-cc37-4334-bd7f-8e316a3c6808.png)

Doesn't seem to block real images on pages I've visited.