### PR TITLE
A: [breakage] https://www.fitbook.de/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -27,6 +27,7 @@
 @@||kameleoon.io/ip^$domain=welt.de
 @@||l.ecn-ldr.de/loader/loader.js$domain=braun-hamburg.com
 @@||online.mps-gba.de/praeludium/$script,domain=auto-motor-und-sport.de|caravaning.de|motorradonline.de
+@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de
 @@||rackcdn.com/stf.js$script,domain=20min.ch
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -27,7 +27,7 @@
 @@||kameleoon.io/ip^$domain=welt.de
 @@||l.ecn-ldr.de/loader/loader.js$domain=braun-hamburg.com
 @@||online.mps-gba.de/praeludium/$script,domain=auto-motor-und-sport.de|caravaning.de|motorradonline.de
-@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|rollingstone.de|stylebook.de
+@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|metal-hammer.de|rollingstone.de|stylebook.de
 @@||rackcdn.com/stf.js$script,domain=20min.ch
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -27,7 +27,7 @@
 @@||kameleoon.io/ip^$domain=welt.de
 @@||l.ecn-ldr.de/loader/loader.js$domain=braun-hamburg.com
 @@||online.mps-gba.de/praeludium/$script,domain=auto-motor-und-sport.de|caravaning.de|motorradonline.de
-@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|stylebook.de
+@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|rollingstone.de|stylebook.de
 @@||rackcdn.com/stf.js$script,domain=20min.ch
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at

--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -27,7 +27,7 @@
 @@||kameleoon.io/ip^$domain=welt.de
 @@||l.ecn-ldr.de/loader/loader.js$domain=braun-hamburg.com
 @@||online.mps-gba.de/praeludium/$script,domain=auto-motor-und-sport.de|caravaning.de|motorradonline.de
-@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de
+@@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|stylebook.de
 @@||rackcdn.com/stf.js$script,domain=20min.ch
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at


### PR DESCRIPTION
*Maybe we should just remove the whole filter*
Images not being rendered at:
https://www.fitbook.de/suche#gsc.q=sleep
https://www.computerbild.de/artikel/cb-News-eKitchen-Computer-Bild-25654273.html

German VPN.

<img width="1293" alt="Screenshot 2024-03-21 at 14 05 32" src="https://github.com/easylist/easylist/assets/65717387/f18dcc86-4880-4f3c-8368-c702822a4c11">
<img width="1292" alt="Screenshot 2024-03-21 at 14 05 59" src="https://github.com/easylist/easylist/assets/65717387/a1d76b81-747b-4f2f-8fd8-f7f0ef1652a0">
