### PR TITLE
A: `appatic.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -23,6 +23,7 @@ doubtnut.com###Desktop_VideoPage_Side_Banner_1-container
 stripes.com###FeatureAd
 howlongagogo.com###FreeStarVideoAdContainer
 titantv.com###GridPlayer
+appatic.com###HTML2
 fanlesstech.com###HTML2 > .widget-content
 fanlesstech.com###HTML3
 fanlesstech.com###HTML4 > .widget-content


### PR DESCRIPTION
Hides advertisement squares.
This pull request fixes #15224.