### PR TITLE
A:`mail.google.com`

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -267,6 +267,7 @@
 @@||gstatic.com/recaptcha/
 @@||hcaptcha.com/captcha/$script,subdocument
 @@||hcaptcha.com^*/api.js
+@@||mail.google.com^$generichide
 @@||recaptcha.net/recaptcha/$script
 @@||search.brave.com/search$xmlhttprequest
 @@||ui.ads.microsoft.com^$~third-party


### PR DESCRIPTION
Hi 🙌 could you please review and add this allowlisting filter for `gmail.com`, as for some of the users on iOS and macOS the conversion of the EL `.ads` gets applied once the user is being redirected to `mail.goog.com` causing a blank screen when trying to open and read any email.
View above the issue: 
<img width="1161" alt="image" src="https://github.com/easylist/easylist/assets/33602691/62634382-fd0c-4844-b556-13dfb1b24928">
Environment: 
- Safari version 17.0.
- MacOs 