### PR TITLE
A: `kiz10.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1279,6 +1279,7 @@ dnaindia.com,wionews.com##.ads-box-970x90
 dnaindia.com,wionews.com##.ads-box-d90-m300
 gosunoob.com,indianexpress.com,roblox.com,spotify.com,wccftech.com##.ads-container
 fintech.tv##.ads-img
+kiz10.com##.ads-medium
 gameshub.com##.ads-slot
 wallpapers.com##.ads-unit-fts
 auto.hindustantimes.com##.adsHeight300x600
@@ -1679,12 +1680,14 @@ timesofindia.com##.bottomnative
 canonsupports.com##.box
 filmbooster.com,ghacks.net##.box-banner
 mybroadband.co.za##.box-sponsored
+kiz10.com##.box-topads-x2
 fctables.com##.box-width > .hidden-xs
 wahm.com##.box2
 flashscore.co.za##.boxOverContent--a
 flashscore.co.uk,soccer24.com##.boxOverContent__banner
 tribunnews.com##.box__reserved
 functions-online.com##.box_wide
+kiz10.com##.boxadsmedium
 retailgazette.co.uk##.boxzilla-overlay
 retailgazette.co.uk##.boxzilla-popup-advert
 wbur.org##.bp--native

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -972,6 +972,7 @@ paradisehill.cc##.block-to-top
 bravotube.net##.btn-up
 qmul.ac.uk##.btt__inner
 staples.ca##.button--back-to-top
+kiz10.com##.button-gotop
 movehub.com##.button-scroll
 tech.co##.button-scroll-top
 urbanoutfitters.com##.c-pwa-back-to-top__icon


### PR DESCRIPTION
Hides web ad placeholders, mobile ad placeholders, and scroll to top button. 
This pull request fixes https://github.com/easylist/easylist/issues/15588.