### PR TITLE
M: java67.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -40596,6 +40596,7 @@
 ||validclick.com^$third-party
 ||valuead.com^$third-party
 ||valuecommerce.com^$third-party
+||vdo.ai^$third-party
 ||velti.com^$third-party
 ||vendexo.com^$third-party
 ||veoxa.com^$third-party


### PR DESCRIPTION
https://www.vdo.ai/ serves videos ads
Seems to be used widely: https://publicwww.com/websites/%22vdo.ai%2Fcore%22/

Examples: 
- empty ad container on https://www.java67.com/2022/02/top-5-microservice-courses-for-java.html
- video ad in body of https://education-load.com/
- empty ad container on https://classnotes.org.in/class-8/english-8/
- video ad on https://samajaepaper.in/epaper/1/73/2024-06-13/1