### PR TITLE
A: deals.ghacks.net + deals.thehackernews.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -896,6 +896,7 @@ filen.io##.css-4xyt0u
 magic.wizards.com##.css-L6WjG
 jove.com##.css-ad08s1
 argent.xyz##.css-fnrkut
+deals.ghacks.net,deals.thehackernews.com##.css-h52rc8
 exeedme.com##.css-jxh131
 taongafarm.com##.css-muxznr-cookie-consent--Panel
 pwsweather.com##.css-nl3u0z


### PR DESCRIPTION
https://deals.ghacks.net/
https://deals.thehackernews.com/

Hides cookie banner.