### PR TITLE
A: just-eat.*

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2121,6 +2121,11 @@ web.dev##web-snackbar
 ! Jimdo
 jimdosite.com##._12d97
 jimdosite.com##._2mmyb
+! Just Eat
+just-eat.co.uk,just-eat.es,justeat.it##div[data-cookie-consent-overlay]
+just-eat.dk##div[data-qa="granular-privacy-settings"]
+just-eat.ie##div[data-qa="jet-privacy-settings"]
+just-eat.ch,just-eat.fr,lieferando.at,lieferando.de,pyszne.pl,takeaway.com,thuisbezorgd.nl##div[data-qa="privacy-settings"]
 ! wayfair
 wayfair.co.uk,wayfair.de,wayfair.ie##.FooterPopups
 ! roninwear.


### PR DESCRIPTION
cookie banners

https://www.just-eat.ch/
https://www.just-eat.co.uk/
https://www.just-eat.dk/
https://www.just-eat.es/
https://www.just-eat.fr/
https://www.just-eat.ie/
https://www.justeat.it/
https://www.lieferando.at/
https://www.lieferando.de/
https://www.pyszne.pl/
https://www.takeaway.com/be
https://www.thuisbezorgd.nl/