### PR TITLE
A: `kooapp.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -94,6 +94,7 @@
 ||analytics.global.sky.com^
 ||analytics.hashnode.com^
 ||analytics.kaggle.io^
+||analytics.kooapp.com^
 ||analytics.makeitmeme.com^
 ||analytics.ml.homedepot.ca^
 ||analytics.mouthshut.com^


### PR DESCRIPTION
The domain `analytics.kooapp.com` is used to track video impressions. At the very least, it tracks client ID, video events, and screen size.

This commit fixes #14198.