### PR TITLE
A: `stuff.tv`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1692,7 +1692,9 @@ insurancejournal.com##.bzn
 insidebitcoins.com##.c-FloatingPrompt
 globalnews.ca##.c-ad
 stuff.tv##.c-ad--mpu-bottom
+stuff.tv##.c-ad--mpu-bottom-mobile
 stuff.tv##.c-ad--mpu-top
+stuff.tv##.c-ad--mpu-top-mobile
 zdnet.com##.c-adDisplay_container_incontent-all-top
 tuko.co.ke##.c-adv
 legit.ng##.c-adv--video-placeholder
@@ -3805,6 +3807,7 @@ urbandictionary.com##[aria-label*="Advertise"]
 gab.com##[aria-label*="Sponsored:"]
 thepointsguy.com##[aria-label="Advertisement"]
 wsj.com##[aria-label="Sponsored Offers"]
+stuff.tv##[class$="block-squirrel-embed"]
 everydaykoala.com,playjunkie.com##[class*="__adspot-title-container"]
 everydaykoala.com,playjunkie.com##[class*="__adv-block"]
 barandbench.com##[class*="ad-slot"]


### PR DESCRIPTION
Hides ad banner placeholders.
This pull request fixes #15400.