### PR TITLE
A: bleepingcomputer.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -57,6 +57,7 @@
 ||bestblackhatforum.com/images/my_compas/
 ||bioinformatics.org/images/ack_banners/
 ||bit.com.au/scripts/js_$script
+||bleepstatic.com/comp/mandiant/mWise-call-for-speakers2.jpg
 ||blbclassic.org/assets/images/*banners/
 ||blue.ktla.com^
 ||bordeaux.futurecdn.net^

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -57,7 +57,7 @@
 ||bestblackhatforum.com/images/my_compas/
 ||bioinformatics.org/images/ack_banners/
 ||bit.com.au/scripts/js_$script
-||bleepstatic.com/comp/mandiant/mWise-call-for-speakers2.jpg
+||bleepstatic.com/comp/mandiant/mWise-call-for-speakers*.jpg$image
 ||blbclassic.org/assets/images/*banners/
 ||blue.ktla.com^
 ||bordeaux.futurecdn.net^


### PR DESCRIPTION
This PR removes an ad on `https://www.bleepingcomputer.com/news/security/critical-infrastructure-also-hit-by-supply-chain-attack-behind-3cx-breach/` (`https://www.bleepstatic.com/comp/mandiant/mWise-call-for-speakers2.jpg` and variations):
![image](https://user-images.githubusercontent.com/84232764/233729941-0d93923a-3a3e-40ab-a822-38e81d7fdf2a.png)
