### PR TITLE
Update easyprivacy/easyprivacy_trackingservers_general.txt

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -362,8 +362,6 @@
 ||vkanalytics.net^
 ||vpdcp.com^
 ||vstats.me^
-||vturb.com.br^
-||vturb.net^
 ||wct-2.com^
 ||whale3.io^
 ||widgetbe.com^


### PR DESCRIPTION
Removes `vturb.com.br` and `vturb.net` which is not related to ads neither tracking users.

Disclaimer: I work at `www.vturb.com`.

I would like to explain a bit for why these endpoints are used and why the website `https://comoconquistarumamulher.com.br/` was using it and our relation to it.

We are a company that provides a platform for users to host their videos and usually use them in their sales pages. 

### About the `vturb.com.br`

The endpoint `vturb.com.br` which at the website was calling a subdomain `api.vturb.com.br` is used to check if the video itself has a valid license from our platform, it's not used to tracking anything related to the user neither do we collect any user information.

### About the `vturb.net`

This endpoint is used to receive analytics data from the video itself, we don't track any user personal information, we store things related to the performance of the video like the velocity the segments are being delivered, if the video A or B was showed, which configuration the video had at the time of the play and other video metrics but not with any user information. We do store at the localstorage things that would allow the user to refresh the page and continue where he left in the video which is useful for clients that provide masterclasses or educational content.

### Our policy for our clients that use our platform

Here is our terms of use in EN: https://vturb.com/en/terms
Here is our privacy in EN: https://vturb.com/en/privacy

Those two are the terms of agreement our clients comply when joining our platform.

We appreciate any pointers on how we can achieve the removal of our domain are we are happy to clarify anything that was not made clear.

The commit that introduced our domains as blocked was this one here: https://github.com/easylist/easylist/commit/daaad642f3825527be1ad21d2c34f9bee325e957 so I will tag @Khrin here. 

Thanks in advance.