### PR TITLE
M: https://www.radiofrance.fr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -180,15 +180,13 @@
 ||events-logs.doctolib.com^
 ||forecast.huffingtonpost.fr^
 ||forecast.lemonde.fr^
-||franceculture.fr/static/js/xtcore-
-||franceinter.fr/vendor/track.js
 ||fsm.lapresse.ca^
 ||gamergen.com/ajax/actualites/addVue
 ||hits.porn.fr^
 ||ianimes.org/img/tracker.gif
 ||jeu.net/hits.js
 ||jscrambler.com^$script,domain=airfrance.fr
-||l.franceculture.fr^
+||kirby.radiofrance.fr^
 ||lacentrale.fr/collect
 ||lacentrale.fr/static/fragment-layout/tracking-
 ||lacoccinelle.net/g.js


### PR DESCRIPTION
Domain used to receive regular pings on different events (page load, scrolling, hover, etc.)

Example:

````
HEAD https://kirby.radiofrance.fr/?nom_page=homepage&type_page=homepage&adblock=non&chaine_page=radio_france&position_mea_cards=1&type_mea_cards=web_carousel_media&tags_mea_cards=sans&nom_mea_cards=nos_incontournables&contribution_mea_cards=manuelle&nom_impression=mea_cards&id_mea_cards=5793a380-560d-4f6c-b7ee-cdf88a85f43f&type_evenement=impression&id_site=614404&source=RADIO_FRANCE_WEB&device_uuid=XXXXXXXXX_a_guid_XXXXXXXXXXXXX&centile_test=44&id_visite=XXXXXXXXX_a_guid_XXXXXXXXXXXXX&url=https://www.radiofrance.fr/&statut_loggue=non&usage_avance_consenti=0&heure=22:34:22&timestamp=167684XXXXXXX&resolution_appareil=1920x1200x24x24&resolution_page=1207x1046
````

The calls are done in `https://www.radiofrance.fr/client/immutable/chunks/trackable-8afe1951.js`. Unfortunately, blocking that specific JS file breaks the entire React app :( 

Also deleted old domains that are now folded into radiofrance.fr.