### PR TITLE
A: exception for doubleclick redirects from finder.com.au and finder.com

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -2,7 +2,7 @@
 @@|data:text^$popup,domain=box.com|clker.com|labcorp.com
 @@||accounts.google.com^$popup
 @@||ad.doubleclick.net/clk*&destinationURL=$popup
-@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be|finder.com.au|finder.com
+@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be|finder.com.au|finder.com|creditcard.com.au
 @@||ad.doubleclick.net/ddm/clk/*http$popup
 @@||ad.doubleclick.net/ddm/trackclk/*http$popup
 @@||ads.doordash.com^$popup

--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -2,7 +2,7 @@
 @@|data:text^$popup,domain=box.com|clker.com|labcorp.com
 @@||accounts.google.com^$popup
 @@||ad.doubleclick.net/clk*&destinationURL=$popup
-@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be
+@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be|finder.com.au|finder.com
 @@||ad.doubleclick.net/ddm/clk/*http$popup
 @@||ad.doubleclick.net/ddm/trackclk/*http$popup
 @@||ads.doordash.com^$popup


### PR DESCRIPTION
**Adding Exception for Finder Domains**
This pull request proposes an update to the existing `doubleclick.net` filter exception rule to include [Finder](finder.com.au) domains `finder.com.au`, `finder.com` and `creditcard.com.au`.
This change addresses the issue where ad blockers were inadvertently closing user-intentionally opened tabs due to redirects involving `ad.doubleclick.net`.
The issue has been first detected while using uBlock Origin and discussed also here: https://github.com/uBlockOrigin/uAssets/issues/21939