### PR TITLE
A: zigstyle.jp, cosmeadviser.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -657,7 +657,8 @@
 ||smartnews-ads.com^$third-party
 ||socdm.com^$third-party
 ||speee-ad.jp^$third-party
-||talpa-analytics.$third-party
+||talpa-analytics.com^$third-party
+||talpa-analytics.work^$third-party
 ||taxel.jp^$third-party
 ||team-rec.jp^$third-party
 ||tgknt.com^$third-party

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -657,6 +657,7 @@
 ||smartnews-ads.com^$third-party
 ||socdm.com^$third-party
 ||speee-ad.jp^$third-party
+||talpa-analytics.$third-party
 ||taxel.jp^$third-party
 ||team-rec.jp^$third-party
 ||tgknt.com^$third-party


### PR DESCRIPTION
`talpa-analytics.com` on `zigstyle.jp` and `talpa-analytics.work` on `cosmeadviser.com`. Used internationally but the company looks to be headquartered in Japan.