### PR TITLE
A: `kkam.com`

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -2285,6 +2285,7 @@
 ###bottom-adspot
 ###bottom-advertising
 ###bottom-boxad
+###bottom-not-ads
 ###bottom-side-ad
 ###bottom-sponsor-add
 ###bottom-story-ad-0

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -591,6 +591,7 @@
 ||kayak.*/vestigo/measure
 ||kbb.com/pixall/
 ||kck.st/web/track
+||kkam.com/rest/high/api/cogitoergosum^
 ||klm.us/CWZUvc/
 ||kloth.net/images/pixel.gif
 ||kohls.com/mtFndb/


### PR DESCRIPTION
Blocks first-party page-view logging and hides ad banner placeholder. 
This pull request fixes https://github.com/easylist/easylist/issues/15942.