### PR TITLE
P: `miro.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1187,7 +1187,8 @@
 ||strtpe.link/stat/
 ||stubhub.com/a/icph
 ||suaurl.com/adblock/js/smarttag.js
-||svc.eu01.miro.com^
+||svc.eu01.miro.com/api/stream/
+||svc.us01.miro.com/api/stream/
 ||swarm.video/stats/
 ||szrpr.raen.com^
 ||t.9gag.com^


### PR DESCRIPTION
Unblocks Talktrack functionality.
This pull request fixes https://github.com/easylist/easylist/issues/18917.