### PR TITLE
A: https://data.qiota.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -70,6 +70,7 @@
 ||cxt.ms^
 ||cybba.solutions^
 ||czx5eyk0exbhwp43ya.biz^
+||data.qiota.com^
 ||datatechonert.com^
 ||demdex.net^
 ||directavenue.tech^


### PR DESCRIPTION
Used on lexpress.fr, sends a request to `https://data.qiota.com/api/event` on every page load.