### PR TITLE
A: `romsmania.games`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -931,6 +931,7 @@
 ||roblox.com/report
 ||roblox.com^*/_/1px.gif
 ||rome.api.flipkart.com/api/1/fdp
+||romsmania.games/*/v1/track^
 ||rps-p2.rockpapershotgun.com^
 ||rps-uk.rockpapershotgun.com^
 ||rs.mail.ru^


### PR DESCRIPTION
Blocks tracking endpoint.
This pull request fixes https://github.com/easylist/easylist/issues/16195.