### PR TITLE
A: https://www.gizmodo.jp/2011/03/fox_news.html

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -264,6 +264,9 @@
 ||masternodes.online/baseimages/
 ||maxgames.com/img/sponsor_
 ||mbauniverse.com/sites/default/files/shree.png
+||media-assistant.tech^
+||media-platform.com^
+||mediagene.co.jp^
 ||mediatrias.com/assets/js/vypopme.js
 ||mediaupdate.co.za/banner/
 ||megashare.website/js/safe.ob.min.js


### PR DESCRIPTION
This change blocks ads from ad company [Mediagene](https://www.mediagene.co.jp/) displayed at the bottom of Gizmodo articles.