### PR TITLE
Add ads.snapchat.com to popup allow list

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -16,6 +16,7 @@
 @@||ads.midwayusa.com^$popup
 @@||ads.pinterest.com^$popup
 @@||ads.shopee.*/$popup
+@@||ads.snapchat.com^$popup
 @@||ads.spotify.com^$popup
 @@||ads.taboola.com^$popup
 @@||ads.twitter.com^$popup


### PR DESCRIPTION
Hello,

I am an engineer at Snap Inc.

I am requesting that we register our [ads.snapchat.com](https://ads.snapchat.com) website to the popup allow list.  This domain is equivalent to other authenticated ad campaign management websites that are listed in the allow list - e.g. [ads.twitter.com](https://ads.twitter.com/), [ads.google.com](https://ads.google.com/), and [ads.microsoft.com](ads.microsoft.com).

If there is any additional information or context I can provide regarding this request please me know!

Thank you,
Jason
