### PR TITLE
A: `openspeedtest.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -705,6 +705,7 @@ msguides.com###right-bottom-camp
 comicbookrealm.com###right-rail > .module
 purewow.com###right-rail-ad
 gogetaroomie.com###right-space
+openspeedtest.com###rightArea
 medicaldialogues.in###right_level_8
 numista.com###right_pub
 yardbarker.com###right_top_sticky
@@ -904,6 +905,7 @@ globalwaterintel.com###top-banner-image
 independent.co.uk,the-independent.com###top-banner-wrapper
 missingremote.com###top-bar
 returnyoutubedislike.com###top-donors
+openspeedtest.com###top-lb
 capetownmagazine.com###top-leader-wrapper
 austinchronicle.com,carmag.co.za,thegazette.com###top-leaderboard
 gogetaroomie.com###top-space

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -115,6 +115,7 @@ beforeitsnews.com###fancybox-wrap
 miningweekly.com,polity.org.za###fde_bar
 thefederalistpapers.org###firefly-poll-container
 breathedreamgo.com###fluentform_6
+openspeedtest.com###footBox3
 independent.co.uk###footerPrompt
 engineeringnews.co.za###footerbar
 ripleys.com###form_newsletter-blog

--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -47,6 +47,7 @@ memuplay.com###fixed-share
 notquitenigella.com###floatingfacebook
 empoweringparents.com,tvmaze.com###follow
 phillyvoice.com###follow_social
+openspeedtest.com###footBox2
 atlasobscura.com###footer-social-list
 aimp.ru###footer_counter
 cybermap.kaspersky.com###footer_social_channels


### PR DESCRIPTION
This pull request
- hides desktop ad banner leftover, 
- hides mobile ad banner leftover, 
- hides social banner, and 
- hides newsletter form.

This pull request fixes https://github.com/easylist/easylist/issues/16193.