### PR TITLE
P: 0xacab.org

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -561,7 +561,7 @@
 /advertisment/*$~image
 /advertisment_
 /advertright.
-/adverts.$~script,domain=~adverts.ie|~adverts.org.ua
+/adverts.$~script,domain=~0xacab.org|~adverts.ie|~adverts.org.ua|~github.com|~gitlab.com
 /adverts/*$~xmlhttprequest
 /adverts_
 /advrotator.js


### PR DESCRIPTION
The rule `/adverts.$~script,domain=~adverts.ie|~adverts.org.ua` blocks non-ad requests on two pages, resulting in breakage:
```
https://github.com/duckduckgo/tracker-radar/blob/af63042a7cc32c499b0adf5e2d2958bf641762a0/entities/Adverts.ie.json#L4
https://0xacab.org/dCF/deCloudflare/-/blob/master/subfiles/cloudflared/adverts.md?ref_type=heads
```
In both of these cases, the XmlHTTPRequests loading the content of the file is blocked:
![image](https://github.com/easylist/easylist/assets/84232764/93cb6abb-e7e9-432f-ad4a-049c43ad745b)
![image](https://github.com/easylist/easylist/assets/84232764/63fc327f-3bb8-4b56-9c68-919411dc4f77)
Thus, I have excluded both domains. 0xacab runs GitLab, and I am sure projects including the word "adverts." exist, but I was unable to find a file containing `adverts.` due to GitLab's search being horrible. I have nevertheless excluded it. I can remove it if the lack of an example is problematic.
Thanks