### PR TITLE
P: https://www.spacemarket.com/spaces/rakuraku-kinshicho/rooms/5iUmIB…

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -303,7 +303,7 @@
 @@||bangumi.org/sdk/rakuraku.js?referer=$domain=bs11.jp
 @@||bdash-cloud.com/recommend-script/$script,domain=junonline.jp
 @@||bdash-cloud.com/tracking-script/*/tracking.js$domain=junonline.jp
-@@||browser.sentry-cdn.com^$domain=marshmallow-qa.com
+@@||browser.sentry-cdn.com^$domain=marshmallow-qa.com|spacemarket.com
 @@||carsensor.net/usedcar/modules/clicklog_top_lp_revo.php$xmlhttprequest
 @@||cdn.petametrics.com^$script,domain=comics.mecha.cc
 @@||cdn.treasuredata.com/sdk/$script,domain=retty.me


### PR DESCRIPTION
…AnCo7AGiEe/reservations/new?from=room_reservation_button&price_type=HOURLY&rent_type=1

![spacemarket1](https://user-images.githubusercontent.com/58900598/218783919-eaa742d2-301a-43ab-b4cd-cbccfde096f5.png)

![spacemarket2](https://user-images.githubusercontent.com/58900598/218783934-81f58774-75bc-4b0b-be79-0de50ed770a6.png)

Now so many exception for sentry-cdn, is the blocking rule needed given this itself does not track and user privacy is protected by `||sentry.io^$third-party`?