### PR TITLE
M: https://www.nytimes.com/

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -677,7 +677,6 @@ luisaviaroma.com##._vgSl0cx4ao
 crossfit.com##._wrapper_1u43b_17
 1ipb.com##.a-warning
 cloudup.com##.a8c-cookie-banner
-nytimes.com##.abe45aa6
 norm.store##.above-pages-container > .animation-container
 nicequest.com##.ac
 presta-module.com##.acbBackdrop
@@ -2173,6 +2172,7 @@ internxt.com##div[class^="Footer_cookiesBgFallback"]
 tinely.com##div[class^="GdprAcceptance_container"]
 porsche.com##div[class^="LegalDisclaimer_"]
 architecturaldigest.com,bonappetit.com,cntraveler.com,gq.com,newyorker.com,pitchfork.com,self.com,teenvogue.com,them.us,vanityfair.com,vogue.com,wired.com##div[class^="MessageBannerWrapper-"]
+nytimes.com##div[class^="MX_COMPLY_GDPR_COMPLIANCE_"]
 kurgo.com##div[class^="PrivacyNotice"]
 similarsites.com##div[class^="PrivacyNotification_"]
 podimo.com##div[class^="SmallCookie"]


### PR DESCRIPTION
Hide cookie consent banner and remove obsolete rule (I think it's obsolete).