### PR TITLE
A: `favpng.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -860,6 +860,7 @@ insidebitcoins.com##.telegrame_cta_content
 decrypt.co##.text-neutral-700
 twitchy.com##.thm-sc
 chinadaily.com.cn##.three-right
+favpng.com##.thumbnail_pinit
 stuff.co.nz##.tik4-sharing
 ncaa.com##.tile-follow
 30seconds.com##.tip-share


### PR DESCRIPTION
Hides pinterest share button.
This pull request fixes https://github.com/easylist/easylist/issues/15394.