### PR TITLE
A: https://*.cafirebreather.com/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -57,6 +57,7 @@
 ||bx-cloud.com^
 ||bydst.com^
 ||cadsuta.net^
+||cafirebreather.com^
 ||catsunrunjam.com^
 ||cbdatatracker.com^
 ||cdnhst.xyz^


### PR DESCRIPTION
Example:
`https://drako.cafirebreather.com/i/0009cd7673176c779954540ce369af68.js` being loaded on `https://www.marian.edu/`

Similar concerns as #19133, #19134 and #19135, appears to be the same/similar script