### PR TITLE
A: `iptvinsider.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4003,6 +4003,7 @@ tutorialink.com##.tutorialink-ad2
 tutorialink.com##.tutorialink-ad3
 tutorialink.com##.tutorialink-ad4
 roseindia.net##.tutorialsstaticdata
+iptvinsider.com##.tve-leads-ribbon
 tvtropes.org##.tvtropes-ad-unit
 drivencarguide.co.nz##.tw-bg-gray-200
 todayonline.com##.tw-flex-shrink-2

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1510,6 +1510,7 @@ nymag.com,thecut.com##.text-form-wrapper
 canarymedia.com##.text-gray-600.mt-5.py-4
 nodejs.libhunt.com##.text-strong-invite
 thefederalistpapers.org##.tgp-ic-subscribe-box
+iptvinsider.com##.thrv-leads-form-box
 theinformation.com##.ti-awareness-bar
 them.us##.ticker-view
 ncaa.com##.tile-newsletter

--- a/fanboy-addon/fanboy_social_general_hide.txt
+++ b/fanboy-addon/fanboy_social_general_hide.txt
@@ -11636,6 +11636,7 @@
 ##[data-xtclick^="social::"]
 ##[eapps-link="share"]
 ##a[data-share="popup"]
+##a[href^="//www.facebook.com/sharer/sharer.php"]
 ##a[href^="fb-messenger://share/?"]
 ##a[href^="fb-messenger://share?link="]
 ##a[href^="http://pinterest.com/pin/create/bookmarklet/"]

--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -396,6 +396,7 @@ madamasr.com##.footer_icons_container
 wafa.ps##.footermenu
 helpnetsecurity.com##.fp-hero-block
 moneycontrol.com##.fsoci
+iptvinsider.com##.ft-s
 digitalcontentnext.org##.ft-soc
 alaskahighwaynews.ca,bowenislandundercurrent.com,burnabynow.com,coastreporter.net,delta-optimist.com,moosejawtoday.com,newwestrecord.ca,nsnews.com,piquenewsmagazine.com,princegeorgecitizen.com,prpeak.com,richmond-news.com,theorca.ca,timescolonist.com,tricitynews.com,vancouverisawesome.com##.ft-social
 haymarketbooks.org##.ftr-follow
@@ -838,6 +839,7 @@ application-remuneratrice.com##.zd-social
 wdwmagic.com##.zocial
 retbit.com##.zox-post-soc-scroll-out
 retbit.com##.zox-post-soc-stat
+iptvinsider.com##[class*="thive-share-cnt"]
 footwearnews.com,indiewire.com##[class^="_socialMedia_"]
 motortrend.com##[data-c="social-share"]
 sundayworld.com##[data-testid="article-share"]


### PR DESCRIPTION
Hides ad banner, newsletter form, social banner, and share counter.
There is also a general filter for Facebook sharer using relative path used by the site in the commit. If you think it is unnecessary or can be made specific instead, let me know. 
This pull request fixes https://github.com/easylist/easylist/issues/14133.