### PR TITLE
A: `boredbro.com`

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -21,6 +21,7 @@
 ###AdBottomLeader
 ###AdBottomRight
 ###AdBox2
+###AdBox728
 ###AdColumn
 ###AdContainerTop
 ###AdContent


### PR DESCRIPTION
Hides ad banner placeholder.
This pull request fixes https://github.com/easylist/easylist/issues/15966.