### PR TITLE
A: https://www.bfmtv.com

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -204,6 +204,7 @@
 ||ianimes.org/img/tracker.gif
 ||jeu.net/hits.js
 ||jscrambler.com^$script,domain=airfrance.fr
+||l.bfmtv.com^
 ||l.franceculture.fr^
 ||lacentrale.fr/collect
 ||lacentrale.fr/static/fragment-layout/tracking-

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -329,6 +329,7 @@
 ||mmtro.com^$third-party
 ||netquattro.com/stats/
 ||netvigie.com^$third-party
+||non.li^$third-party
 ||phywi.org^$third-party
 ||pingclock.net^$third-party
 ||reseau-pub.com^$third-party


### PR DESCRIPTION
l.bfmtv.com is an alias for non.li
https://www.nonli.com/