### PR TITLE
A: `speed.cloudflare.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -51,6 +51,7 @@
 ||aerlingus.com/ahktqsewxjhguuxe.js
 ||affiliates.vpn.ht^
 ||agoda.net/v2/track
+||aim.cloudflare.com/__log^
 ||airtable.com/internal/
 ||airtel.in/analytics/pixel?
 ||aiv-delivery.net/Events/


### PR DESCRIPTION
Blocks AIM logging endpoint.
This pull request fixes https://github.com/easylist/easylist/discussions/14519.