### PR TITLE
A: _vercel/insights/*

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3680,10 +3680,10 @@ _social_tracking.js
 _stat.php?referer=
 _stat_counter.php?
 _trackWebtrekkEvents.
+_vercel/insights/*
 _view_pixel&$image
 _webanalytics.
 _WebVitalsReporter_
-_vercel/insights/*
 ! Facebook pixels
 /ajax/bnzai?_
 /ajax/bz?_

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3683,6 +3683,7 @@ _trackWebtrekkEvents.
 _view_pixel&$image
 _webanalytics.
 _WebVitalsReporter_
+_vercel/insights/*
 ! Facebook pixels
 /ajax/bnzai?_
 /ajax/bz?_


### PR DESCRIPTION
Adds `_vercel/insights/*` route to general easyprivacy list

Description of their analytics service can be found here: https://vercel.com/docs/concepts/analytics

On quickstart page they specifically list proposed route https://vercel.com/docs/concepts/analytics/quickstart

You can check if it works on following websites:
- https://agentgpt.reworkd.ai/
- https://nodejs.org/en
- https://formik.org/