### PR TITLE
A: `gameloop.com`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -170,6 +170,7 @@
 ||hs-analytics.net^
 ||hsadspixel.net^
 ||hsleadflows.net^
+||htrace.wetvinfo.com^
 ||hubty.network^
 ||i218435.net^
 ||ia-dmp.com^
@@ -284,6 +285,7 @@
 ||rlcdn.com^
 ||robotflowermobile.com^
 ||rtactivate.com^
+||rumt-sg.com^
 ||s-onetag.com^
 ||salsify-ecdn.com^
 ||sbgsodufuosmmvsdf.info^


### PR DESCRIPTION
Blocks error event logging and pixel trackers.
For further consideration, the endpoint `rumt-sg.com` is part of Tencent's Aegis Web SDK.
Related issue: https://github.com/easylist/easylist/issues/17512.