### PR TITLE
Do not apply shopify/track rule to github.com

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3792,7 +3792,7 @@
 /shinystat_
 /shopify-boomerang-
 /shopify-event.gif?
-/shopify/track
+/shopify/track$domain=~github.com
 /shopify_stats.js
 /showcounter.$domain=~showcounter.com
 /showhits.php?


### PR DESCRIPTION
This fixes uBlockOrigin/uAssets/issues/17706 by preventing the `/shopify/track` to be applied on `github.com`