### PR TITLE
A: https://www.ecologie.gouv.fr/

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -207,6 +207,7 @@
 ||fsm.lapresse.ca^
 ||gamergen.com/ajax/actualites/addVue
 ||hits.porn.fr^
+||hlms.ecologie.gouv.fr^
 ||ianimes.org/img/tracker.gif
 ||jeu.net/hits.js
 ||jscrambler.com^$script,domain=airfrance.fr


### PR DESCRIPTION
hlms.ecologie.gouv.fr is an alias for minecologie.ent.et-gv.fr. minecologie.ent.et-gv.fr is an alias for gva.et-gv.fr.

et-gv.fr is Eulerian tracking corp (may be needed to add gva.et-gv.fr to the CNAME list?)