### PR TITLE
Update easylist_cookie_allowlist_general_hide.txt

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -325,6 +325,7 @@ inspirock.com,loxam.com#@#div.with-cookie
 what3words.com#@#div[class^="CookieNotice"]
 etsy.com#@#div[data-gdpr-consent-prompt]
 facebook.com,messenger.com#@#div[data-testid="cookie-policy-banner"]
+cookielaw.org#@#section.cookie-banner
 ondacero.es#@#sibbo-cmp-layout
 yoigo.com#@#thor-cookies
 ! truste fixes


### PR DESCRIPTION
To unhide a "Create your Cookie Banner" section on cookielaw.org.
![Screenshot from 2023-07-30 16-22-15](https://github.com/easylist/easylist/assets/89158249/e6a78ca7-c47a-4eaa-8f9e-df9d3f126dff)
