### PR TITLE
Update fanboy_newsletter_specific_hide.txt

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -229,6 +229,7 @@ clutchpoints.com###sib-form
 mv-voice.com###side-block-01
 mv-voice.com,paloaltoonline.com###side-block-02
 mv-voice.com,paloaltoonline.com###side-block-04
+shieldsgazette.com###sidebar-newsletter-signup
 permanentstyle.com###signUpWrapperOuter
 washingtonmonthly.com###signup
 livenation.co.nz###signup-component


### PR DESCRIPTION
`https://www.shieldsgazette.com/news/transport/south-tyneside-closed-roads-the-full-list-of-closed-roads-for-the-2023-great-north-run-4275290`
![Screenshot from 2023-09-02 16-59-42](https://github.com/easylist/easylist/assets/89158249/de8679a0-5dc5-4732-b242-a6bbe86bda50)
