### PR TITLE
M: thesun.co.uk

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2407,6 +2407,8 @@ fandomwire.com##.customad
 total-croatia-news.com##.custombanner
 the-sun.com,thescottishsun.co.uk,thesun.co.uk,thesun.ie##.customiser-v2-layout-1-billboard
 the-sun.com,thescottishsun.co.uk,thesun.co.uk,thesun.ie##.customiser-v2-layout-three-native-ad-container
+thesun.co.uk###article-footer div[id*="-ads-"]
+thesun.co.uk##[data-aspc="newBILL"]
 f150lightningforum.com##.customizedBox
 coincarp.com##.customspon
 citywire.com##.cw-top-advert
@@ -5830,6 +5832,8 @@ homedepot.com##section[id^="browse-search-pods-"] > div.browse-search__pod:has(d
 titantv.com##tr:has(> td[align="center"][valign="middle"][colspan="2"][class="gC"])
 opensubtitles.org##tr[style]:has([src*="php"])
 oneindia.com##ul > li:has(> div[class^="adg_"])
+thesun.co.uk##.sun-grid-container:has([class*="ad_widget"])
+thesun.co.uk##.article-sidebar .widget-sticky:has([class*="ad_widget"])
 ! taboola
 nme.com###taboola-below-article
 oneindia.com###taboola-mid-article-thumbnails


### PR DESCRIPTION
ads appearing on [thesun.co.uk ](https://www.thesun.co.uk/)
on homepage: top banner & banners within body

 [https://www.thesun.co.uk/money/28061924/rejected-dragons-den-business-owner-entrepreneur-matcha-tea/](https://www.thesun.co.uk/money/28061924/rejected-dragons-den-business-owner-entrepreneur-matcha-tea/)
on article page: sidebar & bottom of page tiles

tested on Chrome & Firefox with AdBlock 6.2.0 & Adblock Plus 4.0

![Screenshot 2024-05-28 at 4 25 26 PM](https://github.com/easylist/easylist/assets/56893063/20b0a0a5-9a05-4bef-bbd6-5db5b71159f6)
![Screenshot 2024-05-28 at 4 23 26 PM](https://github.com/easylist/easylist/assets/56893063/dd02de2b-3295-4cbf-99a5-0e54059d1752)


