### PR TITLE
Add an exception for criteo.github.io

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1356,7 +1356,7 @@
 /CreateCookieSSO_
 /CreateVIDCookie.aspx?
 /creative.png?slotId=
-/criteo.$domain=~criteo.blotout.io|~criteo.investorroom.com
+/criteo.$domain=~criteo.blotout.io|~criteo.investorroom.com|~criteo.github.io
 /Criteo/*
 /criteo_
 /criteoRTA.


### PR DESCRIPTION
This is the GitHub Pages domain used for Criteo open source documentation