### PR TITLE
A: `topsmerch.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1621,6 +1621,7 @@ romsgames.net##.affiliate-container
 thebeet.com##.affiliate-disclaimer
 express.co.uk##.affiliate-widget
 usatoday.com##.affiliate-widget-wrapper
+topsmerch.com##.affix-placeholder
 domainnamewire.com##.after-header
 insidemydream.com##.afxshop
 venea.net##.ag_banner
@@ -4548,6 +4549,8 @@ blackbeltmag.com##[aria-label="Wix Monetize with AdSense"]
 top.gg##[class*="__AdContainer-"]
 everydaykoala.com,playjunkie.com##[class*="__adspot-title-container"]
 everydaykoala.com,playjunkie.com##[class*="__adv-block"]
+topsmerch.com##[class*="advertisement"]
+topsmerch.com##[class*="advertisement"] + .text-grey
 bitcoinist.com,captainaltcoin.com,cryptonews.com,cryptonewsz.com,insidebitcoins.com,philnews.ph##[class*="clickout-"]
 bloomberg.com##[class^="FullWidthAd_"]
 uploader.link##[class^="ads"]


### PR DESCRIPTION
Hides ad banner placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/15914.