### PR TITLE
iys.org.tr

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -1103,6 +1103,7 @@
 ||glami.com.tr/tracker/
 ||haberler.com/dinamik/
 ||hstats.hepsiburada.com^
+||iys.org.tr/mti-popts.js
 ||p.milliyet.com.tr^
 ||sahibinden.com/sbbi/
 ||stats.birgun.net^


### PR DESCRIPTION
`https://vatandas.iys.org.tr/giris?redirect=%2Fprofil`

I have tested this rule for a long time. It does not break the website.

<details><summary>Screenshot</summary>

![image](https://github.com/easylist/easylist/assets/103899764/82619a29-ccf7-4073-8fa2-c3be9fc3bb40)


</details>