### PR TITLE
A: juoksufoorumi.fi (generic block)

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -218,6 +218,7 @@
 ||infibeam.com/affiliate/
 ||inrdeals.com^$third-party
 ||instant-gaming.com/affgames/
+||invisioncic.com^$script
 ||ipp.littlecdn.com^
 ||jam.hearstapps.com/js/renderer.js
 ||jinx.com/content/banner/


### PR DESCRIPTION
Encountered here: https://www.juoksufoorumi.fi/

Used on other pages as well:
https://publicwww.com/websites/content.invisioncic.com/

![kuva](https://user-images.githubusercontent.com/17256841/233459471-de42851c-8bda-48b7-9a99-e4678aed83f9.png)

Note, only scripts should be blocked. Otherwise reaction images will get blocked as well.

Reaction images loaded from `invisioncic.com` are found on this link: https://www.juoksufoorumi.fi/forum/46-yleist%C3%A4-keskustelua-juoksusta/