### PR TITLE
A:`datareportal.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -425,6 +425,7 @@ blenderartists.org,stonetoss.com###friends
 peacemakeronline.com###front_mid_right > center
 mangaku.vip###ftads
 imgbox.com###full-page-redirect
+datareportal.com###fuse-sticky
 scienceabc.com###fusenative
 clocktab.com###fv_left-side
 chromecastappstips.com###fwdevpDiv0


### PR DESCRIPTION
Hi, can you please review and add the filter to the list if you check this[ page](https://datareportal.com/reports/digital-2022-social-commerce-takes-off?rq=ads)  there is a sticky ads container at the bottom:
![image](https://github.com/easylist/easylist/assets/33602691/2f085f1d-833c-4f60-a194-f532742ef397)
Thank you