### PR TITLE
M: Remove datadoghq.eu

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -923,7 +923,6 @@
 ||datacoral.io^$third-party
 ||datacygnal.io^$third-party
 ||datadoghq-browser-agent.com^$third-party
-||datadoghq.eu^$third-party
 ||datadsk.com^$third-party
 ||datafeedfile.com^$third-party
 ||datafront.co^$third-party


### PR DESCRIPTION
We're working on using this domain to serve our assets.
So it's not testable right now, but it did block us when we tried to move forward with that.

I don't understand why it's been added in the first place as we don't do tracking from our top domain names to avoid this kind of situation.

[Commit](https://github.com/easylist/easylist/commit/e38b423ecfa0ccba7e8e5eae40fe4fb8a54cf336) where it's been added looks odd as it doesn't state the same domain name in the commit message.
Maybe it was a mistake?