### PR TITLE
A: `bl.uk`

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1018,7 +1018,7 @@ simpleflying.com##.pk-icon-up
 hackread.com,hightimes.com##.pk-scroll-to-top
 muslimshop.fr##.return-top
 timesofmalta.com##.scroll-notification-container
-carscoops.com,piunikaweb.com##.scroll-top
+bl.uk,carscoops.com,piunikaweb.com##.scroll-top
 game-news24.com,manilatimes.net##.scroll-up
 toyota.co.uk,toyota.ie##.scrollTo
 gadgets360.com##.scrollToTop


### PR DESCRIPTION
Hides scroll to top button.
This pull request fixes https://github.com/easylist/easylist/issues/15889.