### PR TITLE
M: Fix for `www.insiderintelligence.com`

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -44,6 +44,7 @@
 @@||apc-pli.com/api/tracking/$~third-party,xmlhttprequest
 @@||api-analytics.magstimconnect.net^$~third-party
 @@||api-js.datadome.co/js/$domain=sso.garena.com
+@@||api.amplitude.com^$xmlhttprequest,domain=insiderintelligence.com
 @@||api.cxense.com/public/widget/data?$domain=bizjournals.com|cxpublic.com|marketwatch.com|wsj.com
 @@||api.enthusiastgaming.net^$xmlhttprequest,domain=diep.io
 @@||api.getmakerlog.com/discussions/$~third-party,websocket,xmlhttprequest


### PR DESCRIPTION
Hi, 👋  could you please add the allowlisting filter to the list.  Easy privacy breaks the search engine (top bar one ☝️ ) on this website `www.insiderintelligence.com`. This filter fixes the issue. Thank you in advance.