### PR TITLE
M: Fully block rac.ruutu.fi

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -624,8 +624,7 @@
 ||omataloyhtio.fi/statb.asp
 ||puutarha.net/ffsw-pushcrew.js
 ||puutarha.net/statb.asp
-||rac.ruutu.fi/rac.gif$image
-||rac.ruutu.fi/sat/sat.gif$image
+||rac.ruutu.fi^
 ||rakentaja.fi/kuvat/pi.gif$image
 ||rantapallo.fi/s/redirect/tracking?
 ||stat.mtv3.fi^


### PR DESCRIPTION
Changed to block tracking request `https://rac.ruutu.fi/json/rac-supla` (POST) on `www.supla.fi/radio/53`. `rac.ruutu.fi` can be fully blocked as it is only used for tracking.