### PR TITLE
A: https://www.google.com/url? ping

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -3590,6 +3590,7 @@ omni.soundestlink.com$image
 /csi_204?$image,other,ping,script
 /gen_204?$image,other,ping,script
 /generate_204?$image
+||google.com/url?$ping
 ||google.com/gen_204?
 ||googleapis.com^*/gen_204?
 ||gstatic.com/gen_204?


### PR DESCRIPTION
At least in Chrome, google.com relies on beacons to track user result clicks. 

In Firefox all google.com result links still have javascript handlers that redirect users by google.com/url