### PR TITLE
Fix non-ad video playback from cdn13.com on multiple sites 

### DIFF
--- a/easylist_adult/adult_specific_block.txt
+++ b/easylist_adult/adult_specific_block.txt
@@ -73,7 +73,6 @@
 ||camvideos.tv/tpd.png
 ||camvideos.tv^$subdocument
 ||capetown.xhamster.com^
-||cdn13.com/*.mp4?cdn_creation_time
 ||cdn3x.com/xxxdan/js/xxxdan.vast.
 ||cdnvideo3.com/api/spots/
 ||celeb.gate.cc/assets/bilder/bann


### PR DESCRIPTION
Too broad pattern breaks video playback on sites using cdn13.com for non-ad videos delivery