### PR TITLE
A: `support.github.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1229,6 +1229,10 @@
 ||strtpe.link/stat/
 ||stubhub.com/a/icph
 ||suaurl.com/adblock/js/smarttag.js
+||support.github.com/_event
+||support.github.com/_stats
+||support.github.com/session/event
+||support.github.com/session/user
 ||svc.eu01.miro.com/api/stream/
 ||svc.us01.miro.com/api/stream/
 ||swarm.video/stats/


### PR DESCRIPTION
Blocks event logging.