### PR TITLE
A: `scribd.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -916,6 +916,8 @@
 ||sciencechannel.com/events/
 ||scloud.online/stat/
 ||scoot.co.uk/ajax/log_
+||scribd.com/documents/*/pingback^
+||scribd.com/log/dd^
 ||search.anonymous.ads.brave.com^
 ||search.aol.com/beacon/
 ||search.brave.com/api/feedback$~third-party


### PR DESCRIPTION
Blocks first-party logging and ping.
A ping-back request can be seen when reading any book preview. 
An example page would be `https://www.scribd.com/read/219884515/Arch-Linux-Fast-and-Light`.
This pull request fixes https://github.com/easylist/easylist/issues/16062.