### PR TITLE
A: `mybib.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -340,6 +340,7 @@ vscode.one###flamelab-convo-widget
 clintonherald.com,ottumwacourier.com,thetimestribune.com###floorboard_block
 streams.tv###flowerInGarden
 12tomatoes.com###footboard
+mybib.com###footer > div
 fanlesstech.com###footer-1
 metasrc.com###footer-content
 bundesliga.com###footer-partnerlogo


### PR DESCRIPTION
After closing the modal that appears upon entering the site, there will be an ad banner on the bottom left. This pull request hides that banner.

<details>

<summary>Screenshot</summary>

![mybib](https://github.com/easylist/easylist/assets/115052854/78d98d56-bc62-4283-a5a4-84b047ca5de2)

</details>

This pull request fixes https://github.com/uBlockOrigin/uAssets/issues/18567.