### PR TITLE
Update EasyPrivacy, and Fanboy's Social/Annoyance

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1181,6 +1181,7 @@
 ||wellsfargo.com/jenny/
 ||wellsfargo.com/PIDO/
 ||wfinterface.com/tracking/$domain=wellsfargo.com
+||wh.ipaddress.com^
 ||whattomine.com/stats
 ||wheregoes.com/api/event
 ||whistleout.com.au/track

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -950,6 +950,7 @@ dealnews.com##.back-to-top-outer
 topuniversities.com##.back_top
 paradisehill.cc##.block-to-top
 bravotube.net##.btn-up
+ipaddress.com##.btt
 qmul.ac.uk##.btt__inner
 staples.ca##.button--back-to-top
 movehub.com##.button-scroll

--- a/fanboy-addon/fanboy_social_specific_block.txt
+++ b/fanboy-addon/fanboy_social_specific_block.txt
@@ -1,1 +1,2 @@
+||ipaddress.com/shariff/
 ||naturalnews.com/getviews2.


### PR DESCRIPTION
Hopefully fixes https://github.com/easylist/easylist/issues/15926.
Wasn't sure about the so called ad scripts, so I left them out.
Fanboy's Social change may not be needed, but thought it would be useful since it entirely prevents the social media buttons from ever showing up, even without cosmetic filtering. (And a possible benefit to a bit less bandwidth being used)