### PR TITLE
Correctly identify PostHog

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -242,7 +242,9 @@
 ||app.carnow.com/dealers/track_visitor
 ||app.link/_r?$script,third-party
 ||app.opmnstr.com/v2/geolocate/
-||app.posthog.com^$script,xmlhttprequest
+||app.posthog.com/static/array.js^
+||app.posthog.com/s/^
+||app.posthog.com/e/^
 ||app.yesware.com/t/$third-party
 ||appinthestore.com/click/
 ||apple.com/hvr/mw/v1/spile


### PR DESCRIPTION
app.posthog.com is completely broken with this rule. The only relevant tracking urls are the ones in the PR.