### PR TITLE
A: https://www.thelocal.it

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -15474,6 +15474,7 @@
 ##.tile_ad_container
 ##.tips_advertisement
 ##.title-ad
+##.tl-ad-container
 ##.tmiads
 ##.tmo-ad
 ##.tmo-ad-ezoic


### PR DESCRIPTION
### Issue:
Ad placeholders on https://www.thelocal.it (including article pages)

<img width="1297" alt="adP" src="https://user-images.githubusercontent.com/57706597/228894448-6ba2aba5-6a1a-4143-8df4-dadae141b1ea.png">


