### PR TITLE
Remove obsolete Cloudflare challenge transparent.gif

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3404,7 +3404,6 @@
 /traffix-track.
 /trafic.js
 /trans_pixel.asp
-/transparent.gif?ray=
 /transparent1x1.
 /transparent_pixel.
 /transpix.gif


### PR DESCRIPTION
Cloudflare challenge pages used to include an image tag loading a transparent gif. This was used to flag issues with loading the JavaScript required to solve the "I'm a human" challenge.

This hasn't been used for a long time, and has recently been removed by Cloudflare from these pages. Thus, we can clean it up from here too.

**For reviewers:**
Example Cloudflare challenge page that shows a request to the gif is no longer made: https://migueldemoura.com/challenge.