### PR TITLE
A: https://lemonde.fr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -197,7 +197,9 @@
 ||lecho.be/track/
 ||lefigaro.fr/ext/analytics
 ||lefigaro.fr/ext/figanalytics
+||lemonde.fr/*&gatp=
 ||lemonde.fr/*&ptag=
+||lemonde.fr/*&vtag=
 ||lemonde.fr/bucket/*/tagistan.
 ||leparking-moto.fr/jsV155/Tracker.js
 ||leparking.fr/*/Tracker.js


### PR DESCRIPTION
Blocks tracking images and pings sent on various page loads and events.

I believe the existing filter was detected by the devs and they just inversed the letters `ptag`/`vtag`. Still kept the old one, you never know.

Some examples:

````
# Image on loaded page, includes where I'm coming from, my GDPR consent status, the fact that I'm a paid subscriber, etc.
https://www.lemonde.fr/cc3303527dc0fa0a9037bc650805c0e0f6c041a6?s=43260&vc=false&vm=exempt&ts=1676319490964&vtag=5.28.1&gatp=js&r=1920x1200x24x24&re=1087x1046&p=Home::Beta::default::Home&s2=5&stc={"Pagetype":"Home","Population":"Premium","Producteur":"Edito","ir":"false","consent":"not found","consent AT":"false"}&ref=https://www.lemonde.fr/societe/article/2023/02/13/violences-au-stade-de-france-planification-ratee-modele-de-police-inapproprie-un-rapport-sans-concession-sur-le-fiasco-de-la-finale-liverpool-madrid_6161670_3224.html

# Beacon sent when scrolling on an article
https://www.lemonde.fr/cc3303527dc0fa0a9037bc650805c0e0f6c041a6?s=43260&vc=false&vm=exempt&ts=1676319777257&vtag=5.28.1&gatp=js&r=1920x1200x24x24&re=1087x1046&p=Wirecutter::Scroll::1er_scroll::les_meilleures_lunch_box_pour_la_pause_dejeuner&s2=91&click=N&stc={"ID_Article":3286970,"Pagetype":"Wirecutter","Titre":"les_meilleures_lunch_box_pour_la_pause_dejeuner","Date":"20220901","Id_huit":3286970,"Statut_article":"Gratuit","Population":"Premium","Producteur":"Edito","Nature_edito":"Factuel","Signes":39594,"ir":"false","consent":"not found","consent AT":"false"}

# Image on first private window load
https://www.lemonde.fr/cc3303527dc0fa0a9037bc650805c0e0f6c041a6?s=43260&vc=false&vm=exempt&ts=1676319547966&vtag=5.28.1&gatp=js&r=1920x1200x24x24&re=1325x1046&ati=PUB-[cookie wall]-------&type=AT&Rdt=On
````