### PR TITLE
A: hs-scripts.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -152,6 +152,7 @@
 ||hs-analytics.net^
 ||hsadspixel.net^
 ||hsleadflows.net^
+||hs-scripts.com^$third-party,domain=~app.hubspot.com
 ||hubty.network^
 ||i218435.net^
 ||id5-sync.com^


### PR DESCRIPTION
This domain serves the HubSpot tracking scripts: https://knowledge.hubspot.com/reports/install-the-hubspot-tracking-code

I think some resources may be necessary on it to support the HubSpot admin UI, so have exlcuded it on that site.