### PR TITLE
Update easylist_adservers.txt

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -5922,6 +5922,7 @@
 ||cdn-adtrue.com^
 ||cdn-server.cc^
 ||cdn-server.top^
+||cdn.b2.ai^
 ||cdn.house^
 ||cdn.optmn.cloud^
 ||cdn.sdtraff.com^


### PR DESCRIPTION
#18604 
I found a new anti-adblock called b2. I don't think I'm working on restoring ads yet, but it's not on the domain block list, so I added it.

```
||cdn.b2.ai^
```
<hr>

See the page for more information. 
https://www.b2.ai/
https://cdn.b2.ai/cdn/b2.min.js