### PR TITLE
A: `game.co.uk`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -113,6 +113,7 @@
 ||firstblackphase.com^
 ||fleraprt.com^
 ||fn-pz.com^
+||fourtimessmelly.com^
 ||fpapi.io^
 ||fpcdn.io^
 ||fptls.com^
@@ -3750,7 +3751,6 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||fortunatemark.com^
 ||fourarithmetic.com^
 ||fourfork.com^
-||fourtimessmelly.com^
 ||frailflock.com^
 ||frailfruit.com^
 ||frailoffer.com^

--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -3750,6 +3750,7 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||fortunatemark.com^
 ||fourarithmetic.com^
 ||fourfork.com^
+||fourtimessmelly.com^
 ||frailflock.com^
 ||frailfruit.com^
 ||frailoffer.com^


### PR DESCRIPTION
The domain `fourtimessmelly.com` is used to load pixel tracker and send page analytics.

<details>

<summary>Screenshot:</summary>

![game](https://github.com/easylist/easylist/assets/115052854/1db2609d-6a2b-40f7-8157-8cf148aac0d1)

</details>

This pull request fixes #14831.