### PR TITLE
A: ampparit.com

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -5,6 +5,7 @@ news18.com##+js(acis, serviceworker.register)
 rd.fi##.nivoSlider:remove()
 puuilo.fi##.cf-container-wrapper
 puuilo.fi##body:style(overflow: auto !important)
+ampparit.com##+js(set-cookie, closedTicker_273, true, , reload, 1)
 ! autoevolution.com
 autoevolution.com###notif_asker_div
 autoevolution.com##body,html:style(height: auto !important; overflow: auto !important)


### PR DESCRIPTION
Useless "We have updated your terms of service" -notification.

![kuva](https://github.com/easylist/easylist/assets/17256841/a448fd6a-dd9c-43eb-bf10-8f628d0a9698)

Better to set a cookie instead because `:has` filter for each page load is too slow. Also we don't want to block all notifications, only this specific.