### PR TITLE
A: react-admin-telemetry.marmelab.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -1777,6 +1777,7 @@
 ||reachforce.com^$third-party
 ||reachlocalservices.com^$third-party
 ||reachsocket.com^$third-party
+||react-admin-telemetry.marmelab.com^$third-party
 ||reactful.com^$third-party
 ||readertracking.com^$third-party
 ||readnotify.com^$third-party


### PR DESCRIPTION
Documented at https://marmelab.com/react-admin/Admin.html#disabletelemetry

Can be seen at https://marmelab.com/react-admin-helpdesk/. technically not a third-party in this case, this is just a demo app, but I can't find other publicly-accessible sites using this tool.