### PR TITLE
URGENT - Allow https://widget.packeta.com/v6/www/js/library.js - it's legit

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -32516,7 +32516,6 @@
 ||webwap.org^$third-party
 ||whatstheword.co^$third-party
 ||whizzco.com^$third-party
-||widget.packeta.com^$third-party
 ||wlmarketing.com^$third-party
 ||wmmediacorp.com^$third-party
 ||wordego.com^$third-party


### PR DESCRIPTION
EasyList now contains this URL widget.packeta.com, but it match to **legit** script (https://widget.packeta.com/v6/www/js/library.js) and this will make it impossible for anyone to load Packeta branches and make order. So, Packeta branches are totally broken now for everyone, who is loading this script and trying to make order on e-shop, what is connected to Packeta.

[Packeta ](https://www.packeta.com/global) is big global genuine company.

**It should we merged ASAP.**

Thousands customers are using this...

Related commit:
https://github.com/easylist/easylist/commit/adf202c4c4e170373134addc97c4940164c86146