### PR TITLE
A:`allrecipes.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -250,6 +250,7 @@ northcountrypublicradio.org###business
 music-news.com###buy-tickets
 channel4.com###c4ad-Top
 timesofindia.indiatimes.com###c_wdt_sports_rhs_atf_ad_1
+allrecipes.com###cal-app
 bitdegree.org###campaign-modal
 chordify.net###campaign_banner
 coinlisting.info###carousel-example-generic


### PR DESCRIPTION
Advertisement feature on the domain redirecting to 3-rd party providers next to ingredients on this [page for example](https://www.allrecipes.com/recipe/272546/enchilada-baked-chicken-thighs/):
<img width="1054" alt="image" src="https://github.com/easylist/easylist/assets/33602691/361128a9-f63e-4154-973b-e0a8ab98247c">
