### PR TITLE
A: `commentpicker.com`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -1000,7 +1000,7 @@ gmx.net##ui-social
 jagranjosh.com##ul[class^="Details_Social_"]
 dailymail.co.uk,thisismoney.co.uk##ul[class^="linksHolder-"]
 !! .social-sharing
-byjus.com,homemark.co.za,malaymail.com,maxabout.com,news24.com,politico.eu,thepostmillennial.com##.social-sharing
+byjus.com,commentpicker.com,homemark.co.za,malaymail.com,maxabout.com,news24.com,politico.eu,thepostmillennial.com##.social-sharing
 !! .share-links
 ansa.it,cryptopotato.com,eff.org,ewn.co.za,hannity.com,jurist.org,lagaceta.com.ec,menselijklichaam.nl,miragenews.com,mobilesyrup.com,mole24.it,sampdoria.it,upcomingvinyl.com,vivercomsaude.site##.share-links
 !! .share-buttons


### PR DESCRIPTION
Hides social icons.
This pull request fixes https://github.com/easylist/easylist/issues/15977.