### PR TITLE
A: `scrolller.com`

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -388,6 +388,7 @@
 ||storage.googleapis.com/adtags/
 ||storage.googleapis.com/ba_utils/stab.js
 ||storage.googleapis.com/cdn.newsfirst.lk/advertisements/$domain=newsfirst.lk
+||stratos.blue^$third-party
 ||stunserver.net/frun.js
 ||sunflowerbright104.io/sdk.js
 ||supply.upjers.com^

--- a/fanboy-addon/fanboy_annoyance_specific_block.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_block.txt
@@ -10,7 +10,7 @@
 ||js.dhresource.com/survey/$domain=dhgate.com
 ||neighbourly.co.nz/stuff/
 ||newegg.com/newegg/survey/
-||photon.scrolller.com/scrolller^$image,media
+||photon.scrolller.com/scrolller^
 ||planelogger.com/Content/Images/avitop6.gif
 ||pornve.com/img/300x250f.gif
 ||psyche.co/_next/static/chunks/SupportBannerHeader.

--- a/fanboy-addon/fanboy_annoyance_specific_block.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_block.txt
@@ -10,6 +10,7 @@
 ||js.dhresource.com/survey/$domain=dhgate.com
 ||neighbourly.co.nz/stuff/
 ||newegg.com/newegg/survey/
+||photon.scrolller.com/scrolller^$image,media
 ||planelogger.com/Content/Images/avitop6.gif
 ||pornve.com/img/300x250f.gif
 ||psyche.co/_next/static/chunks/SupportBannerHeader.

--- a/fanboy-addon/fanboy_notifications_specific_ABP.txt
+++ b/fanboy-addon/fanboy_notifications_specific_ABP.txt
@@ -1,1 +1,3 @@
 ! ABP-specific fixes
+scrolller.com#?#.popup:-abp-has([class^="PremiumCTAPopup"])
+scrolller.com#?#.popup:-abp-has(> #recommendations__popup)

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -305,7 +305,7 @@ sbs.com.au##.pane-bean-in-house-ad
 islambook.com##.panel-danger
 dahuasecurity.com##.partners
 shazam.com##.phones
-pocketnet.app,scrolller.com##.popup
+pocketnet.app##.popup
 m.bilibilicomics.com##.popup-wrapper
 m.bilibilicomics.com##.primary.action-bar
 paveldogreat.github.io##.promo

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -305,7 +305,7 @@ sbs.com.au##.pane-bean-in-house-ad
 islambook.com##.panel-danger
 dahuasecurity.com##.partners
 shazam.com##.phones
-pocketnet.app##.popup
+pocketnet.app,scrolller.com##.popup
 m.bilibilicomics.com##.popup-wrapper
 m.bilibilicomics.com##.primary.action-bar
 paveldogreat.github.io##.promo


### PR DESCRIPTION
This pull request
- blocks third-party ad bidding script,
- blocks premium self-advertisement, inserted between media squares, and
- hides recommendation overlay, shown after scrolling far enough.

<details>

<summary>An example of the premium self-advertisement</summary>

![premium-self-advertisement](https://github.com/easylist/easylist/assets/115052854/bf0400cd-e545-4312-9df1-f7585bff2adf)

</details>

<details>

<summary>An example of the recommendation overlay</summary>

![recommendation-overlay](https://github.com/easylist/easylist/assets/115052854/37f098dd-b291-4261-979c-32bd66048829)

</details>

This pull request fixes https://github.com/easylist/easylist/issues/16149.