### PR TITLE
A: `pdfforge.org`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -1517,6 +1517,7 @@
 ||journity.com^$third-party
 ||js-delivr.com^$third-party
 ||jstracker.com^$third-party
+||jtracking.lulusoft.com^$third-party
 ||jumplead.com^$third-party
 ||jumplead.io^$third-party
 ||junta.net^$third-party


### PR DESCRIPTION
Blocks tracking script.
This pull request fixes https://github.com/easylist/easylist/issues/15615.