### PR TITLE
M: block PopAd plugin, fixes their site

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3151,7 +3151,6 @@
 /pop_packcpm.
 /pop_under.
 /pop_under/*
-/popad-
 /popads/*
 /popads_
 /poprotator.
@@ -3796,6 +3795,7 @@
 /wp-content/plugins/fasterim-optin/*
 /wp-content/plugins/m-wp-popup/*$~stylesheet
 /wp-content/plugins/platinumpopup/*
+/wp-content/plugins/popad/*
 /wp-content/plugins/the-moneytizer/*
 /wp-content/plugins/useful-banner-manager/*
 /wp-content/plugins/wp-ad-guru/*


### PR DESCRIPTION
Used e.g. on `https://www.nei-isep.org`
Their site `https://wp-time.com/popad-ultimate-popup-ads-plugin/` is broken by 12 years old rule `/popad-` and I can't easily find usefulness of the rule: `https://publicwww.com/websites/%22%2Fpopad-%22/`