### PR TITLE
Remove ethyca from easyprivacy_trackingservers.txt

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1083,7 +1083,6 @@
 ||etahub.com^$third-party
 ||ethn.io^$third-party
 ||ethnio.com^$third-party
-||ethyca.com^$third-party
 ||etp-prod.com^$third-party
 ||etracker.com^$third-party
 ||etrigue.com^$third-party


### PR DESCRIPTION
Also requested via email as well as the forums in https://forums.lanik.us/viewtopic.php?p=166322-ethyca-com#p166322
Copying the text from those here as well
***
Hello,

The following is found on the EasyPrivacy list

`||ethyca.com^$third-party`

Ethyca is the steward of the first (maybe only?) open-source data privacy platform, [Fides](https://github.com/ethyca/fides/) and some of our users recently brought this to our attention. I would like to have it removed as it is impacting users being able to effectively allow their users to control their data privacy choices.

Please let me know if I can answer any questions to help sort this out - thank you!