### PR TITLE
Block cookie notice / consent manager more specifically

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -141,7 +141,7 @@
 ||termly.io^$third-party
 ||thirdfloor.it^$third-party
 ||thisisdone.com/gdpr/$third-party
-||transcend.io^$third-party
+||cdn.transcend.io/cm^$third-party
 ||truendo.com^$third-party
 ||truyoproductionuscdn.truyo.com^
 ||uniconsent.mgr.consensu.org^*.cmp.js$third-party

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -141,7 +141,7 @@
 ||termly.io^$third-party
 ||thirdfloor.it^$third-party
 ||thisisdone.com/gdpr/$third-party
-||cdn.transcend.io/cm^$third-party
+||cdn.transcend.io/cm/*/ui.js$third-party
 ||truendo.com^$third-party
 ||truyoproductionuscdn.truyo.com^
 ||uniconsent.mgr.consensu.org^*.cmp.js$third-party

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -141,7 +141,7 @@
 ||termly.io^$third-party
 ||thirdfloor.it^$third-party
 ||thisisdone.com/gdpr/$third-party
-||cdn.transcend.io/cm/*/ui.js$third-party
+||cdn.transcend.io/cm/*/ui.js
 ||truendo.com^$third-party
 ||truyoproductionuscdn.truyo.com^
 ||uniconsent.mgr.consensu.org^*.cmp.js$third-party


### PR DESCRIPTION
Adds some more specificity to this cookie notice rule to prevent breakage of unrelated services and websites. This blocks all functionality related to cookie notices / consent management.