### PR TITLE
A: `kayak.co.id`

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1274,6 +1274,7 @@
 /log/?pixel=
 /log/analytics
 /log/browser/event
+/log/client/messages
 /log/collect/*
 /log/counter?
 /log/debug?

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -668,7 +668,6 @@
 ||k.p-n.io/event-stream
 ||kaggle.com/api/i/diagnostics.MetricsService
 ||kansascity.com/nyb-zsooli/
-||kayak.*/log/
 ||kayak.*/vestigo/measure
 ||kbb.com/pixall/
 ||kck.st/web/track

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -668,6 +668,7 @@
 ||k.p-n.io/event-stream
 ||kaggle.com/api/i/diagnostics.MetricsService
 ||kansascity.com/nyb-zsooli/
+||kayak.*/log/
 ||kayak.*/vestigo/measure
 ||kbb.com/pixall/
 ||kck.st/web/track


### PR DESCRIPTION
The endpoint `/log/client/messages` is used to receive error logs. At the very least, the endpoint logs user agent, view port size, adblocker status, and error stack trace. To view the connection, one must wait about a minute after the page has fully loaded.