### PR TITLE
A: `heavybit.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -406,6 +406,7 @@
 ||formula1.com/api/track
 ||foursquare.com/v2/private/logactions
 ||foxsports.com.au/akam/
+||fp.heavybit.com^
 ||fp.measure.office.com^
 ||fpa-cdn.adweek.com^
 ||fpa-cdn.arstechnica.com^


### PR DESCRIPTION
The domain `fp.heavybit.com` is used to track page impressions.

This pull request fixes #14187.