### PR TITLE
A: `https://meiosral.justica.gov.pt/Meios-RAL`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1465,6 +1465,7 @@ jetbluevacations.com,paisly.com##.jtp-skinny-gdpr
 jetbluevacations.com##.jtpsdk-body-blackout
 jetbluevacations.com##.jtpsdk-popup-modal
 kegworks.com##.ju_Con
+justica.gov.pt##.justica-cookie_bar
 trontv.com##.jw-popups
 trontv.com##.jw-popups-backdrop
 trontv.com##.jw-popups-container


### PR DESCRIPTION
```adblock
justica.gov.pt##.justica-cookie_bar
```
Appears to remove the cookie banner on `meiosral.justica.gov.pt`. As the same banner appears on `justica.gov.pt`, I have extended the rule to that and all of it's subdomains.
I doubt this is used on other websites, and adding it as a generic rule could cause problems, so I have limited it to `*.justica.gov.pt`.
This PR fixes https://github.com/easylist/easylist/issues/18124.
Thank you.