### PR TITLE
Fix for https://thetvdb.com/

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -3600,7 +3600,7 @@ _WebBannerAd_
 _widget_ad.
 ||cacheserve.*/promodisplay/
 ||cacheserve.*/promodisplay?
-||com/banners/$image,object,subdocument,domain=~pingdom.com|~tooltrucks.com
+||com/banners/$image,object,subdocument,to=~pingdom.com|~thetvdb.com|~tooltrucks.com
 ||online.*/promoredirect?key=
 ! https://github.com/easylist/easylist/issues/11123
 /ed/fol457.


### PR DESCRIPTION
@ryanbr Sorry for [the previous PR](https://github.com/easylist/easylist/pull/16918), it actually broke https://thetvdb.com/, I misunderstood how the rules worked.

This PR actually does what i wanted to do originally, which is to allow 3rd parties to embed images from these sources
