### PR TITLE
A: https://www.lemonde.fr/

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -224,8 +224,7 @@
 ||lecho.be/fb2?
 ||lecho.be/tag/tag-
 ||ledevoir.com/js/pianoAnalyticsTags.js
-||lemonde.fr/*&cts=
-||lemonde.fr/*&stc=
+||lemonde.fr$image
 ||lemonde.fr/bucket/*/tagistan.
 ||leparking-moto.fr/jsV155/Tracker.js
 ||leparking.fr/*/Tracker.js


### PR DESCRIPTION
Following cat-and-mouse game with this website, that [regularly update it's tracking url to avoid being blocked](https://github.com/easylist/easylist/pulls?q=is%3Apr+lemonde+is%3Aclosed) to continue to track users, I'm afraid we don't have any other solution than blocking images (request type used by tracker) on this host. Fortunately, article images are on subdomain.

The only useful image we'll miss is the small newspaper image on top left, but link still work so the block is still a win I guess.