### PR TITLE
A: `messitv.net`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -25,12 +25,14 @@ howlongagogo.com###FreeStarVideoAdContainer
 titantv.com###GridPlayer
 appatic.com###HTML2
 fanlesstech.com###HTML2 > .widget-content
+messitv.net###HTML23
 fanlesstech.com###HTML3
 fanlesstech.com###HTML4 > .widget-content
 fanlesstech.com###HTML5 > .widget-content
 fanlesstech.com###HTML6 > .widget-content
 breitbart.com###HavDW
 sitelike.org###HeaderAdsenseCLSFix
+messitv.net###Image5
 newstarget.com###Index06 > .Widget
 newstarget.com###Index07 > .Widget
 fortune.com###Leaderboard0


### PR DESCRIPTION
Hides ad banner and ad banner placeholder.
This pull request fixes https://github.com/easylist/easylist/issues/16141.