### PR TITLE
A: `industrialautomationco.com`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -202,6 +202,7 @@
 ||mrpdata.net^
 ||mt48.net^
 ||mxpnl.com^
+||mysingleromance.com^
 ||n0909.com^
 ||native-track.com^
 ||niblewren.co^


### PR DESCRIPTION
The domain `mysingleromance.com` is used to load pixel tracker and send page analytics.

<details>

<summary>Screenshot:</summary>

![industrial](https://github.com/easylist/easylist/assets/115052854/db730ba8-e3d2-4fb7-948d-585889452655)

</details>

This pull request fixes #14837.