### PR TITLE
A: `techspree.net`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2361,6 +2361,7 @@ nameberry.com##.htlad-InContent_Flex
 nameberry.com##.htlad-Leaderboard_Flex
 wtop.com##.hubb-at-rad-header
 huddle.today##.huddle-big-box-placement
+techspree.net##.hustle-popup
 myabandonware.com##.i528
 animenewsnetwork.com##.iab
 atptour.com##.iab-wrapper

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -375,6 +375,7 @@ merriam-webster.com##.active-subscribe
 walletinvestor.com##.ad-align-center
 drugtargetreview.com##.advads-background
 bucketlistjourney.net,goodnewsnetwork.org,guru99.com##.af-form-wrapper
+techspree.net##.after-post
 insidermedia.com##.alert
 algemeiner.com##.alg_subscribe_cont
 voiceofsandiego.org##.amp-wp-be55f39


### PR DESCRIPTION
Hides ad popup and newsletter form.
This pull request fixes #14658 and fixes #15505.