### PR TITLE
A: block web crypto miner

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -5928,6 +5928,7 @@ _sdcTrackingCode.
 /web_miner/*
 /webcoin.js
 /webcoin.min.js
+/webmnr.min.js
 /webmr.js
 /webxmr.js
 /wproxy$~third-party,websocket

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1558,14 +1558,17 @@ $xmlhttprequest,domain=flashx.cc|nowvideo.sx|onlinevideoconverter.com|povw1deo.c
 ||cloud-miner.de^
 ||cloud-miner.eu^
 ||easyhash.de^
+||f.xmrminingproxy.com^
 ||flashx.*/bootstrap.min.js
 ||gus.host/coins.js
 ||piti.bplaced.net^
 ||shrink-service.it/js/cM.js
 ||site.flashx.
+||trustaproiam.de^
 ||trusteverything.de^
 ||trustiseverything.de^
 ||trustisimportant.fun^
+||trustwebimportant.fun^
 ||wallpoper.com^*/c.js
 ! CSP Mining
 $csp=child-src 'none'; frame-src 'self' *; worker-src 'none',domain=fileone.tv|theappguruz.com

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1549,26 +1549,14 @@ $xmlhttprequest,domain=flashx.cc|nowvideo.sx|onlinevideoconverter.com|povw1deo.c
 /.*(\/proxy|\.wasm|\.wsm|\.wa)$/$websocket,xmlhttprequest,domain=reactor.cc|sickrage.ca|sorteosrd.com|streamplay.to
 !
 /assets/application-$domain=iamdisappoint.com|shitbrix.com|tattoofailure.com
-||binarybusiness.de^
-||bitcoin-cashcard.com^
-||bitcoin-pay.eu^
 ||browsealoud.com/plus/scripts/$script
 ||cdn1.pebx.pl^
 ||cinemafacil.com/js.php
-||cloud-miner.de^
-||cloud-miner.eu^
-||easyhash.de^
-||f.xmrminingproxy.com^
 ||flashx.*/bootstrap.min.js
 ||gus.host/coins.js
 ||piti.bplaced.net^
 ||shrink-service.it/js/cM.js
 ||site.flashx.
-||trustaproiam.de^
-||trusteverything.de^
-||trustiseverything.de^
-||trustisimportant.fun^
-||trustwebimportant.fun^
 ||wallpoper.com^*/c.js
 ! CSP Mining
 $csp=child-src 'none'; frame-src 'self' *; worker-src 'none',domain=fileone.tv|theappguruz.com

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1549,14 +1549,23 @@ $xmlhttprequest,domain=flashx.cc|nowvideo.sx|onlinevideoconverter.com|povw1deo.c
 /.*(\/proxy|\.wasm|\.wsm|\.wa)$/$websocket,xmlhttprequest,domain=reactor.cc|sickrage.ca|sorteosrd.com|streamplay.to
 !
 /assets/application-$domain=iamdisappoint.com|shitbrix.com|tattoofailure.com
+||binarybusiness.de^
+||bitcoin-cashcard.com^
+||bitcoin-pay.eu^
 ||browsealoud.com/plus/scripts/$script
 ||cdn1.pebx.pl^
 ||cinemafacil.com/js.php
+||cloud-miner.de^
+||cloud-miner.eu^
+||easyhash.de^
 ||flashx.*/bootstrap.min.js
 ||gus.host/coins.js
 ||piti.bplaced.net^
 ||shrink-service.it/js/cM.js
 ||site.flashx.
+||trusteverything.de^
+||trustiseverything.de^
+||trustisimportant.fun^
 ||wallpoper.com^*/c.js
 ! CSP Mining
 $csp=child-src 'none'; frame-src 'self' *; worker-src 'none',domain=fileone.tv|theappguruz.com

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -3057,6 +3057,7 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||besstahete.info^$third-party
 ||bewaslac.com^
 ||biberukalap.com^
+||binarybusiness.de^
 ||bitclub.network^
 ||bitclubnetwork.com^
 ||bitcoin-cashcard.com^
@@ -3122,6 +3123,7 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||ethereum-pocket.eu^$third-party
 ||ethtrader.de^$third-party
 ||eucsoft.com^$third-party
+||f.xmrminingproxy.com^
 ||f1tbit.com^
 ||filmoljupci.com^
 ||flare-analytics.com^$third-party
@@ -3231,8 +3233,12 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||thewise.com^$third-party
 ||tmmp.io^$third-party
 ||traffic.tc-clicks.com^$third-party
+||trustaproiam.de^
+||trusteverything.de^
 ||trustiseverything.de^$third-party
+||trustisimportant.fun^
 ||trustmeiamapro.de^$third-party
+||trustwebimportant.fun^
 ||tulip18.com^$third-party
 ||turnsocial.com^$third-party
 ||usa.cc^$third-party

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -3057,7 +3057,6 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||besstahete.info^$third-party
 ||bewaslac.com^
 ||biberukalap.com^
-||binarybusiness.de^
 ||bitclub.network^
 ||bitclubnetwork.com^
 ||bitcoin-cashcard.com^


### PR DESCRIPTION
/webmnr.min.js is used by [MoneroMiner.Rocks](https://monerominer.rocks/miner-website-integration/javascript-miner/)
 trustiseverything.de and other domains containing "trust" are from Crypto-Webminer "integrate": https://crypto-webminer.com/integrate.html (also taken from older wayback machine snapshots)
easyhash.de is also used as an alternative domain by crypto-webminer (if you visit it, there is copyright crypto-webminer.com in the bottom bar)