### PR TITLE
Fix a small typo in figma domain name. Related to #16413

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -405,6 +405,7 @@
 ||fc2.com/ana/processor.php?
 ||fc2.com/counter_img.php?
 ||fdt.kraken.com^
+||figma.com/api/figment-proxy/
 ||filext.com/pageview^
 ||findmatches.com/bts.js
 ||findmatches.com/t/tr/lp/intg.js?
@@ -534,7 +535,6 @@
 ||icgp.ie/overview/js/tracker.php
 ||idiva.com/analytics_
 ||iedc.fitbit.com^
-||igma.com/api/figment-proxy/
 ||ih.newegg.com^
 ||iheart.com/api/v3/playback/reporting
 ||ihg.com/logging/


### PR DESCRIPTION
Related to this request https://github.com/easylist/easylist/issues/16413