### PR TITLE
A: `pocketovens.com`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -235,6 +235,7 @@
 ||api.bit.ly/*/clicks?$third-party
 ||api.blink.net/a/
 ||api.collarity.com/cws/*http
+||api.country.is^$third-party
 ||api.iris.tv/update
 ||api.wipmania.com^
 ||apibaza.com/pixel/


### PR DESCRIPTION
Blocks location getter.
This pull request fixes https://github.com/easylist/easylist/issues/15384.