### PR TITLE
M: [Fix] https://11freunde.de/

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -191,6 +191,7 @@ naver.com#@#.head_ad
 infosecurity-magazine.com#@#.header-ad-row
 mobiili.fi#@#.header_ad
 iedrc.org#@#.home-ad
+11freunde.de#@#.house-ad
 thelincolnite.co.uk#@#.inline-ad
 elektro.info.pl,mashingup.jp#@#.is-sponsored
 vukajlija.com#@#.large-advert

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -822,7 +822,7 @@
 /housead/*
 /housead_
 /houseads.
-/houseads/*
+/houseads/*$domain=~11freunde.de
 /hoverad.js
 /hserver/*
 /ht.js?site_


### PR DESCRIPTION
Self Promo being blocked at https://11freunde.de/startseite
<img width="1288" alt="Screenshot 2024-03-21 at 15 56 21" src="https://github.com/easylist/easylist/assets/65717387/6800d167-b24f-4deb-95ed-a48c48325398">
