### PR TITLE
M: Remove bootstrap generic rules: bitdegree.org, ebook-searcher.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2827,7 +2827,6 @@ arrivealive.co.za##.partnersheading
 liveuamap.com##.passby
 writerscafe.org##.pay
 nhentai.com##.pb-0.w-100[style]
-bitdegree.org##.pb-1
 wweek.com##.pb-f-phanzu-phanzu-ad-code
 cattime.com,dogtime.com,liveoutdoors.com,playstationlifestyle.net,thefashionspot.com##.pb-in-article-content
 playbuzz.com##.pb-site-player
@@ -3604,7 +3603,6 @@ fastpic.ru##.vright
 vaughn.live##.vs_v9_LTabvsLowerThirdWrapper
 vaughn.live##.vs_v9_LTabvsLower_beta
 wral.com##.vw3Klj
-bitdegree.org,ebook-searcher.com##.w-100
 androidpolice.com##.w-pencil-banner
 wsj.com##.w27771
 userscript.zone##.w300


### PR DESCRIPTION
This PR removes generic bootstrap rules from blacklist. 
pb-1 is used for setting padding bottom to 1rem.
w-100 is used for setting width to 100%.

With these rules website gets broken, and useful content to users is not properly displayed.
