### PR TITLE
fix: remove github copilot promotion button

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -294,6 +294,7 @@ healthboards.com##.sign
 licensing.biz,mobile-ent.biz##.sign-up
 investopedia.com##.signup
 github.com##.signup-prompt
+github.com##button[data-testid="copilot-popover-button"]
 wowway.net##.single-cube_clusters_promo-cluster_hrefWrapper
 theguardian.com##.site-message
 hannity.com##.sitewide-tout


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://github.com/uBlockOrigin/uAssets/blob/master/README.md or any other github file.

### Describe the issue

This removes the "Your organization can pay for GitHub Copilot" or "Code 55% faster with GitHub Copilot" promotion buttons when viewing a file in github web.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/41706133/011829d5-a651-40b0-b764-6f45c49ff987)

![image](https://github.com/uBlockOrigin/uAssets/assets/41706133/0fbc41a7-7996-4d4b-aa82-9458b3cde7d4)

### Versions

- Browser/version: Firefox 118.0.2 / Chromium 118
- uBlock Origin version: 1.52.2

### Settings

defaults + 
- uBlock filters – Annoyances
- uBlock filters – Cookie Notices

### Notes

This is not always shown, especially if you've clicked on the "Don't show again" button before. I see these while I'm signed in with accounts I've not pressed the "Don't show again" button.
