### PR TITLE
A: https://*.powerrobotflower.com/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -264,6 +264,7 @@
 ||pixrealm.com^
 ||pjstat.com^
 ||plausiblecdn.co^
+||powerrobotflower.com^
 ||prfct.co^
 ||procroanalytics.com^
 ||progmxs.com^


### PR DESCRIPTION
Rationale: Domain loads fingerprinting scripts per #19133

Fixes: #19133

Found using analysis performed on [VisibleV8](https://github.com/wspr-ncsu/visiblev8) logs :)