### PR TITLE
P: https://adcovery.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -1289,7 +1289,6 @@
 ||adcloud.net^
 ||adcolo.com^
 ||adconjure.com^
-||adcovery.com^
 ||adcrax.com^
 ||adcron.com^
 ||addelive.com^

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -1,6 +1,7 @@
 ||000webhost.com/images/banners/
 ||1080872514.rsc.cdn77.org^
 ||1675450967.rsc.cdn77.org^
+||adcovery.com^$third-party
 ||a-delivery.rmbl.ws^
 ||a.ucoz.net^
 ||ad-serve.b-cdn.net^


### PR DESCRIPTION
Site doesn't load because of EL rule: `||adcovery.com^`

<img width="835" alt="adcvry" src="https://user-images.githubusercontent.com/57706597/236869571-f1643610-de2b-4d32-b881-7862d0976912.png">
