### PR TITLE
A: `kvak.io`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2318,6 +2318,7 @@
 ||simpleanalytics.io^$third-party
 ||simpleanalyticsbadge.com^$third-party
 ||simpleanalyticscdn.com^$third-party
+||simpleanalyticsexternal.com^$third-party
 ||simplehitcounter.com^$third-party
 ||simplereach.com^$third-party
 ||simpli.fi^$third-party


### PR DESCRIPTION
The domain `simpleanalyticsexternal.com` is used to load third party analytics script and pixel tracker. At the very least, it tracks host name, user agent, time zone, path name, view port size, screen size, browser language, and page-view events.