### PR TITLE
A: https://usermaven.com/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2690,6 +2690,7 @@
 ||user-red.com^$third-party
 ||usercycle.com^$third-party
 ||userlook.com^$third-party
+||usermaven.com^$third-party
 ||userneeds.dk^$third-party
 ||userreplay.net^$third-party
 ||userreport.com^$third-party


### PR DESCRIPTION
tracking seen on https://usermaven.com/ page itself, also on third-party like blog.contentstudio.io

tracking company