### PR TITLE
Update fanboy-cookie.template

### DIFF
--- a/fanboy-cookie.template
+++ b/fanboy-cookie.template
@@ -20,3 +20,10 @@
 !---------------------------------Allowlists----------------------------------!
 %include easylist:easylist_cookie/easylist_cookie_allowlist_general_hide.txt%
 %include easylist:easylist_cookie/easylist_cookie_allowlist.txt%
+!
+!--------------------------Custom Rules for whyopencomputing.com------------------------!
+! 2024-01-11 https://whyopencomputing.com
+whyopencomputing.com###idxrcookies
+whyopencomputing.com##body.idxrcookies-block-user-nav:style(overflow: unset !important;)
+whyopencomputing.com##body.idxrcookies-block-user-nav::before
+whyopencomputing.com##.contenido


### PR DESCRIPTION
Add custom blocking rules for whyopencomputing.com in the EasyList Cookie List:

- Added rules to block the element with ID 'idxrcookies' on whyopencomputing.com.
- Applied styles to prevent overflow in 'body.idxrcookies-block-user-nav'.
- Added a rule to hide the '::before' pseudo-element in 'body.idxrcookies-block-user-nav'.
- Blocked the element with class 'contenido' on whyopencomputing.com.

These changes aim to improve cookie-related element blocking on the specified site. Tested and verified on the latest version of the website as of 2024-01-11.