### PR TITLE
A: `beforeitsnews.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3350,6 +3350,7 @@ rebelnews.com##.rn-sidebar-ad
 realitytea.com##.roadblock
 surinenglish.com##.roba
 boxrox.com##.rolling-mrt
+beforeitsnews.com##.rotating_text_link
 superhumanradio.net##.rotating_zone
 atalayar.com##.rotulo-publi
 flightconnections.com##.route-display-box

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -166,6 +166,7 @@
 ||beacon.shutterfly.com^
 ||beacon.walmart.com^
 ||beacon.wikia-services.com^
+||beforeitsnews.com/core/ajax/counter/count.php^
 ||behance.net/log
 ||behance.net/v2/logs
 ||bfp.capitalone.com^


### PR DESCRIPTION
Blocks page hit counter and hides ad links.
This pull request fixes https://github.com/easylist/easylist/issues/16197.