### PR TITLE
A: `forums.androidcentral.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -270,6 +270,7 @@
 ||cloudfront.net/tracker-latest.min.js
 ||cloudfront.net/vis_opt.js
 ||cloudfront.net/vis_opt_no_jquery.js
+||cloudmetrics.xenforo.com/api/send
 ||clp-mms.cloudpro.co.uk^
 ||cm-mms.coachmag.co.uk^
 ||cm.nordvpn.com^

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -42,6 +42,7 @@ yummly.com##.house-promo-root
 ft.com##.instant-alert-cta
 recyclingproductnews.com##.modal-notifications
 techpowerup.com##.notice-content
+forums.androidcentral.com##.notices
 correiobraziliense.com.br##.noticia_notificacao
 laarena.com.ar##.notificacion-modal
 mdjonline.com##.notification-button


### PR DESCRIPTION
Hides notification and Bbocks Umami analytics.
This pull request fixes https://github.com/easylist/easylist/issues/16061.