### PR TITLE
only block tracking endpoint of koko analytics

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1493,7 +1493,7 @@
 /KISSmetricsTrackCode.
 /klaviyo_analytics.
 /KochavaAnalytics.
-/koko-analytics-
+/koko-analytics-collect
 /koko-analytics/*/script.js
 /kontera.js
 /krux-sass-helper.js


### PR DESCRIPTION
I'm the plugin author of the Koko Analytics plugin for WordPress, which aims to be a privacy-friendly self-hosted website analytics that only does aggregated counts, not anything visitor specific. 

We're currently developing a paid version of the plugin to help sustain its development and support costs, but having the generic `koko-analytics-` line in the EasyList filter breaks our admin pages because our plugin is named `koko-analytics-pro`.

This change only blocks the tracking script (unchanged) and the data collection endpoint (`/koko-analytics-collect`), instead of anything with `koko-analytics-` in it.