### PR TITLE
Allow UPS delivery tracking when open directly

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2548,7 +2548,7 @@
 /webtag.js
 /webtrack.js
 /webtracker.dll
-/webtracking/*$~subdocument,~domain,domain=~wwwapps.ups.com
+/webtracking/*$~subdocument,~document,domain=~wwwapps.ups.com
 /webtraffic.js
 /webtraxs.js
 /webtrekk_mediaTracking.min.js

--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2548,7 +2548,7 @@
 /webtag.js
 /webtrack.js
 /webtracker.dll
-/webtracking/*$~subdocument,domain=~wwwapps.ups.com
+/webtracking/*$~subdocument,~domain,domain=~wwwapps.ups.com
 /webtraffic.js
 /webtraxs.js
 /webtrekk_mediaTracking.min.js


### PR DESCRIPTION
those links are sent over email so when open in the browser have no initiator