### PR TITLE
A: `privacyguides.org`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -124,6 +124,7 @@
 ||api-router.kaspersky-labs.com/logger2/metrics/
 ||api.ffm.to/sl/e/$image
 ||api.narrativ.com/favicon.ico
+||api.privacyguides.net^
 ||app-bnkr.b-cdn.net/js/lv.js
 ||app.box.com/app-api/split-proxy/api/metrics
 ||app.box.com/gen204


### PR DESCRIPTION
The domain `api.privacyguides.net` is used to log page-view events. It logs current page, page referrer, and viewport width.

<details>

<summary>Screenshot:</summary>

![privacyguides](https://github.com/easylist/easylist/assets/115052854/eacb1162-7b1c-4abe-91bb-12c4859e08b8)

</details>