### PR TITLE
Resolve overblocking for birdeatsbug.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -312,7 +312,7 @@
 ||bigreal.org^$third-party
 ||bigtracker.com^$third-party
 ||bionicclick.com^$third-party
-||birdeatsbug.com^$third-party
+||sdk.birdeatsbug.com^$third-party
 ||bizible.com^$third-party
 ||bizo.com^$third-party
 ||bizspring.net^$third-party


### PR DESCRIPTION
Narrows the rule for birdeatsbug.com to just the SDK embedded as 3rd party code into other websites.

Resolves overblocking where ad blockers using the `easyprivacy` list would experience broken flows when using the official Bird Eats Bug browser extension https://chrome.google.com/webstore/detail/bird-eats-bug-effortless/mdplmiioglkpgkdblijgilgebpppgblm, e.g. when the extension was trying to authenticate the user by making API calls to accounts.birdeatsbug.com.

I'm still [making the argument](https://github.com/easylist/easylist/pull/18781) that the domain should be entirely removed, but removing a rule that breaks first party usage hopefully is in everybody's shared interest.