### PR TITLE
A: `timesnownews.com` & `zoomtventertainment.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -915,7 +915,7 @@ bostonglobe.com###sticky_container.width_full
 eurogamer.net,rockpapershotgun.com,vg247.com###sticky_leaderboard
 lethbridgeherald.com###stickybox
 medicinehatnews.com###stickyleaderboard
-timesnownews.com###stky
+timesnownews.com,zoomtventertainment.com###stky
 sun-sentinel.com###stnWrapperDiv
 westernjournal.com###stnvideo
 rawstory.com###story-top-ad
@@ -1720,7 +1720,7 @@ animalcrossingworld.com##.at-sidebar-1
 guidingtech.com##.at1
 guidingtech.com##.at2
 fedex.com##.atTile1
-timesnownews.com##.atfAdContainer
+timesnownews.com,zoomtventertainment.com##.atfAdContainer
 atptour.com##.atp_ad
 miragenews.com##.attachment-wt450_250
 audiobacon.net##.audio-widget.et_pb_widget
@@ -5378,7 +5378,7 @@ costco.ca##div.product:has(.criteo-sponsored)
 thebay.com##div.product:has(div.citrus-sponsored)
 healthyrex.com##div.textwidget:has(a[rel="nofollow sponsored"])
 bestbuy.ca##div.x-productListItem:has([class^="sponsoredProduct"])
-timesnownews.com##div:has(> .bggrayAd)
+timesnownews.com,zoomtventertainment.com##div:has(> .bggrayAd)
 skyscanner.com,skyscanner.net##div:has(> a[data-testid="inline-brand-banner"])
 outlook.live.com##div:has(> div > div.fbAdLink)
 tripadvisor.com##div:has(> div > div[class="ui_column ovNFo is-3"])

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -915,6 +915,7 @@ bostonglobe.com###sticky_container.width_full
 eurogamer.net,rockpapershotgun.com,vg247.com###sticky_leaderboard
 lethbridgeherald.com###stickybox
 medicinehatnews.com###stickyleaderboard
+timesnownews.com###stky
 sun-sentinel.com###stnWrapperDiv
 westernjournal.com###stnvideo
 rawstory.com###story-top-ad


### PR DESCRIPTION
Hides desktop and mobile ad banner placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/14996.