### PR TITLE
A: `birdsend.net`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -342,6 +342,7 @@
 ||bi.medscape.com^
 ||birdsend.co/assets/static/js/pixel/
 ||birdsend.email/pixel
+||birdsend.net/o/$image,third-party
 ||birdsend.net/pixel
 ||bit.ly/stats?
 ||bitrix.info/ba.js


### PR DESCRIPTION
Blocks email tracking pixel.
This pull request fixes https://github.com/easylist/easylist/issues/15584.