### PR TITLE
A: `hellodoktor.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -991,6 +991,8 @@
 ||15min.lt/cached/tgif$~third-party
 ||g.delfi.lt/g.js
 ||lrytas.lt/counter/
+! Malaysian
+||event-tracking.hellohealthgroup.com^
 ! Norwegian
 ||click.vgnett.no^
 ||data.nrk.no^


### PR DESCRIPTION
The domain `event-tracking.hellohealthgroup.com` is used to receive page-view analytics. At the very least, it logs user agent, page url, user id, and page access time.