### PR TITLE
A: aggle.net

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -44,6 +44,7 @@
 ||affirm.com/api/v2/cookie_sent
 ||affirm.com/api/v2/session/touch_track
 ||afterpay.com^*/v1/event
+||aggle.net
 ||akamaihd.net/p1lakjen.gif
 ||akamaized.net/cookie_check/
 ||akatracking.esearchvision.com^


### PR DESCRIPTION
Reopening a PR with more info. Previously closed #18713

This domain is a CDN for distributing a tracking script for Opensend. Opensend is an email de-anonymizing service. It captures the email address of a user landing on a website merely by a user visiting the website.

@ryanbr Please let me know if I need to add more info before closing this PR. 