### PR TITLE
[NSFW] First-party kemono.su and coomer.su

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -289,7 +289,7 @@
 ||consumer.org.nz/session/ping/
 ||containers.appdomain.cloud/api/send-log$domain=ibm.com
 ||conversion.mooncard.co^
-||coomer.su/api/v1/gevent
+||coomer.su/api/v1/coomernumba1
 ||copilot-telemetry.githubusercontent.com^
 ||count.rin.ru^
 ||counter.darkreader.app^
@@ -645,7 +645,7 @@
 ||kayak.*/vestigo/measure
 ||kbb.com/pixall/
 ||kck.st/web/track
-||kemono.su/api/v1/gevent
+||kemono.su/api/v1/kemononumba1
 ||kinesis.us-east-1.analytics.edmentum.com^
 ||kkam.com/rest/high/api/cogitoergosum^
 ||klm.us/CWZUvc/


### PR DESCRIPTION
See #17477, #17651, #17818, and #17946 for info.
URL for first party tracking on both sites has once again changed.