### PR TITLE
removed browsealoud from blocklist

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1569,7 +1569,6 @@ $xmlhttprequest,domain=flashx.cc|nowvideo.sx|onlinevideoconverter.com|povw1deo.c
 /.*(\/proxy|\.wasm|\.wsm|\.wa)$/$websocket,xmlhttprequest,domain=reactor.cc|sickrage.ca|sorteosrd.com|streamplay.to
 !
 /assets/application-$domain=iamdisappoint.com|shitbrix.com|tattoofailure.com
-||browsealoud.com/plus/scripts/$script
 ||cdn1.pebx.pl^
 ||cinemafacil.com/js.php
 ||flashx.*/bootstrap.min.js


### PR DESCRIPTION
Browsealoud is not a problem product. It is a website addon that some website owners choose to add to their site to help improve accessibility and reachability. It offers text-to-speech, translation, and many other features that are beneficial to many users. The product is owned by Texthelp, a world leader in assistive technology.