### PR TITLE
A: adservers

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -27157,6 +27157,7 @@
 ||gururevenue.com^$third-party
 ||havetohave.com^$third-party
 ||headbidder.net^$third-party
+||head-clickfusion.com^$third-party
 ||headerbidding.ai^$third-party
 ||headerlift.com^$third-party
 ||healthtrader.com^$third-party
@@ -27708,6 +27709,7 @@
 ||vibrantmedia.com^$third-party
 ||videoo.tv^$third-party
 ||videoroll.net^$third-party
+||video.vid4u.org^$third-party
 ||vidverto.io^$third-party
 ||viewtraff.com^$third-party
 ||vlyby.com^$third-party


### PR DESCRIPTION
Adservers, borrowed from AG filters ([here](https://github.com/AdguardTeam/AdguardFilters/blob/de5a62230eb8cee26ef947ce232bb8e4aea442e4/BaseFilter/sections/foreign.txt#L2581) and [here](https://github.com/AdguardTeam/AdguardFilters/blob/de5a62230eb8cee26ef947ce232bb8e4aea442e4/BaseFilter/sections/foreign.txt#L2771C1-L2771C39)). See [discussion](https://github.com/hufilter/hufilter-dev/issues/398)



