### PR TITLE
A: `miro.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1186,6 +1186,7 @@
 ||strtpe.link/stat/
 ||stubhub.com/a/icph
 ||suaurl.com/adblock/js/smarttag.js
+||svc.eu01.miro.com^
 ||swarm.video/stats/
 ||szrpr.raen.com^
 ||t.9gag.com^
@@ -1327,6 +1328,7 @@
 ||tracking.unrealengine.com^
 ||trackr.vivenu.com^
 ||tradingview.com/ping
+||trcksplt.miro.com^
 ||treatment.grammarly.com^
 ||tredir.go.com^
 ||tripadvisor.*/BALinkImpressionTracking/


### PR DESCRIPTION
Blocks analytics endpoints.
This pull request fixes https://github.com/easylist/easylist/issues/15503.