### PR TITLE
A: `neonheightsservers.com`

### DIFF
--- a/easylist/easylist_specific_hide_abp.txt
+++ b/easylist/easylist_specific_hide_abp.txt
@@ -102,6 +102,7 @@ metager.org#?#.result:-abp-has(a[href^="https://metager.org"][href*="/partner/r?
 metager.org#?#.result:-abp-has(a[href^="https://r.search.yahoo.com/"])
 mg.co.za#?#article:-abp-has(.sponsored-single)
 nationalgeographic.com#?#.FrameBackgroundFull--grey:-abp-has(.ad-wrapper)
+neonheightsservers.com#?#.well:-abp-has(ins.adsbygoogle)
 nex-software.com#?#.toolinfo:-abp-has(a[href$="/reimage"])
 nex-software.com#?#h4:-abp-has(a[href$="/reimage"])
 noelleeming.co.nz#?#div.product-tile:-abp-has(span:-abp-contains(Sponsored))


### PR DESCRIPTION
Hides ad banner leftover.
This pull request fixes https://github.com/easylist/easylist/issues/14876.