### PR TITLE
A: `github.dev`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -471,6 +471,7 @@
 ||gettyimages.*/pulse$ping
 ||ghacks.net/statics/px.gif
 ||github.com/_private/browser/stats
+||github.dev/diagnostic?
 ||glassdoor.*/geb/events/
 ||glassmoni.researchgate.net^
 ||global.canon/00cmn/js/*/analytics-


### PR DESCRIPTION
The endpoint `github.dev/diagnostic` is used to receive page analytics. At the very least, it tracks browser, operating system, location, session identifier, and session identifier.