### PR TITLE
A: i.posthog.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1063,6 +1063,7 @@
 ||hydro-ma-proxy.akamaized.net^
 ||hypercomments.com/widget/*/analytics.html
 ||i.compendium.com^
+||i.posthog.com^
 ||i.s-microsoft.com/wedcs/ms.js
 ||i.viafoura.co^
 ||iabusprivacy.pmc.com^


### PR DESCRIPTION
PostHog will be adding some new capture endpoints to replace the existing `app.posthog.com` ones that are blocked

We don't want this change to impact adblock users so we want to preemptively add the new domain (anything under `*.i.posthog.com` should be blocked)

