### PR TITLE
P: videos on `eurogamer.net`, `vg247.com`; A: `xxlmag.com`

### DIFF
--- a/easylist/easylist_allowlist.txt
+++ b/easylist/easylist_allowlist.txt
@@ -159,7 +159,7 @@
 @@||lastpass.com/images/ads/$image,~third-party
 @@||letocard.fr/wp-content/uploads/$image,~third-party
 @@||linkbucks.com/tmpl/$image,stylesheet
-@@||live.primis.tech/live/$script,domain=eurogamer.net|vg247.com
+@@||live.primis.tech^$script,domain=eurogamer.net|vg247.com|xxlmag.com
 @@||live.streamtheworld.com/partnerIds$domain=iheart.com|player.amperwave.net
 @@||lokopromo.com^*/adsimages/$~third-party
 @@||looker.com/api/internal/$~third-party


### PR DESCRIPTION
Makes videos playable on `eurogamer.net`, `vg247.com`, and `xxlmag.com`.

```
xxlmag.com/xxl-cypher-lab/
vg247.com/the-best-games-ever-show-episode-80
eurogamer.net/digitalfoundry-2023-after-25-years-daytona-usa-2-is-finally-available-to-play-at-home-and-its-brilliant
```