### PR TITLE
A: `delfi.lt`

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -977,6 +977,7 @@
 ||tanks.lv/top/stats.php
 ! Lithuanian
 ||15min.lt/cached/tgif$~third-party
+||g.delfi.lt/g.js
 ||lrytas.lt/counter/
 ! Norwegian
 ||click.vgnett.no^


### PR DESCRIPTION
Blocks location getter.
This pull request fixes https://github.com/easylist/easylist/issues/15507.