### PR TITLE
Add adinplay.workers.dev to adservers list

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -26936,6 +26936,7 @@
 ||adindigo.com^$third-party
 ||adingo.jp^$third-party
 ||adinplay.com^$third-party
+||adinplay.workers.dev^$third-party
 ||adintend.com^$third-party
 ||adinterax.com^$third-party
 ||adinvigorate.com^$third-party


### PR DESCRIPTION
From `gartic.io`:
![image](https://github.com/easylist/easylist/assets/30274161/384f2087-9595-466d-917e-fe475266ffee)

Weirdly, `adinplay.com` does not appear to be blocked even though it is present in the list.