### PR TITLE
A: `weatherboy.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -320,7 +320,7 @@ eetimes.eu,miloserdov.org###custom_html-16
 budgetbytes.com,ets2.lt,miloserdov.org###custom_html-2
 sonyalpharumors.com###custom_html-25
 mostlyblogging.com,sarkarideals.com,tvarticles.me###custom_html-3
-colombiareports.com,filmschoolrejects.com,hongkongfp.com,phoneia.com,sarkarideals.com###custom_html-6
+colombiareports.com,filmschoolrejects.com,hongkongfp.com,phoneia.com,sarkarideals.com,weatherboy.com###custom_html-6
 medievalists.net###custom_html-7
 noqreport.com###custom_html-7 > .custom-html-widget
 theteche.com###custom_html-8


### PR DESCRIPTION
Hides ad box placeholder.
This pull request fixes https://github.com/easylist/easylist/issues/16088.