### PR TITLE
A:`macys.com`

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -75,7 +75,7 @@ dailymail.co.uk,namesecure.com#@#.adHolder
 hdfcbank.com#@#.adLink
 seznam.cz#@#.adMiddle
 aggeliestanea.gr,infotel.ca#@#.adResult
-news24.jp#@#.adText
+macys.com,news24.jp#@#.adText
 clien.net#@#.ad_banner
 sozai-good.com#@#.ad_block
 panarmenian.net#@#.ad_body


### PR DESCRIPTION
Hi, could you please add the filter to the existing allowlisting filter.  The generic filter is hiding one of the websites heading at the moment: 
![image](https://github.com/easylist/easylist/assets/33602691/536c84a0-bb8a-4671-9270-a8c056871ebf)
Thank you