### PR TITLE
Make Easyprivacy more modular

### DIFF
--- a/easyprivacy.template
+++ b/easyprivacy.template
@@ -6,7 +6,13 @@
 !
 !-----------------General tracking systems-----------------!
 %include easylist:easyprivacy/easyprivacy_general.txt%
+%include easylist:easyprivacy/easyprivacy_general_emailtrackers.txt%
 !-----------------Third-party tracking domains-----------------!
+%include easylist:easyprivacy/easyprivacy_trackingservers_general.txt%
+%include easylist:easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+%include easylist:easyprivacy/easyprivacy_trackingservers_mining.txt%
+%include easylist:easyprivacy/easyprivacy_trackingservers_admiral.txt%
+%include easylist:easyprivacy/easyprivacy_trackingservers_notifications.txt%
 %include easylist:easyprivacy/easyprivacy_trackingservers.txt%
 !-----------------International third-party tracking domains-----------------!
 %include easylist:easyprivacy/easyprivacy_trackingservers_international.txt%
@@ -16,8 +22,30 @@
 %include easylist:easyprivacy/easyprivacy_thirdparty_international.txt%
 !-----------------Individual tracking systems-----------------!
 %include easylist:easyprivacy/easyprivacy_specific.txt%
+%include easylist:easyprivacy/easyprivacy_specific_perimeterx.txt%
+!-----------------Extension specific systems-----------------!
+%include easylist:easyprivacy/easyprivacy_specific_abp.txt%
+%include easylist:easyprivacy/easyprivacy_specific_uBO.txt%
 !-----------------Individual cname tracking systems-----------------!
-%include easylist:easyprivacy/easyprivacy_specific_cname.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_dataunlocker.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_a8net.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_plausible.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_tracedock.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_at-internet.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_adobe.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_acton.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_commanders-act.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_ingenious-technologies.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_np6.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_criteo.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_oracle.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_ad-ebis.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_eulerian.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_keyade.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_lead-forensics.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_webtrekk.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_wizaly.txt%
+%include easylist:easyprivacy/easyprivacy_specific_cname_branch.txt%
 !-----------------International individual tracking systems-----------------!
 %include easylist:easyprivacy/easyprivacy_specific_international.txt%
 !-----------------------Allowlists to fix broken sites------------------------!


### PR DESCRIPTION
Improve EP. Maybe we need to seperate off: 

```
%include easylist:easyprivacy/easyprivacy_specific_abp.txt%
%include easylist:easyprivacy/easyprivacy_specific_uBO.txt%
```

* Split up CNAME to make it more easy to maintain and update.