### PR TITLE
Don't hide alert box on godbolt.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -61,7 +61,7 @@ basecamelectronics.com###agreement-alert
 bracketfights.com,tiermaker.com###agreementMessage
 ibispaint.com###agreementPane
 airvpn.org###air_cookielaw_container
-chefoo.co.uk,godbolt.org###alert
+chefoo.co.uk###alert
 rome2rio.com###alert-banner
 youtube.com###alert-banner > .ytd-browse > .yt-alert-with-actions-renderer
 supermicro.com###alert-container


### PR DESCRIPTION
This `#alert` box is used for documentation of assembly instructions. I don't get any cookie notice when opening the website, but I'm not in the EU.

https://github.com/compiler-explorer/compiler-explorer/issues/3174