### PR TITLE
A: `indiatimes.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -548,6 +548,7 @@
 ||geo.brobible.com^
 ||geo.nbcsports.com^
 ||geo.yahoo.com^
+||geoapi.indiatimes.com^
 ||geoip.boredpanda.com^
 ||geoip.hmageo.com^
 ||geoip.ifunny.co^
@@ -683,6 +684,7 @@
 ||irs.gov/h4z97Hz8jMrNO/
 ||isc-tracking.eventim.com^
 ||isharemetric.rediff.com^
+||iturl.in/analytics?
 ||ivx.lacompagnie.com^
 ||j927.statnews.com^
 ||jansatta.com/api/capture/ua


### PR DESCRIPTION
Blocks location getter and page-view logging.
This pull request fixes https://github.com/easylist/easylist/issues/16049.