### PR TITLE
A: https://www.olay53.com/

### DIFF
--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -599,6 +599,7 @@ dinamalar.com##.asset-paging
 markapark.com##.htext
 takvim.com.tr##.relatedNewsBox
 milliyet.com.tr##.sticky
+||ilan.gov.tr^$third-party
 ||tmgrup.com.tr^*/tmdsurvey.
 !
 ! ---------- Ukranian Site Specific Hiding Rules ----------


### PR DESCRIPTION
ilan.gov.tr is an official public website.  The site announces official actions for the public such as personnel recruitment, government tenders and judicial sales. The widget is used by many websites.

```
https://www.olay53.com/
https://www.posta.com.tr/
```

<details><summary>Screenshot</summary>

![annotely_image](https://github.com/easylist/easylist/assets/103899764/c8cb4ceb-8761-4b91-8d73-d5690f8ce8bb)


</details>