### PR TITLE
Update easyprivacy_specific.txt

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1038,6 +1038,7 @@
 ||telemetry.tradingview.com^
 ||tellerreport.com/react/pixel
 ||terabox.com/abdr?
+||termsfeed.com/track/
 ||tgt.maep.ibm.com^
 ||the-sun.com/assets/client/analyticsListeners~
 ||the-sun.com/assets/client/newrelicExperimentTracking~


### PR DESCRIPTION
To address https://github.com/easylist/easylist/issues/15850.
Already added in AdGuard Tracking Protection so far.