### PR TITLE
Allow 4gtv video streaming

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -504,6 +504,7 @@
 @@||scan-manga.eu/*pageID=$~third-party
 @@||search.spotxchange.com/vmap/*&content_page_url=www.bsfuji.tv$xmlhttprequest,domain=imasdk.googleapis.com
 @@||searchad.naver.com^$~third-party
+@@||service.4gtv.tv/4gtv/Data/GetAD.ashx$xhr,domain=www.4gtv.tv
 @@||site-banner.hange.jp/adshow?$domain=animallabo.hange.jp
 @@||smartadserver.com/genericpost$domain=filmweb.pl
 @@||so-net.ne.jp/access/hikari/minico/ad/images/$~third-party


### PR DESCRIPTION
4gtv requires IP address in Taiwan.

For issue that other have reported, please see:
https://github.com/AdguardTeam/AdguardFilters/issues/33755