### PR TITLE
A: `bylancer.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -672,6 +672,7 @@ beincrypto.com##.share-block
 calcioefinanza.it,crealitycloud.com,news-medical.net,scientificamerican.com##.share-box
 ibtimes.co.in##.share-btn-wrp
 tastecooking.com##.share-button
+bylancer.com##.share-buttons-icons
 apptrigger.com##.share-capture
 cryptopolitan.com##.share-col
 cheknews.ca,fandomwire.com,stadiumtalk.com,tvline.com##.share-container


### PR DESCRIPTION
Hides social icons.
This pull request fixes https://github.com/easylist/easylist/issues/15407.