### PR TITLE
A:`fmovies.wtf`

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -1,4 +1,5 @@
 /asgg.php$domain=ghostbin.me|paste.fo
+/assets/bn/movie.jpg$image,domain=vidstream.pro
 ||0xtracker.com/assets/advertising/
 ||123.manga1001.top^
 ||123animehub.cc/final


### PR DESCRIPTION
Hi 👋  could you please add this filter to the list. There are a couple of domains in which this image ad is embedded into the play/pause function and redirects the user to 3rd-party domains. For example:
- https://fbox.to/tv/one-piece-mjxqz/1-1
- https://fmovies.wtf/movie/indiana-jones-and-the-dial-of-destiny-ro2jn/1-1
- https://hurawatch.at/movie/meg-2-the-trench-x1kkq/1-1
The blank space is still there, but at least it's not redirecting anymore.
<img width="1320" alt="image" src="https://github.com/easylist/easylist/assets/33602691/4d55f365-82fa-482b-8a66-cc3c06b13bf7">
