### PR TITLE
Remove pr0gramm.com overlay-rule as it blocks too much

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -130,7 +130,6 @@ parking.hamburg-airport.de###notificationBar
 parking.hamburg-airport.de###notificationBar_modal
 sh-mueller.de###notify
 rundfunkbeitrag.de###optInId
-pr0gramm.com###overlay
 happyweekend-club.com###page
 gasthof-bub.de###page_evconsent
 parkscout.com###parkteamcks
@@ -373,7 +372,6 @@ unkrautfuchs.de,wohlleben-sports.de##.offcanvas
 otto-office.com##.ooB-black-overlay-machmichweg
 online-services.rundfunkbeitrag.de##.optInContainer
 belgium.be##.orejime-Notice
-pr0gramm.com##.overlay-consent
 albatrueffel.de##.overlay-container
 staige.tv##.overlay-content
 koenig.de##.overlay__wrapper


### PR DESCRIPTION
The EasyList Cookies contains two lines for the site pr0gramm.com:
```
1. pr0gramm.com###overlay
2. pr0gramm.com##.overlay-consent
```

This PR removes both, because of:
1. is a wrapper element for all kinds of overlays. This rule blocks essential functionality of the site, such as logging in, resetting passwords and more specific features, such as content collection (marking content as favorites). This rule also removes the possibility for users to report inappropiate content. It is not used for cookie consents and also not for ads. It only wraps site specific features and is not used for tracking elements.
2. pr0gramm.com switched to a third-party cookie consent management called Quantcast, which is already covered by this list. Therefore, this rule is no longer needed.