### PR TITLE
A: https://blog.contentstudio.io/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1248,6 +1248,7 @@
 ||ulogin.ru/stats.html
 ||ultimate-guitar.com/components/ab/event?
 ||ultimedia.com/deliver/statistiques/
+||um.contentstudio.io^
 ||umami.wakarimasen.moe^
 ||unity3d.com/v1/events
 ||unsplash.com/a/third-party/snow-


### PR DESCRIPTION
um.contentstudio.io is an alias for whitelabel.usermaven.com

fix #15576