### PR TITLE
A: `tuna.voicemod.net`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -228,6 +228,7 @@
 ||app.carnow.com/dealers/track_visitor
 ||app.link/_r?$script,third-party
 ||app.opmnstr.com/v2/geolocate/
+||app.sealmetrics.com/tag/tracker^
 ||app.yesware.com/t/$third-party
 ||appdynamics.com/geo/$third-party
 ||appinthestore.com/click/


### PR DESCRIPTION
Blocks tracking script.
This pull request fixes https://github.com/easylist/easylist/issues/15868.