### PR TITLE
A: lr-in.com, lr-in-prod.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1620,6 +1620,8 @@
 ||losstrack.com^$third-party
 ||lp4.io^$third-party
 ||lporirxe.com^$third-party
+||lr-in-prod.com^$third-party
+||lr-in.com^$third-party
 ||lr-ingest.io^$third-party
 ||lsfinteractive.com^$third-party
 ||lucidel.com^$third-party


### PR DESCRIPTION
Adds extra logrocket tracking domains, as listed on https://docs.logrocket.com/docs/troubleshooting-sessions

Logrocket is already on this list (lr-ingest.io, logrocket.io, logrocket.com), this just makes coverage more complete.