### PR TITLE
A: whatphone.com.au

### DIFF
--- a/easylist/easylist_allowlist_popup.txt
+++ b/easylist/easylist_allowlist_popup.txt
@@ -2,7 +2,7 @@
 @@|data:text^$popup,domain=box.com|clker.com|labcorp.com
 @@||accounts.google.com^$popup
 @@||ad.doubleclick.net/clk*&destinationURL=$popup
-@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|creditcard.com.au|finder.com|finder.com.au|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be
+@@||ad.doubleclick.net/ddm/$popup,domain=billiger.de|creditcard.com.au|finder.com|finder.com.au|guide-epargne.be|legacy.com|mail.yahoo.com|nytimes.com|spaargids.be|whatphone.com.au
 @@||ad.doubleclick.net/ddm/clk/*http$popup
 @@||ad.doubleclick.net/ddm/trackclk/*http$popup
 @@||ads.doordash.com^$popup


### PR DESCRIPTION
This change adds `whatphone.com.au` to the doubleclick popup exception to cover the same [issue](https://github.com/easylist/easylist/issues/18277) that was previously happening on `finder.com.au` pages fixed by this PR: https://github.com/easylist/easylist/pull/18276
>This change addresses the issue where ad blockers were inadvertently closing user-intentionally opened tabs due to redirects involving ad.doubleclick.net.

Could you please add `whatphone.com.au` domain too 🙏
cc: @monzta