### PR TITLE
A: `oppo.com`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1207,6 +1207,7 @@ aoc.com##.country-popup
 ecosys.net,vertica.com##.courier-modal-overlay
 hik-connect.com##.coverShow
 videojug.com##.cp-alert-message
+oppo.com##.cp-cookie-tip-euro
 mad-daily.com##.cp-info-bar-container
 itv.com##.cp_dialog
 drafty.co.uk##.cpc-float

--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -885,6 +885,7 @@
 ||ontraport.com/opt_assets/static/js/logging.js
 ||opendesktop.org/l/fp
 ||ophan.theguardian.com^
+||oppo.com/api/country
 ||optimizely.com/js/geo.js
 ||optimizely.techtarget.com^
 ||oracle.com/visitorinfo/


### PR DESCRIPTION
Blocks location getter and hides cookie notice.
This pull request fixes https://github.com/easylist/easylist/issues/15498.