### PR TITLE
A: manuals.co.uk (generic block)

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -1162,6 +1162,7 @@
 /adunits.
 /adunits/*
 /adunits?
+/adunit/track-view
 /adUnitsBreakpoints.
 /adUnitsData.
 /adunix.


### PR DESCRIPTION
Sample page:

https://www.manuals.co.uk/

Others:

`bedienungsanleitu.ng|bruksanvisni.ng|bruksanvisningpdf.no|handleidi.ng|hasznalati-utasitasok.hu|huang-dan.vn|instrukcjaobslugipdf.pl|juhend.ee|kayttooh.je|kullanimkilavuzu.com.tr|manua.ls|manual.ar|manual.bo|manual.com.ve|manual.cr|manual.do|manual.ec|manual.gt|manual.hn|manual.md|manual.nz|manual.pa|manual.pe|manual.sv|manualdeinstructiuni.ro|manualeduso.it|manuales.com.co|manuales.mx|manualpdf.cl|manualpdf.co.il|manualpdf.com.br|manualpdf.es|manualpdf.ge|manualpdf.in|manualpdf.pt|manuals.ca|manuals.co.uk|manualspdf.ru|manualypdf.cz|modesdemploi.fr|pdfmanualer.dk|petunjuk.co.id|prirocnikpdf.si|prirucky.sk|prirucnici.hr|qollanmalar.uz|rokasgramataspdf.lv|udhezimet.al|uputstvo.rs|usermanuals.au|vadovaspdf.lt|xn----2lbcmca4cdtsdb1c.gr|xn--80aweql3c59aea5q.xn--80ao21a|xn--80apbinjhb8d.xn--d1alf|xn--80adah2aybmok5f.bg|xn--80aaexjatkpdggghih8b1a2yhv.com.ua|xn--l2bmcno7cen.xn--i1b6b1a6a2e|xn--vg1b14l6tk.xn--3e0b707e`