### PR TITLE
Update easylist_specific_hide.txt

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2558,7 +2558,7 @@ lookbook.nu##.leaderboard_container
 rottentomatoes.com##.leaderboard_wrapper
 gpfans.com##.leaderboardbg
 ubergizmo.com##.leaderboardcontainer
-dailyegyptian.com,northernstar.info,theprospectordaily.com##.leaderboardwrap
+dailyegyptian.com,northernstar.info,theorion.com,theprospectordaily.com##.leaderboardwrap
 dnsleak.com##.leak__submit
 homehound.com.au##.left-banner
 republicbroadcasting.org##.left-sidebar-padder > #text-8


### PR DESCRIPTION
To address the ad placeholder on theorion.com.
![Screenshot from 2023-08-15 18-51-35](https://github.com/easylist/easylist/assets/89158249/de5957b0-7df9-4052-9441-de231fab61ee)
