### PR TITLE
A: `sibnet.ru`

### DIFF
--- a/fanboy-addon/fanboy_social_international.txt
+++ b/fanboy-addon/fanboy_social_international.txt
@@ -544,6 +544,7 @@ ntv.ru###bottomsoc
 dnr-online.ru###footsoc
 rg.ru###rgb_vk
 rg.ru###rgb_yandex-zen_zen
+sibnet.ru###telegram_push
 gidonline.in###soc
 rosphoto.com###widget
 5-tv.ru##._links


### PR DESCRIPTION
Hides telegram overlay.
This pull request fixes #15288.