### PR TITLE
A: kaypahoito.fi & gogolf.fi (generic block, GDPR)

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -40,6 +40,7 @@
 -gdpr-compliance/
 -gdpr-consents/
 -gdpr-cookie-$~script
+-gdpr-cookie-consent/
 -gdpr-custom.
 -gdpr-min.
 -gdpr-popup.

--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -40,7 +40,6 @@
 -gdpr-compliance/
 -gdpr-consents/
 -gdpr-cookie-$~script
--gdpr-cookie-consent/
 -gdpr-custom.
 -gdpr-min.
 -gdpr-popup.
@@ -1059,6 +1058,7 @@
 /warnCookies.
 /we_use_cookies?
 /webflow-consent-manager
+/webtoffee-gdpr-cookie-consent/*
 /webtrekk_gdpr.
 /wecoma-lite.js
 /widget_privacy/*


### PR DESCRIPTION
https://www.kaypahoito.fi/
https://www.gogolf.fi/

No problems with tweets https://www.gogolf.fi/artikkelit/charlie-woods-haluaa-osansa-tigerille-myonnetysta-8-miljoonasta-lisaa-viikkorahaa-ilman-minua-et-olisi-ollut-kymmenen-joukossa/

I think this generic wp script is ok to block.

Or if `-gdpr-cookie-consent/` is too generic, this can also be used:
`/webtoffee-gdpr-cookie-consent/*`
