### PR TITLE
A: `cryptoecom.care`

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -31054,6 +31054,7 @@
 ||croea.com^$third-party
 ||cryptoads.space^$third-party
 ||cryptocoinsad.com^$third-party
+||cryptoecom.care^$third-party
 ||ctrhub.com^$third-party
 ||ctrip.com^$third-party
 ||ctrmanager.com^$third-party


### PR DESCRIPTION
Hides ad banner at bottom of `crypto.news` site.
https://github.com/uBlockOrigin/uAssets/issues/20842