### PR TITLE
A: `coldplayeu.gorgias.help`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -424,6 +424,7 @@
 ||event-router.olympics.com^
 ||event.platform.tunein.com^
 ||eventlog.jackpot.de^
+||events-ingestion.services.gorgias.com^
 ||events-prod.autolist.com^
 ||events-tracker.deliveroo.net^
 ||events.api.godaddy.com^


### PR DESCRIPTION
The domain `events-ingestion.services.gorgias.com` is used to receive page-view analytics. At the very least, the domain logs user agent, page url, curent article, and page referrer. A test link can be accessed via `https://coldplayeu.gorgias.help/en-US/mens-size-guide-430709`