### PR TITLE
Tracker acaric.jp

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1286,6 +1286,7 @@
 /fp2.compressed.js
 /fp_204?
 /fpc.pl?a=
+/fpc/cookie_js.php
 /fpcookie?
 /fpcount.exe
 /fprnt.min.js

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -580,6 +580,7 @@
 ||adgocoo.com^$third-party
 ||admatrix.jp^$third-party
 ||adpon.jp^$third-party
+||adrange.net^$third-party
 ||af-z.jp^$third-party
 ||afi-b.com^$third-party
 ||aid-ad.jp^$third-party

--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -601,6 +601,7 @@
 ||datasign.co^$third-party
 ||dbfocus.jp^$third-party
 ||deteql.net^$third-party
+||dmtag.jp^$third-party
 ||docodoco.jp^$third-party
 ||docomo-analytics.com^$third-party
 ||e-click.jp^$third-party


### PR DESCRIPTION
`https://ac.dmtag.jp/fpc/cookie_js.php` on `www.rosettastone-lc.jp` too, they share the same pattern `/fpc/cookie_js.php`.