### PR TITLE
P: bloomberg.com (ELC issue on Adguard Safari)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2740,9 +2740,11 @@ etlehti.fi,gloria.fi,hyvaterveys.fi,kodinkuvalehti.fi,soppa365.fi,tiede.fi,vauva
 supla.fi##div[id^="sp_message_container_"]
 supla.fi##html.sp-message-open > body:not([style="overflow: hidden;"]):style(position: unset !important; margin-top: 0 !important; overflow: visible !important)
 ! bloomberg.com
+!#if !adguard_ext_safari
 bloomberg.com##html.sp-message-open:style(width: initial !important)
 bloomberg.com##html.sp-message-open > body:style(position: unset !important; overflow: unset !important; margin-top: 0 !important)
 bloomberg.com##body:not(:has(div[class*="player" i][class*="_container"], #root .datastrip)) > div[id^="sp_message_container"]
+!#endif
 ! Alma Media
 arvopaperi.fi,iltalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,www.kauppalehti.fi,www.uusisuomi.fi###alma-cmpv2-container:style(display: none)
 arvopaperi.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,www.kauppalehti.fi,www.uusisuomi.fi##body:has(.article-body p:has-text(Sisältöä ei voitu ladata.Tämä voi johtua selainlaajennuksesta.)) > .alma-cmpv2-container:style(display: block !important)


### PR DESCRIPTION
These rules cause breakages on Adguard Safari. Added a pre-parsing directive, to mark these rules not to load on Adguard Safari.

See:
https://github.com/AdguardTeam/AdguardFilters/issues/144434
https://app.slack.com/client/T010N0F70N4/C010N14G4TF/thread/C010N14G4TF-1679324071.857329