### PR TITLE
A:`beyondtheflag.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -480,6 +480,7 @@ robbreport.com###icon-sprite
 maxsports.site,newsturbovid.com###id-custom_banner
 rakuten.com###id_parent_rrPlacementTop
 atishmkv.site###idbannerplayer
+beyondtheflag.com###iFrameResizer2
 fc-lc.xyz,tophostingapp.com###iframe_id
 unitconversion.org###ileft
 4f.to,furbooru.org###imagespns

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -480,7 +480,6 @@ robbreport.com###icon-sprite
 maxsports.site,newsturbovid.com###id-custom_banner
 rakuten.com###id_parent_rrPlacementTop
 atishmkv.site###idbannerplayer
-beyondtheflag.com###iFrameResizer2
 fc-lc.xyz,tophostingapp.com###iframe_id
 unitconversion.org###ileft
 4f.to,furbooru.org###imagespns
@@ -4910,6 +4909,7 @@ drive.com.au##hr
 carls-sims-4-guide.com##hr.post_separator + .windowbg
 avanigo.com##iframe.lazyloaded
 coincodex.com,yourbittorrent.com##iframe[src]
+beyondtheflag.com,buffalowdown.com##iframe[src^="https://tallysight.com/widget/offers/"]
 realgearonline.com##iframe[src^="http://www.adpeepshosted.com/"]
 bollyflix.loan,downloadlagu321.site,dramacool.sr,streamingcommunity.mom,uwatchfre.cam##iframe[style*="z-index: 2147483646"]
 123movies.net,4anime.gg,actvid.com,apkmody.io,batotoo.com,beetoon.net,bollyflix.loan,bravoporn.com,cineb.net,coloredmanga.com,downloadlagu321.site,dragontranslation.com,dramacool.sr,gogoanime.co.in,gogoanime.run,harimanga.com,hds-streaming-hd.com,himovies.to,hurawatch.cc,iflixmovies.lol,instamod.co,jujutsukaisenonline.net,leercapitulo.com,linksly.co,mangadna.com,mangageko.com,mangahere.today,manganatos.com,mangatigre.net,manhuafast.com,manhwadesu.ink,manhwalist.xyz,membed.net,messitv.net,miraculous.to,movies-watch.com.pk,moviesmod.pro,nkiri.com,prmovies.beauty,putlocker.vc,putlockers.fm,putlockers.li,sflix.se,sockshare.ac,ssoap2day.to,streamingcommunity.mom,sukidesuost.info,tamilyogi.bike,uwatchfre.cam,waploaded.com,watchomovies.net,y-2mate.com,yomovies.team,ytmp3.cc,yts-subs.com##iframe[style*="z-index: 2147483647"]


### PR DESCRIPTION
Hi, please add this filter to the list to hide this gaming widget on this page for example `https://beyondtheflag.com/2023/10/26/nascar-one-driver-faces-must-win-situation-martinsville/`: 
<img width="719" alt="image" src="https://github.com/easylist/easylist/assets/33602691/3e52e7e4-a142-40aa-99c3-ecc1de57a67c">
Thanks 