### PR TITLE
M: blocks cookie message on `purebreak.com`

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -8445,7 +8445,6 @@
 ||getcong.com^
 ||getels.com^
 ||getherefwu.xyz^
-||getjad.io^
 ||getmari.com^
 ||getnewsfirst.com^
 ||getoptad360.com^


### PR DESCRIPTION
When you will go to purebreak.com with EU VPN you should see cookie message but if you will go there with ABP without AA (only EL) you won't see it. Additionally lack of cookie message causes that the ad wall doesn't load so it's an additional legal issue.

The reason behind it is a filter `||getjad.io^` in EL, which blocks the request `https://cdn.lib.getjad.io/library/120157152/purebreak_fr_web` responsible for showing cookie message. 

Please let me know is an allowlisting would make more sense.
Thank you