### PR TITLE
M: Fix for #17503

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2054,7 +2054,6 @@ finbold.com##.cta-etoro
 thelines.com##.cta-row
 filerio.in##.ctl25
 seattlepi.com##.ctpl-fullbanner
-namepros.com##.ctrtodbbjp
 apotelyt.com##.cu8ucFitaCon
 apotelyt.com##.cuLinkLoad
 homefinder.com##.cubeContainer
@@ -3018,8 +3017,8 @@ all3dp.com##.notification
 mondoweiss.net##.notrack
 bleepingcomputer.com##.noty_bar
 pcgamebenchmark.com##.nova_wrapper
-namepros.com##.np-ghwe78
-namepros.com##.np-h23NVk
+namepros.com##.np--shadow
+namepros.com##.np-iu34fdg
 nextpit.com##.np-top-deals
 zimbio.com##.npd-video-break
 crypto-news-flash.com##.nso_ad_under_article


### PR DESCRIPTION
Fix for this issue https://github.com/easylist/easylist/issues/17503
`namepros.com##.np--shadow` covers most of the banners on the page
`namepros.com##.np-iu34fdg` left over banner in the middle of the page
Thanks 