### PR TITLE
A: `unogs.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2758,6 +2758,7 @@ publishedreporter.com##.no-bg-box-model
 marketbeat.com##.no-underline
 ferrarichat.com##.node_sponsor
 greyhound-data.com##.non-sticky-publift
+unogs.com##.nordvpnAd
 miniwebtool.com##.normalvideo
 chipchick.com##.noskim.ntv-moap
 4dayweek.io##.notadvert-tile-wrapper


### PR DESCRIPTION
Hides ad banner leftover.
This pull request fixes #15184.