### PR TITLE
Block navan.com Amplitude proxy

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -801,6 +801,7 @@
 ||nasi.etherscan.com^
 ||nature.com/platform/track/
 ||naukrigulf.com/ni/nibms/bms_display.php
+||navan.com/api/analytics
 ||nbarizona.com/metrics/
 ||nbc.com/webevents/
 ||nbcnews.com/_next/static/chunks/ads.$script,domain=msnbc.com|nbcnews.com


### PR DESCRIPTION
Looks like `/api/analytics` is a proxy for the Amplitude API as it appears to take a payload matching that which is used by Amplitude analytics + also mentions amplitude by name:

![Capture](https://github.com/easylist/easylist/assets/17305277/bba5b064-f6e9-4f49-875b-06d27f1dd342)
