### PR TITLE
M: theverge GDPR dialog already covered by a generic cosmetic rule

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -214,7 +214,6 @@ crocs.co.uk,crocs.eu,crocs.nl,crocs.fi,crocs.fr,crocs.de##+js(rc, cx-modal-open,
 crocs.co.uk,crocs.eu,crocs.nl,crocs.fi,crocs.fr,crocs.de##+js(rc, cx-no-scroll, , stay)
 elio-systems.io,sanha.com##+js(rc, e-cookie-bar-open, body, stay)
 rappjmed.ch##+js(rc, cookies-not-set, body, stay)
-theverge.com##+js(remove-class, bottom-0, , stay)
 stilord.fr,stilord.it,stilord.de,stilord.es##+js(rc, active-overlay-blur, , stay)
 dasfutterhaus.at##+js(rc, is-blurred-cookiebox, html, stay)
 developer.paypal.com##+js(rc, ccpaCookieBanner-acceptedAll, body, stay)


### PR DESCRIPTION
https://www.theverge.com/

This covers it already:
`##.duet--cta--cookie-banner`