### PR TITLE
A: `eweek.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -231,6 +231,7 @@ forum.wordreference.com###botSupp
 coinarbitragebot.com###botfix
 cheese.com,investorplace.com###bottom-banner
 000webhost.com###bottom-banner-with-counter-holder-desktop
+eweek.com###bottom-footer-fixed-slot
 audioreview.com###bottom-leaderboard
 reverso.net###bottom-mega-rca-box
 nytimes.com,nytimesn7cgmftshazwhfgzm37qxb44r64ytbb2dj3x62d2lljsciiyd.onion###bottom-wrapper


### PR DESCRIPTION
Hides ad banner leftover.
This pull request fixes https://github.com/easylist/easylist/issues/16058.