### PR TITLE
A: https://impots.gouv.fr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -187,6 +187,7 @@
 ||analytics.allovoisins.com^
 ||api.odysee.com/locale/get
 ||batiactu.com/cap_
+||bmly.impots.gouv.fr^
 ||boingtv.fr/track_view
 ||cdtm.cdiscount.com^
 ||cesu.urssaf.fr/clm10

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -308,6 +308,7 @@
 ||early-birds.io^$third-party
 ||edt02.net^$third-party
 ||emailretargeting.com^$third-party
+||et-gv.fr^$third-party
 ||ew3.io^$third-party
 ||ezakus.net^$third-party
 ||facil-iti.com^$third-party


### PR DESCRIPTION
bmly.impots.gouv.fr is an alias for mineco.ent.et-gv.fr. is an alias for gva.et-gv.fr.

et-gv.fr belongs to Eulerian, big tracking corp