### PR TITLE
improve e995f66b6ac49603897a8947176c798dbe00b7c0

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1391,8 +1391,7 @@
 /kissmetrics.js
 /klaviyo_analytics.js
 /koko-analytics-collect.php
-/koko-analytics/assets/dist/js/script.js
-/koko-analytics/assets/dist/js/*.script.js
+/koko-analytics/assets/dist/js/*script.js
 /kontera.js
 /krux-sass-helper.js
 /krux.js

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1391,7 +1391,8 @@
 /kissmetrics.js
 /klaviyo_analytics.js
 /koko-analytics-collect.php
-/koko-analytics/assets/dist/js/*
+/koko-analytics/assets/dist/js/script.js
+/koko-analytics/assets/dist/js/*.script.js
 /kontera.js
 /krux-sass-helper.js
 /krux.js


### PR DESCRIPTION
After e995f66b6ac49603897a8947176c798dbe00b7c0, the issue in #12974 was reintroduced and [people started reporting issues with their dashboard being blocked again](https://wordpress.org/support/topic/koko-tracking-script-blocked-by-adblocker/).

I can see that e995f66b6ac49603897a8947176c798dbe00b7c0 was introduced because listland.com changes the name of the tracking script with a hash prepended, so this change targets just that. This way, the dashboard for people running Koko Analytics (an analytics plugin that only does aggregate counts, nothing visitor specific, so one could argue it shouldn't even be on this list) will keep on working.