### PR TITLE
A: `w3docs.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1862,7 +1862,7 @@ stylist.co.uk##.css-rybqcx
 healthline.com##.css-umsscj
 unmineablesbest.com##.ct_ipd728x90
 comparitech.com##.ct_popup_modal
-techspot.com##.cta
+techspot.com,w3docs.com##.cta
 dailydot.com##.cta-article-wrapper
 thelines.com##.cta-content
 finbold.com##.cta-etoro


### PR DESCRIPTION
Hides CTA ads.
This pull request fixes #14040.