### PR TITLE
A: `bikerumor.com`

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1126,6 +1126,7 @@ parsintl.com##.eut-back-top
 about.bgov.com##.fab__scrollTop
 byjus.com##.fixed-up-arrow
 easeus.com##.float_totop
+bikerumor.com##.footer-back-button
 newrepublic.com##.footer__middleRow
 jw.com.au##.footer__scroll-top
 global.toyota##.footer_pagetop

--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -490,6 +490,7 @@ levernews.com,overkill.wtf##.kg-callout-card-blue
 4sysops.com##.kleo-quick-contact-wrapper
 echonewshub.com,jugomobile.com##.l-shared-sec
 sendatext.co##.lb_overlay
+bikerumor.com##.ldm-social-menu
 axios.com##.leading-0
 nms.si##.leftColumn-socialLinks
 mymodernmet.com##.lets-connect


### PR DESCRIPTION
Hides social buttons and back to top button.
This pull request fixes https://github.com/easylist/easylist/issues/15567.