### PR TITLE
A: `1000logos.net`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -132,6 +132,7 @@ exportfromnigeria.info###affs
 osdn.net###after-download-ad
 prepostseo.com###after_button_ad_desktop
 amgreatness.com###ag-lead
+1000logos.net###ai_widget-4
 solidtorrents.to###alart-box > .view-box
 alchetron.com###alchetronFreeStarVideoAdContainer
 djchuang.com###amazon3


### PR DESCRIPTION
Hides ad leftover.
This pull request fixes #15259.