### PR TITLE
Remove too broad and outdated datadome rule

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1614,7 +1614,6 @@
 /datacapture/track
 /datacollectcode?
 /datacollectionapi-client/*
-/datadome/*
 /dataunlocker-prod.
 /dataunlocker.js
 /DatazoomAnalytics.


### PR DESCRIPTION
**Disclaimer**: I work for DataDome.

### Filter affected:
easyprivacy_general.txt
/datadome/*

![Screenshot 2023-03-09 at 16 56 50](https://user-images.githubusercontent.com/55994650/224090004-68674c49-eab6-4bcb-87ad-0f0a1204ac8b.png)


### 1st/3rd-party sites affected:
URL blocked is 
https://datadome.na.chilipiper.com/api/api/v1/book-me/session/datadome/all-else?id=13442951&routeId=6409ff1a4e99e41dc89ff1d1&marketing=true&title=&titleStyle=&fromSnippet=tr when visiting https://datadome.co/book-live-product-demo/ and submitting a demo form.


## How is broken? If we visit the site directly whats broken? 
The demo form can't be submitted/doesn't load because the url contains the word "datadome"

![Screenshot 2023-03-09 at 16 46 23](https://user-images.githubusercontent.com/55994650/224090227-942ab512-7e17-44bf-9576-d028eeca6445.png)


### Description why it should be removed:
This filter was added in commit 2fc3e6032b2b (fanboynz 2020-01-24 13:06:27 +0100 1617) /datadome/*
On darty.com: https://github.com/search?q=repo%3Aeasylist%2Feasylist+2fc3e6032b2b&type=commits
However, if you go on darty.com, you will see it doesn't match anything anymore.
Moreover, this rule is too broad, it can block any URL that contains the word datadome between "/". This can happen on lot of websites that dynamically generate URLs that contain the name of datadome, e.g. on job boards like https://www.welcometothejungle.com/fr/companies/datadome/jobs/devops-engineer-6-months-internship_paris?q=4af8c8e2caf3a56769ad19ebb6b8fa01&o=1612777






