### PR TITLE
Update EasyList Specific Block/Third Party

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -651,7 +651,6 @@ $webrtc,websocket,xmlhttprequest,domain=pirateproxy.live|thehiddenbay.com|thepir
 @@||thepiratebay.*/static/js/scriptaculous.js$domain=thepiratebay.org
 @@||thepiratebay.org/*.php$csp,~third-party
 @@||thepiratebay.org/static/main.js$script,~third-party
-@@||torrindex.net^$image,script,stylesheet,domain=thepiratebay.org
 ||thepirate-bay3.org/banner_
 ||thepiratebay.$script,domain=pirateproxy.live|thehiddenbay.com|thepiratebay.org
 ||thepiratebay.*/static/$subdocument

--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -401,6 +401,7 @@
 ||ti.tradetracker.net^
 ||tillertag-a.akamaihd.net^
 ||toplist.raidrush.ws^$third-party
+||torrindex.net/images/ads/
 ||torrindex.net/images/epv/
 ||torrindex.net/static/tinysort.min.js
 ||track.10bet.com^


### PR DESCRIPTION
To address #16026. I don't think this is needed.
`||torrindex.net/images/ads/` blocks a "download" button ad image on `https://thepiratebay.org/description.php?id=70263353`.
Allowing the image/script of the domain causes `||torrindex.net/images/epv/` and `||torrindex.net/static/tinysort.min.js` to not function.