### PR TITLE
A: `https://geekflare.com/screenshot-on-chromebook`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3730,6 +3730,7 @@ paultan.org##.wrapper-footer
 tftactics.gg##.wrapper-lb1
 webtoolhub.com##.wth_zad_text
 forums.ventoy.net##.wwads-cn
+geekflare.com##.x-article-818cc9d4
 beforeitsnews.com##.x1x2prx2lbnm
 aupetitparieur.com##.x7zry3pb
 mcpmag.com##.xContent
@@ -4470,6 +4471,7 @@ mrchecker.net##p > [href^="https://www.mrchecker.net/"]
 bitref.com##picture > img[src]
 courier-journal.com,courierpress.com,detroitnews.com,freep.com,greenbaypressgazette.com,jsonline.com,lohud.com,northjersey.com,sheboyganpress.com,tallahassee.com,theadvertiser.com##promo-story-bucket-short[style="min-height: 335px;"]
 healthgrades.com##ps-action-intercept
+geekflare.com##section.geekflare-core-resources
 mashable.com##section.mt-4 > div
 bbc.com##section[data-e2e="advertisement"]
 thesaurus.com##section[data-type="ad-horizontal-module"]


### PR DESCRIPTION
Hides sponsor's brand on articles.
This pull request fixes #14091.