### PR TITLE
A: `copyprogramming.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2258,6 +2258,7 @@ thetimes.co.uk##.gyLkkj
 tvcancelrenew.com##.h-72
 buzzly.art##.h-min.overflow-hidden
 target.com##.h-position-fixed-bottom
+copyprogramming.com##.h-screen
 lyricsmode.com##.h113
 opoyi.com##.hLYYlN
 marketscreener.com##.hPubRight2

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1562,6 +1562,7 @@ dexerto.com##.bg-neutral-grey-4.items-center
 wccftech.com##.bg-square
 wccftech.com##.bg-square-mobile
 wccftech.com##.bg-vertical
+copyprogramming.com##.bg-yellow-400
 biblegateway.com##.bga
 overclock3d.net##.bglink
 bhamnow.com##.bhamn-adlabel
@@ -2670,6 +2671,7 @@ heatmap.news##.middle_leaderboard
 thefastmode.com##.middlebanner
 fruitnet.com##.midpageAdvert
 extremetech.com##.min-h-24
+copyprogramming.com##.min-h-250
 uwufufu.com##.min-h-\[253px\]
 uwufufu.com##.min-h-\[300px\]
 stripes.com##.min-h90


### PR DESCRIPTION
Hides ad banner and ad banner leftover.
This pull request fixes #15511.