### PR TITLE
A: [breakage] https://biz.yelp.com/

### DIFF
--- a/easylist/easylist_general_block_popup.txt
+++ b/easylist/easylist_general_block_popup.txt
@@ -5,7 +5,7 @@
 &zoneid=*&ad_$popup
 &zoneid=*&direct=$popup
 .co/ads/$popup
-.com/ads?$popup
+.com/ads?$popup,domain=~biz.yelp.com
 .fuse-cloud.com/$popup
 .net/adx.php?$popup
 .prtrackings.com$popup


### PR DESCRIPTION

Yelp Business account redirect popups being blocked for their users. 

Example page -  https://biz.yelp.com/ads?utm_source=SFMC&utm_medium=email&utm_campaign=PostClaimJourney&utm_content=FreeTrial 

This url is not an ad, instead it redirects small business owners from Yelp's email marketing campaigns to a page to learn more about buying ads on Yelp.

![ yelp](https://github.com/easylist/easylist/assets/65717387/2b3c8dad-85d8-472b-8f5c-74839a522ff3)
