### PR TITLE
A: `support.shorthand.com`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -805,6 +805,7 @@
 ||events.btw.so^
 ||events.demoup.com^
 ||events.devcycle.com^
+||events.elev.io^
 ||events.flagship.io^
 ||events.jokerly.com^
 ||events.jotform.com^


### PR DESCRIPTION
The domain `events.elev.io` is used to send page analytics. At the very least, it tracks user ID, page referrer, time zone, and view port size.