### PR TITLE
M: mail.aol.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5876,6 +5876,7 @@ weather.com##div[id^="Taboola-main-"]
 express.co.uk##div[id^="taboola-"]
 linkvertise.com##lv-taboola-ctr-ad-dummy
 filmibeat.com,gizbot.com,goodreturns.in,oneindia.com##ul > li:has(> div[id^="taboola-mid-home-stream"])
+mail.aol.com##li:has(a[data-test-id="pencil-ad-messageList"])
 ! firework
 ndtv.com,ndtv.in##[class^="firework"]
 ndtv.com,ndtv.in##[id^="firework"]


### PR DESCRIPTION
ads appear above legitimate emails in aol inbox

Tested using Adblock & Adblock Plus
Using Easylist & ABP Filters

![Screenshot 2024-05-30 at 3 57 00 PM](https://github.com/easylist/easylist/assets/56893063/d600d8c2-918d-40a3-9bc0-a727860df573)

