### PR TITLE
A: `muzines.co.uk`

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -91,6 +91,7 @@ walkingclub.org.uk#@#.ad_div
 admanager.line.biz#@#.ad_frame
 modelhorseblab.com#@#.ad_global_header
 myhouseabroad.com,njuskalo.hr,starbuy.sk.data10.websupport.sk#@#.ad_item
+muzines.co.uk#@#.ad_main
 huffingtonpost.co.uk#@#.ad_spot
 kpanews.co.kr#@#.ad_top
 genshinimpactcalculator.com#@#.adban


### PR DESCRIPTION
Images in `muzines.co.uk/ads` search results do not display properly such as in `muzines.co.uk/ad/9120`.
This PR makes the images display.

<img width="1439" src="https://github.com/easylist/easylist/assets/46979193/1ac5027f-a9b3-46e1-a18a-7afa3de07bee">
