### PR TITLE
A:`sport24.gr`

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -15657,6 +15657,7 @@
 ##div[id^="gpt_ad_"]
 ##div[id^="lazyad-"]
 ##div[id^="optidigital-adslot"]
+##div[id^="pa_sticky_ad_box_middle_"]
 ##div[id^="rc-widget-"]
 ##div[id^="sticky_ad_"]
 ##div[id^="vuukle-ad-"]


### PR DESCRIPTION
Hi, could you please add this filter to the generic.  I know the domain is greek but this popping empty placeholders are truly disturbing users view for example here: `https://www.sport24.gr/football/ `
![image](https://github.com/easylist/easylist/assets/33602691/52bda626-074a-40cc-bf5c-00dd0039d12b)
Thank you