### PR TITLE
A: `kompas.com`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -468,6 +468,7 @@
 ||tvid.in/log/
 ! Indonesian
 ||mediaquark.com/tracker.js
+||tracker.oval.id^
 ! Italian
 ||alice.it/cnt/
 ||analytics.competitoor.com^


### PR DESCRIPTION
The domain `tracker.oval.id` is used to track page analytics. At the very least, it tracks user id, event id, user agent, time zone, time stamp, user action, and input count.