### PR TITLE
Update easyprivacy_trackingservers_thirdparty.txt

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -312,7 +312,6 @@
 ||bigreal.org^$third-party
 ||bigtracker.com^$third-party
 ||bionicclick.com^$third-party
-||birdeatsbug.com^$third-party
 ||bizible.com^$third-party
 ||bizo.com^$third-party
 ||bizspring.net^$third-party


### PR DESCRIPTION
Removes birdeatsbug.com, which is neither related to ads, nor tracking users.

Disclaimer: I work for https://birdeatsbug.com.

I'm happy to provide any information needed to convince that the service is unserverdly on an ad blocker list.