### PR TITLE
Remove snap.com from adservers list

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -35506,7 +35506,6 @@
 ||smowtion.com^$third-party
 ||smpgfx.com^$third-party
 ||snack-media.com^$third-party
-||snap.com^$third-party
 ||sndkorea.co.kr^$third-party
 ||sni.ps^$third-party
 ||snigelweb.com^$third-party


### PR DESCRIPTION
Hello Easylist Team!

I am an engineer at Snap Inc. Our team  has found that uBlock Origin (and potentially other ad blockers) is blocking our custom font downloads on many of our websites because the fonts are served from the `snap.com` domain. This forces uBlocks users to view the site using a system font. I believe [this rule](https://github.com/easylist/easylist/blob/0b7ca5929ba7a05095d9ec930fd175283941e6ab/easylist/easylist_adservers.txt#L35509) to be the cause. You can reproduce by navigating to [forbusiness.snapchat.com](https://forbusiness.snapchat.com/) with uBlock activated and see multiple failed font file requests...

![Screenshot 2024-02-12 at 3 10 47 PM](https://github.com/easylist/easylist/assets/141043397/a464cbb0-f36c-4359-acff-79aa2a3fa9c4)

Notice our font files are served from `https://marketing-web-api.snap.com` which appears to be covered by the `snap.com` rule. We do not serve ads from the `snap.com` domain.

I am requesting to remove the rule in question so that users can download the correct font files. If there is any additional context I can provide, please me know!

Thank you,
Brandon