### PR TITLE
A: `themarshallproject.org`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2264,6 +2264,7 @@
 ||twitter.com/jot.html
 ||twitter.com/oct.js
 ||twitter.com/scribe/
+||typeform.com/*/insights/events^
 ||uadblocker.com/pixel1.php?$third-party
 ||uc.cn/collect?
 ||ucounter.ucoz.net^


### PR DESCRIPTION
Blocks Typeform analytics endpoint.
Here's an accessible test link: `https://www.themarshallproject.org/2022/09/01/they-lost-their-pregnancies-then-prosecutors-sent-them-to-prison`