### PR TITLE
More specific targetting for aria-live

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1671,7 +1671,7 @@ helthjem.no##.schibsted-bar
 nordiskporselen.com##.w3-black
 nitedals.no##.wf-section
 direktesport.no##[aria-label="Informasjonskapsler"]
-vy.no##div[aria-live="polite"]
+vy.no##body div div[aria-live="polite"]
 norsk-tipping.no##div[data-test="cookie-toaster"]
 aftenposten.no##div[id^="sp_message_"]
 digiforms.no##fieldset

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1671,7 +1671,7 @@ helthjem.no##.schibsted-bar
 nordiskporselen.com##.w3-black
 nitedals.no##.wf-section
 direktesport.no##[aria-label="Informasjonskapsler"]
-vy.no##body div div[aria-live="polite"]
+vy.no###cookie-banner
 norsk-tipping.no##div[data-test="cookie-toaster"]
 aftenposten.no##div[id^="sp_message_"]
 digiforms.no##fieldset


### PR DESCRIPTION
The current targetting on vy.no, div[aria-live="polite"] also hides critical functionality, like passenger amounts, etc. Targetting all div that has accessibility labeling results in a hard-to-use website for non-screenreaders

| With EasyList | Default |
|---|---|
|![image](https://github.com/easylist/easylist/assets/22146437/9c51d4b0-a2ab-4e50-8841-1f1622b92683)|![image](https://github.com/easylist/easylist/assets/22146437/40146acd-2040-4ce5-ae2a-e0075e091e67)|

Did I assume correctly that it is CSS selectors being used? So a [descendant selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) can be more precise targetting? 

The cookie banner that should be targetted is the blue div here:
![image](https://github.com/easylist/easylist/assets/22146437/2ce92263-91a6-43b4-9c18-98ebfda86049)
