### PR TITLE
A: `simplelogin.io`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1050,6 +1050,7 @@
 ||siberiantimes.com/counter/
 ||sid.nordstrom.com^
 ||silvergames.com/div/g.php?
+||simplelogin.io/*/event
 ||skyscanner.*/slipstream/view
 ||slack-edge.com/bv1-10/slack_beacon.
 ||slack.com/beacon/


### PR DESCRIPTION
The endpoint `/p/api/event` is used to receive page-view analytics. At the very least, the endpoint logs page-view events, page referrer, and page href.