### PR TITLE
A: `d1f0tbk1v3e25u.cloudfront.net`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2379,6 +2379,7 @@
 ||d1cdnlzf6usiff.cloudfront.net^
 ||d1clfvuu2240eh.cloudfront.net^
 ||d1cr9zxt7u0sgu.cloudfront.net^
+||d1f0tbk1v3e25u.cloudfront.net^
 ||d1f1eryiqyjs0r.cloudfront.net^*/track.
 ||d1gp8joe0evc8s.cloudfront.net^
 ||d1k8sb4xbepqao.cloudfront.net^


### PR DESCRIPTION
Blocks pixel tracker.
This pull request fixes https://github.com/easylist/easylist/issues/16013.