### PR TITLE
A: https://asus.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -144,6 +144,7 @@ enermax.com###cookice-text
 cookieshark.eu###cookie--Modal
 peterchristian.co.uk###cookie-acceptancce
 energylivenews.com###cookie-notification-mask
+asus.com###cookie-policy-info-bg
 gorillas.io###cookie-settings
 511mt.net###cookieBannerHolder
 gezondheidsplein.nl###cookieForm


### PR DESCRIPTION
Without the additional filter rule the page stays greyed out with no apparent reason since the cookie info container itself is already blocked.

Site to test: https://estore.asus.com/de/90nr0bp0-p10020-rog-xg-mobile-2023.html