### PR TITLE
M: Fixes https://github.com/uBlockOrigin/uAssets/issues/17458 (lego.com)

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -902,7 +902,7 @@
 ||crosspixel.net^$third-party
 ||crosswalkmail.com^$third-party
 ||crowdscience.com^$third-party
-||crowdtwist.com^$third-party
+||crowdtwist.com^$third-party,domain=~ct-prod.lego.com
 ||crtx.info^$third-party
 ||csdata1.com^$third-party
 ||ctnsnet.com^$third-party


### PR DESCRIPTION
This PR modifies `||crowdtwist.com^$third-party` to exclude requests from `ct-prod.lego.com`, which unblocks the images on `https://www.lego.com/it-it/vip/rewards-center/rewards`. This issue was reported at https://github.com/uBlockOrigin/uAssets/issues/17458.
Credentials for a test account can be provided on request.