### PR TITLE
A: data.tm-awx.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -188,7 +188,6 @@
 @@||extreme-ip-lookup.com^$script,domain=bulkbarn.ca
 @@||fast.appcues.com^$script,domain=static.abcmouse.com
 @@||fast.fonts.net/jsapi/core/mt.js$script,domain=eclecticbars.co.uk|gables.com|itsolutions-inc.com|senate.gov
-@@||felix.data.tm-awx.com/felix.min.js$script,domain=cambridge-news.co.uk
 @@||files.mycloud.com/js/analytics/google_analytics.js
 @@||firebase.google.com/docs/analytics/$~third-party
 @@||flipboard.com/setcookie?$~third-party

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -829,7 +829,6 @@
 ||feedblitz.com/imp?$third-party
 ||feedblitz.com^*.gif?$third-party
 ||feedify.net/thirdparty/json/track/
-||felix.data.tm-awx.com^
 ||filament-stats.herokuapp.com^
 ||filesonic.com/referral/$third-party
 ||fingerprinter-production.herokuapp.com^
@@ -1565,7 +1564,6 @@
 ||rapidspike.com/rum/
 ||raygun.io/events?
 ||rbl.ms/res/users/tracking/
-||reach-id.orbit.tm-awx.com^
 ||readcube.com/assets/track_
 ||realm.hearst3pcc.com^
 ||rebelmouse.com/pharos/
@@ -1917,6 +1915,8 @@
 ||tkx.mp.lura.live/rest/v2/server_time
 ||tl.tradetracker.net^
 ||tm-awx.com/pageview
+||data.tm-awx.com^
+||orbit.tm-awx.com^
 ||tm.tradetracker.net^
 ||tm.vendemore.com^
 ||tms.fmm.io^

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -292,6 +292,7 @@
 ||testingmetriksbre.ru^
 ||the-ozone-project.com^
 ||thefontzone.com^
+||data.tm-awx.com^
 ||tncid.app^
 ||track-selectmedia.com^
 ||trackclicks.info^

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -292,7 +292,6 @@
 ||testingmetriksbre.ru^
 ||the-ozone-project.com^
 ||thefontzone.com^
-||data.tm-awx.com^
 ||tncid.app^
 ||track-selectmedia.com^
 ||trackclicks.info^


### PR DESCRIPTION
Appears to be related to https://www.smileweb.net/en/platform, a tracking server used across a number of news websites e.g. https://www.mirror.co.uk/