### PR TITLE
A: `delacortereview.org`

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1192,8 +1192,8 @@ ianvisits.co.uk##.sendysubscribe
 dailyedge.ie,thejournal.ie##.separator-newsletter-redesign
 alldayidreamaboutfood.com,inspiredtaste.net##.seva-overlay
 webmd.com##.sf-nls-wrapper
-creativedestructionmedia.com,floridianpress.com,mediaplaynews.com,thefullpint.com##.sgpb-popup-dialog-main-div-wrapper
-asianjournal.com,creativedestructionmedia.com,floridianpress.com,mediaplaynews.com,prescouter.com,thefullpint.com##.sgpb-popup-overlay
+creativedestructionmedia.com,delacortereview.org,floridianpress.com,mediaplaynews.com,thefullpint.com##.sgpb-popup-dialog-main-div-wrapper
+asianjournal.com,creativedestructionmedia.com,delacortereview.org,floridianpress.com,mediaplaynews.com,prescouter.com,thefullpint.com##.sgpb-popup-overlay
 vtdigger.org##.shop-promo
 platformer.news,substack.com##.show-subscribe
 swissinfo.ch##.si-teaser--newsletter-subscription


### PR DESCRIPTION
Hides newsletter popup leftovers.
This pull request fixes #13223.