### PR TITLE
Update easyprivacy_thirdparty.txt

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1501,7 +1501,6 @@
 ||p.typekit.net^
 ||p.yotpo.com^
 ||p0.com/1x1
-||paddle.com/paddle/assets/images/health-check.gif?
 ||paddle.com^*/analytics.js
 ||page-events-ustats.udemy.com^
 ||pagecloud.com/event


### PR DESCRIPTION
Removing Paddle.com checkout health check file.
Adding this file to the block list has caused legitimate checkout traffic to be blocked.