### PR TITLE
M:Update

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3087,7 +3087,6 @@ tineye.com##.shutterstock-similar-images
 scriptinghelpers.org##.shvertise-skyscraper
 stuff.co.nz##.sics-component__app__top-leaderboard-ads-container
 stuff.co.nz##.sics-component__widget--neighbourlyShowcasePlus
-pcgamebenchmark.com##.side
 cartoq.com##.side-a
 chaseyoursport.com##.side-adv-block-blog-open
 news.am,nexter.org,viva.co.nz##.side-banner


### PR DESCRIPTION
Please remove this filter from the list it's hiding more than it is supposed to also there are already good filters blocking ads:
![image](https://github.com/easylist/easylist/assets/33602691/6016510e-99f8-4d2f-b34b-6f4af79fc305)
For example on this page `https://www.pcgamebenchmark.com/asus-va27dqsb-27-review`