### PR TITLE
A: `game.granbluefantasy.jp` (JP IP)

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -561,6 +561,7 @@
 ||analytics.contents.by-fw.jp^
 ||analytics.liveact.cri-mw.jp^
 ||analytics.livesense.marketing^
+||analytics.mbga.jp^
 ||analytics.partcommunity.com^
 ||analyzer51.fc2.com^
 ||api.all-internet.jp^$third-party


### PR DESCRIPTION
Blocks third-party page view analytics.
This pull request fixes https://github.com/easylist/easylist/issues/15214.