### PR TITLE
M: removed too generic GDPR blocking script

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -892,7 +892,6 @@
 /opnWidget.js
 /opt-in-select/cookie/*
 /optInCookieGdprSSR.
-/otBannerSdk.js
 /oupcookiepolicy_
 /PDCookieConsent_
 /pescookies.


### PR DESCRIPTION
This script is part of `cookielaw.org` stuff.

cookielaw.org is already a site specific in Easylist Cookie:
https://github.com/easylist/easylist/blob/66801ddc81f9d0a5c2dc69f3038b8040a0b41ed7/easylist_cookie/easylist_cookie_specific_block.txt#L189


Sample page where it can be seen that script is loading from cookielaw.org: https://www.mtvuutiset.fi/artikkeli/kilpikonna-kiitoradalla-viivytti-viitta-lentoa-japanissa/8248130

![kuva](https://github.com/easylist/easylist/assets/17256841/15008017-9226-4a8b-aa46-4cf3438498d2)
