### PR TITLE
A: `geekflare.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -887,6 +887,7 @@ telesurenglish.net##.wpRedesFoot
 budgetbytes.com,butterwithasideofbread.com,handletheheat.com,therecipecritic.com##.wprm-call-to-action
 manhwatop.com##.wrap_social_account
 coinspeaker.com##.wrapp_aside-share
+geekflare.com##.x-social-menu
 spring.org.uk##.yasip.widget
 news.am##.youtube-subscriber
 application-remuneratrice.com##.zd-social


### PR DESCRIPTION
Hides social icons.
This pull request fixes https://github.com/easylist/easylist/issues/15591.