### PR TITLE
https://st1.zoom.us/zoom.ico

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -729,6 +729,7 @@ spiegel.de##div[id*="/spon_dt/"]:not(#google_ads_iframe_\/6032\/spon_dt\/homepag
 ||smartadserver.com^$domain=spiegel.de
 ||smartstream.tv^$domain=spiegel.de
 ||spotxchange.com^$domain=spiegel.de
+||st1.zoom.us/zoom.ico
 ||stickyadstv.com^$domain=spiegel.de
 ||teads.tv^$domain=spiegel.de
 ||twiago.com^$domain=spiegel.de


### PR DESCRIPTION
A proposal to block Zoom's favicon basically being [a symbol of russian invasion](https://en.wikipedia.org/wiki/Z_(military_symbol)).

Using the letter "z" as a favicon is inappropriate and insensitive, particularly in light of the tragic reality that this very same symbol is being used by Russians to kill thousands of innocent people. It goes without saying that such a use of the letter "z" is deeply offensive and deeply problematic. We should be mindful of our symbols and their potential impact on others, particularly in the context of such violence and suffering.