### PR TITLE
A: `linguisticsociety.org`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1920,6 +1920,7 @@ businessinsider.com,insider.com##.commerce-coupons-module
 goal.com,thisislondon.co.uk##.commercial
 telegraph.co.uk##.commercial-unit
 bitdegree.org##.comparison-suggestion
+linguisticsociety.org##.component-3
 goal.com##.component-ad
 hunker.com,livestrong.com##.component-article-section-jwplayer-wrapper
 binnews.com,iheart.com,jessekellyshow.com,steveharveyfm.com##.component-pushdown


### PR DESCRIPTION
Hides ad box leftover.
This pull request fixes https://github.com/easylist/easylist/issues/16196.