### PR TITLE
A: https://www.newsweek.com/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1083,6 +1083,7 @@
 ||stats.ibtimes.co.in^
 ||stats.ibtimes.sg^
 ||stats.justpaste.it^
+||stats.newsweek.com^
 ||stats.pandora.com^
 ||stats.paste2.org^
 ||stats.pstream.net^


### PR DESCRIPTION
Needs to have `?amp=` parameter in the url to show up.

e.g. `https://www.newsweek.com/lake-tulare-california-filling-water-return-1795617?amp=1`

![image](https://user-images.githubusercontent.com/84513173/233844717-b2be02da-ec29-4eb2-8ed3-cea94f509477.png)
