### PR TITLE
A: https://lordofthesuperfrogs.com/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -208,6 +208,7 @@
 ||logicanalytics.io^
 ||logtail.com^
 ||loopcybersec.com^
+||lordofthesuperfrogs.com^
 ||lsdm.co^
 ||lyfnh.io^
 ||maggieeatstheangel.com^


### PR DESCRIPTION
Example: `https://rocky.lordofthesuperfrogs.com/i/0c928789f9e0fe002203675ad3b9fdd2.js` in https://press.princeton.edu/books

Similar concerns as #19133, #19134 and #19135, #19136 appears to be the same/similar script.