### PR TITLE
A: `nrc.no`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -172,6 +172,7 @@
 ||analytics.salesanalytics.io^
 ||analytics.shareaholic.com^
 ||analytics.shorte.st^
+||analytics.shorthand.com^
 ||analytics.sitewit.com^
 ||analytics.sleeknote.com^
 ||analytics.snidigital.com^


### PR DESCRIPTION
Blocks tracking script.
This pull request fixes https://github.com/easylist/easylist/issues/16064.