### PR TITLE
coveo.com/coveo.analytics.js/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -598,7 +598,6 @@
 ||counter.top.ge^
 ||counter.yadro.ru^
 ||counters.freewebs.com^
-||coveo.com/coveo.analytics.js/
 ||covery.ai/fp/$third-party
 ||covet.pics/beacons
 ||cp.official-coupons.com^


### PR DESCRIPTION
Hi, blocking this `coveo.com/coveo.analytics.js/` prevents a lots of websites running on Coveo to properly load when using adblock.

Considering that the domain `analytics.cloud.coveo.com^` is already blacklisted above in the file blocking any analytics request to reach the server, could we consider removing `coveo.com/coveo.analytics.js/` to at least allow websites likes https://www.basspro.com/shop/en to load properly when using adblock. Currently, they're broken.

