### PR TITLE
[16343] Remove lndo from privacy list.

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2458,7 +2458,6 @@
 ||domaincontrol.com^
 ||fbi.com^
 ||lacolhost.com^
-||lndo.site^
 ||local.computer^
 ||local.qinlili.bid^
 ||local.sisteminha.com^


### PR DESCRIPTION
Resolve https://github.com/easylist/easylist/issues/16343

lndo.site is a developer tool, localhost resolution is intended.