### PR TITLE
M: Update

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -4964,7 +4964,6 @@
 /udctrack.
 /uds/stats?
 /uecomscore_
-/uedata?
 /uem-ep.js
 /uf-stat?
 /ui/analytics/*
@@ -4976,7 +4975,6 @@
 /umami.js
 /umg-analytics/*
 /umt.gif?
-/unagi.amazon.
 /unbxdAnalytics.
 /unbxdAnalyticsConfig.
 /unica.gif?


### PR DESCRIPTION
Hi, 👋  Amazon complaint in regards to the existing filters and provide the following explanation: `The analytics resources are exclusively used for 1st party performance – how fast the amazon site loads, which content is seen on the site and how customers interact with the site, error tracking. No 3rd party data sharing, cookies or cross-site user tracking.` Could you please remove or would you rather want them allow-listed? please let me know.  Thank you in advance.