### PR TITLE
A: `mathgames.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2624,6 +2624,7 @@ permies.com##.forum-top-banner
 newsroom.co.nz##.foundingpartners
 freepresskashmir.news##.fpkdonate
 theiphoneappreview.com##.frame
+mathgames.com##.frame-container
 freedomfirstnetwork.com##.freed-1
 looperman.com##.freestar
 esports.gg##.freestar-esports_between_articles
@@ -3190,6 +3191,7 @@ macdailynews.com##.macdailynews-after-article-ad-holder
 antimusic.com##.mad
 methodshop.com##.mai-aec
 wccftech.com##.main-background-wrap
+mathgames.com##.main-banner-adContainer
 sporcle.com##.main-content-unit-wrapper
 numuki.com##.main-header-responsive-wrapper
 ggrecon.com##.mainVenatusBannerContainer
@@ -3809,6 +3811,7 @@ moneycontrol.com##.rhs_banner_300x34_widget
 siteslike.com##.rif
 terminal.hackernoon.com##.right
 cnbctv18.com##.right-ad-amp
+mathgames.com##.right-ad-override
 news.net##.right-banner-wr > .right
 africanews.com##.right-legend
 essentialenglish.review##.right-panel


### PR DESCRIPTION
Hides ad banner placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/15956.