### PR TITLE
Update EasyList/EasyPrivacy Third Party

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -3,6 +3,7 @@
 ||1187531871.rsc.cdn77.org^
 ||1675450967.rsc.cdn77.org^
 ||1736253261.rsc.cdn77.org^
+||360playvid.info^$third-party
 ||a-delivery.rmbl.ws^
 ||a.ucoz.net^
 ||ad-serve.b-cdn.net^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1862,6 +1862,7 @@
 ||sync.outbrain.com^$third-party
 ||synergizeonline.net/trackpoint/
 ||syteapi.com/et?
+||t.360playvid.info^
 ||t.91syun.com^
 ||t.a3cloud.net^
 ||t.adx.opera.com^


### PR DESCRIPTION
Address the ad/tracker on `https://www.freeroms.com/sega_dreamcast.htm`.