### PR TITLE
update: pushpushgo rules

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -3035,7 +3035,7 @@ $third-party,xmlhttprequest,domain=opensubtitles.org
 ||pushmaster-cdn.xyz^
 ||pushowl.com^$third-party
 ||pushprofit.ru^$third-party
-||pushpushgo.com^$third-party
+||api.pushpushgo.com/beacon^$third-party
 ||pushwize.com^$third-party
 ||pushwoosh.com^$third-party
 ||reprocautious.com^$third-party

--- a/fanboy-addon/fanboy_notifications_thirdparty.txt
+++ b/fanboy-addon/fanboy_notifications_thirdparty.txt
@@ -75,7 +75,9 @@
 ||pushpro.io^$third-party
 ||pushprofit.ru^$third-party
 ||pushprospush.com^$third-party
-||pushpushgo.com^$third-party
+||s-eu-1.pushpushgo.com^$third-party
+||s-us-1.pushpushgo.com^$third-party
+||cdn.pushpushgo.com^$third-party
 ||pushstack.it^$third-party
 ||pushtide.com^$third-party
 ||pushvip.ru^$third-party


### PR DESCRIPTION
Hi there,

I am a product owner of pushpushgo services.
There is a pull request that will update our endpoints.

Finally in this PR:
 - blockers will block our popups (js popups)
 - blockers will not block "notifications" for users that want to receive

In some words our domains:
s-eu-1.pushpushgo.com
s-us-1.pushpushgo.com
cdn.pushpushgo.com

Are resoinsible for "showing" js popup <- it will be blocked
api.pushpushgo.com/beacon - is used for tracking <- it will be blocked

all other requests like
api.pushpushgo.com/m/ - get message
api.pushpushgo.com/c/ - get message

will be not blocked and our service will work properly for our clients.

Thanks for approving it,
Regards.