### PR TITLE
A: `wordcounter.icu`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3800,6 +3800,7 @@ proprivacy.com##.sidebar-top-vpn
 indianapublicmedia.org##.sidebar-upper-underwritings
 bigleaguepolitics.com##.sidebar-widget
 zap-map.com##.sidebar__advert
+wordcounter.icu##.sidebar__display
 pbs.org##.sidebar__logo-pond
 hepper.com##.sidebar__placement
 snopes.com##.sidebar_ad


### PR DESCRIPTION
Hides ad square leftover.
This pull request fixes https://github.com/easylist/easylist/issues/15014.