### PR TITLE
A: `playstore.pw`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -312,7 +312,7 @@ asmag.com###ctl00_en_footer1_bannerPopUP1_panel_claudebro
 digit.in###cubewrapid
 wolfstream.tv###customAnnouncement
 miloserdov.org,playstore.pw,reneweconomy.com.au,wpneon.com###custom_html-10
-miloserdov.org###custom_html-11
+miloserdov.org,playstore.pw###custom_html-11
 theregister.co.nz###custom_html-13
 colombiareports.com,miloserdov.org,mostlyblogging.com###custom_html-14
 mostlyblogging.com,sonyalpharumors.com###custom_html-15

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -311,7 +311,7 @@ croxyproxy.rocks###croxyExtraZapper
 asmag.com###ctl00_en_footer1_bannerPopUP1_panel_claudebro
 digit.in###cubewrapid
 wolfstream.tv###customAnnouncement
-miloserdov.org,reneweconomy.com.au,wpneon.com###custom_html-10
+miloserdov.org,playstore.pw,reneweconomy.com.au,wpneon.com###custom_html-10
 miloserdov.org###custom_html-11
 theregister.co.nz###custom_html-13
 colombiareports.com,miloserdov.org,mostlyblogging.com###custom_html-14


### PR DESCRIPTION
Hides desktop and mobile ad placeholder.
This pull request fixes https://github.com/easylist/easylist/issues/16140.