### PR TITLE
M: Update

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -16826,6 +16826,7 @@
 ||mmotraffic.com^
 ||mmphijndajxiui.com^
 ||mmtnat.com^
+||mmvideocdn.com^
 ||mn1nm.com^
 ||mn230126pb.com^
 ||mnaujmo.com^


### PR DESCRIPTION
Adserver responsible for videos that are unrelated to the content and covers the main image of every article. 

Example: https://hailfloridahail.com/2023/10/27/florida-football-gators-x-factor-uga/ 

List of domains covered:
hailfloridahail.com
hardwoodhoudini.com
highposthoops.com
hoopshabit.com
hotspurhq.com
howlinhockey.com
inn.co.il
insidetheloudhouse.com
jaysjournal.com
jetswhiteout.com
justblogbaby.com
kardashiandish.com
kckingdom.com
keepingitheel.com
kingjamesgospel.com
kingsofkauffman.com
lastnighton.com
lobandsmash.com
lombardiave.com
marlinmaniac.com
maroonandwhitenation.com
milehighsticking.com
mlsmultiplex.com
motorcitybengals.com
musketfire.com
nflmocks.com
ninernoise.com
nolanwritin.com
nothinbutnets.com
nugglove.com
octopusthrower.com
oilonwhyte.com
onechicagocenter.com
orlandomagicdaily.com
paininthearsenal.com
pelicandebrief.com
phinphanatic.com
pippenainteasy.com
pistonpowered.com
playingfor90.com
predlines.com
predominantlyorange.com
princerupertstower.com
progolfnow.com
puckettspond.com
puckprose.com
pucksandpitchforks.com