### PR TITLE
A: pyhajokiseutu.fi (generic hide)

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -6407,6 +6407,7 @@
 ##.ad-sense
 ##.ad-sense-ad
 ##.ad-sep
+##.ad-separator
 ##.ad-sharethrough-top
 ##.ad-shifted
 ##.ad-show-label


### PR DESCRIPTION
https://www.pyhajokiseutu.fi/

Ad separator, visible if you resize your screen to small.

EL already has this rule:
`###ad-separator`

So the class version would be a good generic also imo.