### PR TITLE
A: `nist.gov`

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -860,6 +860,7 @@ mirror.co.uk##.social-sites
 nhm.org##.social-story-bottom
 lgbtqnation.com##.social-tile
 politico.com##.social-tools__list
+nist.gov##.social-twitter
 mmorpg.com##.social-web
 gnttv.com##.social-widget
 rbth.com##.social-wrapper


### PR DESCRIPTION
Hides social icon.
This pull request fixes https://github.com/easylist/easylist/issues/16073.