### PR TITLE
A: historianet.fi,tieku.fi (GDPR, uBO)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -3010,3 +3010,8 @@ akaanseutu.fi,alueviesti.fi,kiuruvesilehti.fi,lempaala.ideapark.fi,lvs.fi,olutpo
 akaanseutu.fi,alueviesti.fi,kiuruvesilehti.fi,lempaala.ideapark.fi,lvs.fi,olutposti.fi,orivedensanomat.fi,pirkkalainen.fi,pirmediat.fi,radiosun.fi,shl.fi,urjalansanomat.fi,ylojarvenuutiset.fi##+js(aeld, scroll, innerHeight)
 ! anna.fi
 anna.fi##+js(set, tcfAllowUseCookies, true)
+! historianet.fi,tieku.fi
+historianet.fi,tieku.fi##.topscroll-banner
+historianet.fi,tieku.fi##+js(set, cicc.cookie_cat_functional, true)
+historianet.fi,tieku.fi##+js(set, cicc.cookie_cat_statistic, true)
+historianet.fi,tieku.fi##+js(set, cicc.cookie_cat_marketing, true)


### PR DESCRIPTION
https://historianet.fi/kulttuuri/arkeologia/3d-kuvat-paljastavat-uskomattoman-loydon-titanicin-hylysta

https://tieku.fi/teknologia/twitterin-perustaja-loi-uuden-sosiaalisen-verkoston

Needed for embedded content.

In order to reproduce this, might need to block tinypass.com temporarily (unlock articles).

`##.topscroll-banner` is a banner that appears at the top occasionally, warning about content that might not be visible because of GDPR. But content works just fine.