### PR TITLE
Add KING5 to the TENGA exit overlay list

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -133,7 +133,7 @@ watchsomuchproxy.com##.modal-backdrop
 watchsomuchproxy.com###btnStopAds
 watchsomuchproxy.com##body:style(overflow: scroll !important)
 ! Exit overlay
-firstcoastnews.com,wtsp.com,ajc.com,wusa9.com,wfaa.com,9news.com,fox2now.com,wcnc.com,13newsnow.com,wsvn.com,abc15.com,wwltv.com,wkyc.com,wthr.com,11alive.com,wcnc.com,wusa9.com,wfaa.com,9news.com,fox2now.com,abc15.com,wwltv.com,wkyc.com,wthr.com,11alive.com##+js(ra, data-name="exitInterstitial", , stay)
+firstcoastnews.com,wtsp.com,ajc.com,wusa9.com,wfaa.com,9news.com,fox2now.com,wcnc.com,13newsnow.com,wsvn.com,abc15.com,wwltv.com,wkyc.com,wthr.com,11alive.com,wcnc.com,wusa9.com,wfaa.com,9news.com,fox2now.com,abc15.com,wwltv.com,wkyc.com,king5.com,11alive.com##+js(ra, data-name="exitInterstitial", , stay)
 ! Floating video
 texasmonthly.com##.float-player
 texasmonthly.com##+js(rc, float-player, , stay)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.king5.com/`

### Describe the issue

Prevents this annoying "Before You Leave, Check This Out" overlay that occurs any time your cursor leaves the tab.

### Screenshot(s)

![05:09:03-2024-02-04](https://github.com/nalderto/uAssets/assets/25762130/bef9acbd-1dbf-4e91-8937-bed2b8ca7538)

### Notes

WTHR was listed twice, so I just replaced one of the instances with KING5.