### PR TITLE
A: `hiphopkit.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -757,6 +757,7 @@ firmwarefile.com###spon
 progressillinois.com,slitaz.org###sponsor
 meteocentrale.ch###sponsor-info
 newsfirst.lk###sponsored-content-1
+hiphopkit.com###sponsored-sidebar
 techmeme.com###sponsorposts
 fastseduction.com,geekwire.com,landreport.com,whenitdrops.com###sponsors
 ourworldofenergy.com###sponsors_container

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4662,6 +4662,7 @@ bollyflix.loan,downloadlagu321.site,dramacool.sr,streamingcommunity.mom,uwatchfr
 dexdotexe.com##iframe[title="Top Games"]
 premiumtimesng.com##img[alt$=" Ad"]
 windycitymediagroup.com,windycitytimes.com##img[alt*="Sponsor"]
+hiphopkit.com##img[alt="Zappy"]
 therainbowtimesmass.com##img[alt="banner ad"]
 thebradentontimes.com##img[class^="custom_adgroup_"]
 nepallivetoday.com,wjr.com##img[height="100"]


### PR DESCRIPTION
Hides ad banner and ad banner leftover.
An example of the ad banner can be found in `https://hiphopkit.com/music-mp3/digga-d-cherish-god-more/`
This pull request fixes https://github.com/easylist/easylist/issues/15910.