### PR TITLE
Update easylist_adservers_popup.txt

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -230,6 +230,7 @@
 ||adzblockersentinel.net^$popup
 ||adzerk.net^$popup
 ||adzshield.info^$popup
+||ad.tapdb.net^$popup
 ||aeeg5idiuenbi7erger.com^$popup
 ||afcpatrk.com^$popup
 ||aff-handler.com^$popup
@@ -2033,6 +2034,7 @@
 ||lyconery-readset.com^$popup
 ||lylydevelope.com^$popup
 ||lywasnothycanty.info^$popup
+||l.tapdb.net^$popup
 ||m73lae5cpmgrv38.com^$popup
 ||ma3ion.com^$popup
 ||macan-native.com^$popup
@@ -3374,7 +3376,6 @@
 ||takeyouforward.co^$popup
 ||talentorganism.com^$popup
 ||tallysaturatesnare.com^$popup
-||tapdb.net^$popup
 ||tapewherever.com^$popup
 ||tapingdynasty.com^$popup
 ||tapinvited.com^$popup


### PR DESCRIPTION
The main domain tapdb.net is not an advertising site, but the two subdomains l.tapdb.net and ad.tapdb.net are. Blocking the main domain will affect the display of static resources (static.tapdb.net) on the data tool website (tapdb.com).