### PR TITLE
A: `crossian.net.seowebstat.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -129,6 +129,7 @@ offidocs.com###adbottomoffidocs
 4qrcode.com###addContainer
 odditycentral.com###add_160x600
 lifenews.com###adds
+seowebstat.com###adhead-block
 englishclub.com###adhed
 freepik.com###adobe-pagination-mkt-copy
 onworks.net###adonworksbot


### PR DESCRIPTION
Hides ad banner leftovers.
This pull request fixes https://github.com/easylist/easylist/issues/15026.