### PR TITLE
A: `developers.miro.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -367,6 +367,7 @@
 ||deovr.com/api_logs/
 ||dev.to/fallback_activity_recorder
 ||developer.mozilla.org/submit/
+||developers.miro.com/pageview
 ||df.infra.shopee.
 ||df.infra.sz.shopee.
 ||dhl.com/g8Dj6P8TAg/


### PR DESCRIPTION
Blocks page-view logging.