### PR TITLE
Block dagbladet.no cookie popup

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_block.txt
@@ -199,6 +199,7 @@
 ! ---------- Norwegian ----------
 !
 ||widforss.no/bundles/consent-init
+||sp.dagbladet.no/unified/wrapperMessagingWithoutDetection.js
 !
 ! ---------- Polish ----------
 !


### PR DESCRIPTION
## Description
This PR adds a filter to block the `wrapperMessagingWithoutDetection.js` script, responsible for the cookie consent popup on [dagbladet.no](https://www.dagbladet.no/). The purpose of this filter is to enhance user experience and privacy by preventing the cookie consent dialogue from appearing, thereby not prompting users for data consent.

## Motivation
1. **User Experience**: Removing the popup improves the browsing experience by eliminating a common source of interruption.
2. **Privacy Protection**: By not displaying the cookie consent popup, users are less likely to inadvertently agree to data collection and usage.

## Technical Details
The filter rule being added is as follows:
`||sp.dagbladet.no/unified/wrapperMessagingWithoutDetection.js`

This rule targets and blocks the specific script related to the cookie consent mechanism.

## Testing
The effectiveness of this filter has been confirmed through testing, ensuring that it:
- Blocks the cookie consent popup on `dagbladet.no`.
- Does not negatively impact the website’s functionality.