### PR TITLE
A:`boatsonline.com.au,yachthub.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5404,6 +5404,7 @@ rawstory.com##.connatix-hodler
 apkmirror.com##.ezo_ad
 duckduckgo.com,duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion##.js-results-ads
 duckduckgo.com,duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion##.js-sidebar-ads > .nrn-react-div
+boatsonline.com.au,yachthub.com##.js-sticky
 history.com##.m-balloon-header--ad
 history.com##.m-in-content-ad
 history.com##.m-in-content-ad-row


### PR DESCRIPTION
Hi could you please add this filter to the list there are some 3-rd party advertisements banners on the right side of the page on both pages(might need to refresh a couple of times for them to appear) : 
![image](https://github.com/easylist/easylist/assets/33602691/fca169c4-f45d-4068-b5b8-b076bf2dafd4)
Best regards,