### PR TITLE
Remove !#include uBO Fanboy notifications

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -330,5 +330,3 @@ google.ad,google.ae,google.al,google.am,google.as,google.at,google.az,google.ba,
 weatherbug.net##smart-app-banner
 voicy.jp##v-sp-download
 reddit.com##xpromo-top-button
-! uBO-specific fixes
-!#include fanboy_notifications_specific_uBO.txt


### PR DESCRIPTION
Because of this entry, the whole notification list is now unloadable in uBO, as easylist-downloads.adblockplus.org doesn't host this file: fanboy_notifications_specific_uBO.txt

This doesn't work in uBO: https://easylist-downloads.adblockplus.org/fanboy-notifications.txt

As now this whole list is unloadable in uBO, It's better to leave uBO section out rather than drop the whole list from uBO. If this change is made, the list should work in uBO as before.