### PR TITLE
[NSFW] Update url for kemono.su and coomer.su first-party analytics

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -289,7 +289,7 @@
 ||consumer.org.nz/session/ping/
 ||containers.appdomain.cloud/api/send-log$domain=ibm.com
 ||conversion.mooncard.co^
-||coomer.su/api/v1/%D0%B5vent
+||coomer.su/api/v1/gevent
 ||copilot-telemetry.githubusercontent.com^
 ||count.rin.ru^
 ||counter.darkreader.app^
@@ -645,7 +645,7 @@
 ||kayak.*/vestigo/measure
 ||kbb.com/pixall/
 ||kck.st/web/track
-||kemono.su/api/v1/%D0%B5vent
+||kemono.su/api/v1/gevent
 ||kinesis.us-east-1.analytics.edmentum.com^
 ||kkam.com/rest/high/api/cogitoergosum^
 ||klm.us/CWZUvc/


### PR DESCRIPTION
See #17477, #17651, #17818 for background info.
`kemono.su` and `coomer.su` both use first party analytics. It seems the admins of the site change the url they report back to from time to time in a deliberate attempt to circumvent adblockers.