### PR TITLE
A:`thingstodovalencia.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -410,6 +410,7 @@ engadget.com###gemini-right-rail-thumbnails
 investing.com###generalOverlay
 getvideobot.com###getvideobot_com_300x250_responsive
 getvideobot.com###getvideobot_com_980x250_billboard_responsive
+thingstodovalencia.com###getyourguide-widget
 glowstery.com###ghostery-highlights
 freegames.org###gla
 wordcounter.net###glya
@@ -2300,6 +2301,7 @@ investing.com##.generalOverlay
 perfectdailygrind.com##.gengpdg
 perfectdailygrind.com##.gengpdg-col
 perfectdailygrind.com##.gengpdg-single
+thingstodovalencia.com###.get-your-guide
 flickr.com##.getty-search-view
 flickr.com##.getty-widget-view
 thehackernews.com##.gg-1


### PR DESCRIPTION
On this article `https://www.thingstodovalencia.com/who-is-santiago-calatrava/` on the right side there is a `get your guide` widget, both filters are required because once the id is hidden the class is being displayed:
![image](https://github.com/easylist/easylist/assets/33602691/ad7c5117-1a8b-4b23-936e-41f3699e41a6)
