### PR TITLE
P: Removed partnerstack.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -13590,7 +13590,6 @@
 ||partion-ricism.xyz^
 ||partnerlinks.io^
 ||partnershipknackcloset.com^
-||partnerstack.com^
 ||partoukfa.com^
 ||partsnoises.com^
 ||partyguarantee.com^


### PR DESCRIPTION
<!-- Which filter(s) are causing the issue -->
### Filter affected:
Here is the commit partnerstack.com was added to the adserver list in https://github.com/easylist/easylist/commit/b27cfaba9441d860ac8351bbeef505a6af5b778c

<!-- Example of broken site -->
### 1st/3rd-party sites affected:

PartnerStack.com is our primary domain which hosts the marketing website, and our applications. 
Our customers using ad blockers have been contacting support because a warning screen is displayed for the application.

All of partnerstack applications and sites, this is just the most trafficed subset, there are other sites affected as well.

- partnerstack.com
- app.partnerstack.com
- dash.partnerstack.com
- market.partnerstack.com
- *.partnerstack.com (all of our customers hosted program pages e.g. https://mondaycom.partnerstack.com/)

<!-- How is it broken? If we visit the site directly, what's broken? -->
### How is it broken?
Users presented with adblock warning screen before visiting any web property.

<!-- Why should we remove this filter? -->
### Description of why it should be removed:
👋 Hi, I run PartnerStack — the company this domain belongs to.

I believe the rule was added because of our tracking snippet at https://js.partnerstack.com/v1 

Fair enough to add js.partnerstack.com domain with a third party script rule but after reviewing your policies I don't think the current rule is fair. It is causing severe stress on our business and users (many of whom make their living on our site)

The affiliate links for PartnerStack application are hosted on grsm.io and partnerlinks.io. These domains are listed in the easylinks_adservers block list alongside partnerstack.com. While it would be more accurate to put them on a tracking list, this is acceptable given the easylist policy.

I took the liberty of finding a similar case, linked below- Rewardful provides the same services as PartnerStack and also had their domain added in error.
https://github.com/easylist/easylist/pull/4212

Thank you for looking into this, and for the continued work on Easylist, I have been a happy uBO user for many many years.