### PR TITLE
Revert "Fix for https://thetvdb.com/ #16917"

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -218,6 +218,7 @@
 @@||survey.g.doubleclick.net^$script,domain=sporcle.com
 @@||thdstatic.com/experiences/local-ad/$domain=homedepot.com
 @@||thepiratebay.org/cdn-cgi/challenge-platform/$~third-party
+@@||thetvdb.com/banners/$image,domain=tvtime.com
 @@||thingiverse.com/assets/ad/$image,~third-party
 @@||townhall.com/resources/dist/js/prebid-pjmedia.js$script,domain=pjmedia.com
 @@||tractorshed.com/photoads/upload/$~third-party

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3600,7 +3600,7 @@ _WebBannerAd_
 _widget_ad.
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
-||com/banners/$image,object,subdocument,domain=~pingdom.com|~tooltrucks.com
+||com/banners/$image,object,subdocument,domain=~pingdom.com|~thetvdb.com|~tooltrucks.com
 ||online.*/promoredirect?key=
 ! https://github.com/easylist/easylist/issues/11123
 /ed/fol457.


### PR DESCRIPTION
Reverts easylist/easylist#16918
@ryanbr Sorry for the broken PR, this actually broke https://thetvdb.com/

My intention was to be able to embed images from their website onto other origins and i misunderstood how the rule worked...

I'm not sure how to allow their images to be embedded without being blocked by the rules, any help would be useful