### PR TITLE
A: `torontolife.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3874,7 +3874,7 @@ warcraftpets.com##.sitelogo > div
 garagejournal.com##.size-full.attachment-full
 newsnext.live##.size-large
 garagejournal.com##.size-medium
-canadianbusiness.com##.sjm-dfp-wrapper
+canadianbusiness.com,torontolife.com##.sjm-dfp-wrapper
 charismanews.com##.skinTrackClicks
 pinkvilla.com##.skinnerAd
 hltv.org##.skinport


### PR DESCRIPTION
Hides ad placeholders at https://torontolife.com/real-estate/condo-of-the-week-knitting-mill-lofts/