### PR TITLE
A: `serverstoplist.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2956,6 +2956,7 @@ birdwatchingdaily.com##.mobile-incontent-ad-label
 businessplus.ie##.mobile-mpu-widget
 forbes.com##.mobile-sticky-ed-placeholder
 pcmacstore.com##.mobileHide
+serverstoplist.com##.mobile_ad
 pinkvilla.com##.mobileads
 thedailybeast.com##.mobiledoc-sizer
 criminaljusticedegreehub.com##.mobius-container
@@ -3194,6 +3195,7 @@ washingtonpost.com##.pb-sm.pt-sm.b
 publicbooks.org##.pb_ads_widget
 recipesandcooker.com##.pbl
 caixinglobal.com##.pc-ad-left01
+serverstoplist.com##.pcOnly
 thefintechtimes.com##.penci-widget-sidebar
 bestbuy.ca##.pencilAd_EE9DV
 thegatewaypundit.com,westernjournal.com,wnd.com##.persistent-footer

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -633,6 +633,7 @@ calvinklein.se,calvinklein.fi,calvinklein.sk,calvinklein.si,calvinklein.ch,calvi
 calvinklein.se,calvinklein.fi,calvinklein.sk,calvinklein.si,calvinklein.ch,calvinklein.ru,calvinklein.com,calvinklein.pt,calvinklein.pl,calvinklein.at,calvinklein.nl,calvinklein.hu,calvinklein.lu,calvinklein.lt,calvinklein.lv,calvinklein.it,calvinklein.ie,calvinklein.hr,calvinklein.fr,calvinklein.es,calvinklein.ee,calvinklein.de,calvinklein.dk,calvinklein.cz,calvinklein.bg,calvinklein.be,calvinklein.co.uk##+js(set-cookie, PVH_COOKIES_GDPR_ANALYTICS, Reject)
 ofdb.de##+js(set-cookie, ofdb_werbung, Y, , reload, 1)
 dtksoft.com##+js(set-cookie, user_cookie_consent, 1)
+serverstoplist.com##+js(set-cookie, STAgreement, 1)
 ! set-local-storage-item
 omroepbrabant.nl##+js(set-local-storage-item, psh:cookies-other, false)
 omroepbrabant.nl##+js(set-local-storage-item, psh:cookies-seen, true)


### PR DESCRIPTION
Hides ad banners and cookie notice.
This pull request fixes https://github.com/easylist/easylist/issues/16403.