### PR TITLE
A: `infobyip.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -467,6 +467,7 @@ news18.com##.nhsocial
 nist.gov##.nist-social__wrapper
 trendy.letudiant.fr##.nl-social
 nowness.com##.nn-join-us__col
+infobyip.com##.noprint
 nerdnomads.com,stationx.net##.ns-share-count
 crypto-news-flash.com##.nso_single_social
 foodnetwork.com##.o-SocialShare


### PR DESCRIPTION
Hides social banner.

<details>

<summary>Screenshot:</summary>

![infobyip](https://github.com/easylist/easylist/assets/115052854/9f8b55e3-c2fd-422c-8bcb-e6209c9b5997)

</details>

This pull request fixes #14230.