### PR TITLE
A: `livescience.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -250,6 +250,7 @@ agrimag.co.za,androidpolice.com,automart.co.za,maketecheasier.com##.btn-twitter
 agrimag.co.za,androidpolice.com,automart.co.za##.btn-whatsapp
 unz.com##.button-holder
 healthline.com##.button-wrapper
+livescience.com##.buttons-social
 newshub.co.nz##.c-ArticleHeading-actions
 noovomoi.ca##.c-actionsTools
 nature.com##.c-article-extras-additional-links


### PR DESCRIPTION
Hides social buttons.
This pull request fixes https://github.com/easylist/easylist/issues/16243.