### PR TITLE
A: `sussexexpress.co.uk`

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -16029,3 +16029,6 @@
 ! Kayak
 ##.resultsList > div > div > div > div.G-5c[role="tab"][tabindex="0"] > .yuAt-pres-rounded
 ##.resultsList > div > div > div > div[data-resultid$="-sponsored"]
+! National World Publishing (https://github.com/easylist/easylist/issues/14785)
+##[class^="AdLoadingText"]
+##[class^="AdWrapper__AdDiv"]


### PR DESCRIPTION
Hides ad banner placeholders on sites operated by National World Publishing.
I followed a commit format previously used on the file. If you prefer the usual sorted format and want it changed, let me know.
This pull request fixes https://github.com/easylist/easylist/issues/14785.