### PR TITLE
M: chosun.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2030,7 +2030,7 @@ allmonitors24.com,streamable.com##.bottombanner
 arcadebomb.com##.bottombox
 timesofindia.com##.bottomnative
 canonsupports.com##.box
-chosun.com##.box--bg-grey-20
+chosun.com##.box--bg-grey-20:has(.dfpAd) 
 filmbooster.com,ghacks.net##.box-banner
 mybroadband.co.za##.box-sponsored
 kiz10.com##.box-topads-x2


### PR DESCRIPTION
The box--bg-grey-20 is used to show the element's background color as grey. Other general elements other than advertisements will not be displayed on the web page.
https://www.chosun.com/national/welfare-medical/2024/04/24/RHXAEOKNL5EPVGT36BMFB46YGE/

<img width="1126" alt="classblocking1" src="https://github.com/easylist/easylist/assets/65717387/48b53ff1-420c-4363-81ad-53650ca5333d">
<img width="1211" alt="classblocking2" src="https://github.com/easylist/easylist/assets/65717387/a78b148c-3064-46c5-a10f-e71fd8f65148">
<img width="1211" alt="classblocking3" src="https://github.com/easylist/easylist/assets/65717387/287f6dbf-d311-47e6-9cbe-9494e0ec1244">
