### PR TITLE
A: `yidio.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3767,6 +3767,7 @@ coinmarketcap.com##.trending-sponsored
 livemint.com##.trendingSimilarHeight
 naturalblaze.com##.trfkye8nxr
 thumbsnap.com##.ts-blurb-wrap
+yidio.com##.tt
 telegraphindia.com##.ttdadbox310
 venturebeat.com##.tude-cw-wrap
 tutorialink.com##.tutorialink-ad1


### PR DESCRIPTION
Hides ad banner.
This pull request fixes https://github.com/easylist/easylist/issues/16159.