### PR TITLE
A: `perplexity.ai`

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -10,6 +10,7 @@
 -adobe-analytics.
 -adobe-analytics/
 -adobeDatalayer_bridge.js
+-beta.perplexity.ai/api^
 -click-tracker.
 -didomi.js
 -geoIP.js

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -841,6 +841,7 @@
 ||pcmag.com/js/z0WVjCBSEeGLoxIxOQVEwQ.min.js
 ||pendo.scopus.com/data/ptm.gif
 ||perf.mouser.com^
+||perplexity.ai/*/metrics^
 ||perr.hola.org^
 ||pf.newegg.com^
 ||ph.thenextweb.com^


### PR DESCRIPTION
Blocks analytics endpoints. The `beta.perplexity.ai` endpoint can be seen at the site's home page. The `/metrics` endpoint can be seen by using the chat model. Both endpoints are implementations of `segment.io`'s `analytics.js`.