### PR TITLE
Add rule to block ad-related requests on search.brave.com

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -546,6 +546,7 @@
 /api.ad.
 /api.ads.$domain=~ads.instacart.com|~www.ads.com
 /Api/Ad.
+/api/ads/*
 /api/ads?
 /api/v1/ad/*
 /apopwin.js

--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -546,7 +546,6 @@
 /api.ad.
 /api.ads.$domain=~ads.instacart.com|~www.ads.com
 /Api/Ad.
-/api/ads/*
 /api/ads?
 /api/v1/ad/*
 /apopwin.js

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -473,6 +473,7 @@ asgg.php$domain=ghostbin.me|paste.fo
 ||sciencefocus.com/pricecomparison/$subdocument
 ||scoot.co.uk/delivery.php
 ||scrolller.com/scrolller/affiliates/
+||search.brave.com/api/ads/
 ||search.brave.com/serp/v1/static/serp-js/paid/
 ||search.brave.com/serp/v1/static/serp-js/shopping/
 ||searchenginereports.net/theAdGMC/$image


### PR DESCRIPTION
Needed to block SERP ads on search.brave.com. Without this rule, `https://search.brave.com/api/ads/metric/rendered?` network requests still happen on search.brave.com.

Test case:
https://search.brave.com/search?q=vpn&source=web
Check DevTools for request to search.brave.com/api/ads/metric/rendered