### PR TITLE
A: `booking.com`

### DIFF
--- a/easylist/easylist_specific_hide_abp.txt
+++ b/easylist/easylist_specific_hide_abp.txt
@@ -1,4 +1,6 @@
 ! Advanced element hiding rules for Adblock Plus
+booking.com#?#div[data-testid="property-card"]:-abp-has(div[data-testid="new-ad-design-badge"])
+booking.com#?#div[data-testid="property-card"]:-abp-has(span[data-testid="new-ad-design-badge"])
 countdown.co.nz#?#cdx-card:-abp-has(product-badge-list)
 pigglywigglystores.com#?#.fp-item:-abp-has(.fp-tag-ad)
 wowcher.co.uk#?#.two-by-two-deal:-abp-has(a[href*="src=sponsored_search_"])


### PR DESCRIPTION
Hi please review and add these filters to block ads on `booking.com` There are ads on desktop view for which this filter can be used `booking.com#?#div[data-testid="property-card"]:-abp-has(div[data-testid="new-ad-design-badge"])`
![image](https://user-images.githubusercontent.com/33602691/229463942-8ad1433a-ecff-4405-b124-a4c5f15b25af.png)
Ads on lower screen, like tablets for which this filter would work: `booking.com#?#div[data-testid="property-card"]:-abp-has(span[data-testid="new-ad-design-badge"])` 
![image](https://user-images.githubusercontent.com/33602691/229464091-4608d4a1-0621-4e21-bcfd-ddbf76a6d2cc.png)
Thank you in advance