### PR TITLE
A: https://www.bouyguestelecom.fr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -228,6 +228,7 @@
 ||sncf-connect.com/bff/api/v1/t/events
 ||space-blogs.net/include/counter/
 ||stat.ouedkniss.com^
+||stats.bouyguestelecom.fr^
 ||stats.sexemodel.com^
 ||stats.zone-annuaire.
 ||stats.zone-telechargement.


### PR DESCRIPTION
Domain used for a rehost of Google's gtag, and various custom tracking scripts.

Doesn't seem to block user interaction, including subscription and login.