### PR TITLE
A: https://www.shuttle.rs/ (Fix #16234)

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2580,7 +2580,7 @@ cinobo.com,jdslabs.com,simtex.io,vloot.io##.bottom-5
 !! .bottom-8
 dr-anns.com,lightyear.one,vecer.com##.bottom-8
 !! .bottom-4
-my.openbb.co,remnote.com,thecycle.game,urlcast.io##.bottom-4
+my.openbb.co,remnote.com,shuttle.rs,thecycle.game,urlcast.io##.bottom-4
 !! .bottom-3
 accu-components.com,accu.co.uk##.bottom-3
 !! .bottom-16


### PR DESCRIPTION
Fix #16234 — cookie banner