### PR TITLE
M: Fixes twitchadvertising.tv/ad-products

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -2007,7 +2007,7 @@
 /asrv/campaign/*
 /asset/ad/*
 /asset/adv/*
-/assets/ad-
+/assets/ad-$domain=~twitchadvertising.tv
 /assets/ad/*
 /assets/ads-
 /assets/ads/*$domain=~outlook.live.com


### PR DESCRIPTION
Some images on [twitchadvertising.tv/ad-products/](https://twitchadvertising.tv/ad-products/) are blocked by EL filter: `/assets/ad-`

Images are also blocked on article pages such as:
https://twitchadvertising.tv/ad-products/homepage-carousel/
https://twitchadvertising.tv/ad-products/homepage-headliner/
https://twitchadvertising.tv/ad-products/first-impression-takeover/

<img width="1124" alt="t1f" src="https://user-images.githubusercontent.com/57706597/221836022-9996bf5d-ca92-4398-9bf7-aa8e458d831c.png">
<img width="1114" alt="t2f" src="https://user-images.githubusercontent.com/57706597/221836035-f2bf221b-63f4-4522-9e9c-ec3451904e64.png">

