### PR TITLE
remove call-a-pizza.de from easylist_cookie_specific_uBO.txt

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1206,11 +1206,6 @@ tether.to##body,html:style(overflow: auto !important; position: initial !importa
 ! tonyschocolonely.com
 tonyschocolonely.com##.cookie-notification
 tonyschocolonely.com##.wrapper--locked:style(position: relative !important;)
-! call-a-pizza.de
-call-a-pizza.de##.fancybox-overlay
-call-a-pizza.de##.overlay
-call-a-pizza.de##+js(rc, blurred, , stay)
-call-a-pizza.de##body,html:style(overflow: auto !important; position: initial !important;)
 ! mader.bz.it
 mader.bz.it##.ae-cookiebanner
 mader.bz.it##body,html:style(overflow: auto !important; position: initial !important;)


### PR DESCRIPTION
I am one of the developers who works on [call-a-pizza.de](https://www.call-a-pizza.de/)

Recently we have heard from customers that the website does not work on the Brave browser, which uses the Easylist by default.

The problem is that the filter list not only removes the cookie message. It removes all popups. This includes information  at startup (like opening hours) and the possibility to add a product to the cart, because there are multiplie choices of extra ingredients.

So, the website is currently completely broken.

We decided to add the id **cookies-fancybox** to our overlay when it's the cookie popup, which is a part of the [easylist_cookie_general_hide.txt](https://github.com/easylist/easylist/blob/29c2d87237cc4a314fe014732aefe85cb38c2f5f/easylist_cookie/easylist_cookie_general_hide.txt#L3892). 
Furthermore we check if the popup has **display: none** to close the popup to get a graceful exit. In this case, only essential cookies are set and no third-party cookies.

Therefore, the old specific definitions are now unnecessary anyway.

Please merge this PR to fix this issue.