### PR TITLE
A: https://www.education.gouv.fr/

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -267,6 +267,7 @@
 ||tracking.bd4travel.com^
 ||unblog.fr/cu.js
 ||wawacity.*/bypass
+||wrhv.education.gouv.fr^
 ||woopic.com/z.gif
 ||wstats.gameblog.fr^
 ||wt.oscaro.com^


### PR DESCRIPTION
wrhv.education.gouv.fr is an alias for mineductandem.ent.et-gv.fr.,  is an alias for gva.et-gv.fr.

et-gv.fr is Eulerian tracking corp (may be needed to add gva.et-gv.fr to the CNAME list?)