### PR TITLE
A: `deepnote.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -319,6 +319,7 @@
 ||dd.nytimes.com^
 ||dealnews.com/lw/ul.php
 ||deepl.com/web/statistics
+||deepnote.com/api/track^
 ||deezer.com/ajax/gw-light.php?method=triton.pixelTracking&
 ||deliver.ptgncdn.com^
 ||deliveroo.com^*/events
@@ -1112,6 +1113,7 @@
 ||t.av.st^
 ||t.birchlane.com^
 ||t.dailymail.co.uk^
+||t.deepnote.com^
 ||t.freelancer.com^
 ||t.imgur.com^
 ||t.indeed.com^


### PR DESCRIPTION
Blocks analytics endpoints. The endpoint `t.deepnote.com` requires an account to interact with a notebook. Both endpoints are implementations of `segment.io`'s `analytics.js`. Please refer to the screenshots attached for considerations.

<details>

<summary>`api/track`</summary>

![api-track](https://github.com/easylist/easylist/assets/115052854/74e122a3-e35c-47af-b770-0ea956787831)

</details>

<details>

<summary>`t.deepnote.com`</summary>

![t deepnote com](https://github.com/easylist/easylist/assets/115052854/834e68e3-c96c-496d-9b77-a71d32ef8bca)

</details