### PR TITLE
A: `getfreecourses.co.websiteoutlook.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4969,6 +4969,7 @@ onetransistor.eu##a[onclick][target="_blank"]
 1001tracklists.com##a[onclick^="lTrInt"]
 earlygame.com,i711.com##a[rel*="sponsored"]
 amishamerica.com##a[rel="nofollow"] > img
+websiteoutlook.com##a[rel="nofollow"][target="_blank"]
 gab.com##a[rel="noopener"][target="_blank"][href^="https://grow.gab.com/go/"]
 amandawalkins.com##a[rel="noreferrer noopener nofollow sponsored"]
 nslookup.io##a[rel^="sponsored"]


### PR DESCRIPTION
Hides ad square.
This pull request fixes https://github.com/easylist/easylist/issues/15025.