### PR TITLE
A: `jolstad.no`

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1728,6 +1728,7 @@ nrk.no##.nrk-masthead__info-banner
 minnemi.no##.popup-overlay
 bighorn.no##.pp-announcement-bar-bottom
 helthjem.no##.schibsted-bar
+jolstad.no##.show-cookie-pop-up
 nordiskporselen.com##.w3-black
 nitedals.no##.wf-section
 direktesport.no##[aria-label="Informasjonskapsler"]


### PR DESCRIPTION
Hides cookie pop up leftover.
This pull request fixes https://github.com/easylist/easylist/issues/15519.