### PR TITLE
Blocking Unnecessary Domain Removal

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -40710,7 +40710,6 @@
 ||b211.xyz^$document,popup
 ||b59c.xyz^$document,popup
 ||b714b1e8-4b7d-4ce9-a248-48fd5472aa0b.online^$document,popup
-||bamgosu.site^$document,popup
 ||bcbe.site^$document,popup
 ||ca3d.site^$document,popup
 ||content-loader.com^$document,popup

--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -40725,7 +40725,6 @@
 ||fadeb9a7-2417-4a51-8d99-0421a5622cbe.xyz^$document,popup
 ||html-load.cc^$document,popup
 ||html-load.com^$document,popup
-||ygosu.com^$document,popup
 ! Samsung/LG/Philips smart-TV ad domains
 ||ad.lgappstv.com^
 ||ad.nettvservices.com^


### PR DESCRIPTION
```
ygosu.com
```
This is the domain of the community site. It is not related to advertising.