### PR TITLE
A: `cuisineaz.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1975,6 +1975,7 @@ theportugalnews.com##.banners-250
 rt.com##.banners__border
 unixmen.com##.banners_home
 m.economictimes.com##.bannerwrapper
+cuisineaz.com##.banniere-haute-wrapper
 barrons.com##.barrons-body-ad-placement
 marketscreener.com##.bas
 euronews.com##.base-leaderboard

--- a/fanboy-addon/fanboy_newsletter_specific_ABP.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_ABP.txt
@@ -1,6 +1,7 @@
 ! fanboy_newsletter_specific_ABP.txt
 ! Sorted alphabetically by the domain
 cmswire.com#?#section:-abp-has(.footer__join-us-form)
+cuisineaz.com#?#section.None:-abp-has(.c-box-news)
 engadget.com#?#.rwd-outer-container:-abp-has(.newsletter-footer)
 headphonesty.com#?#div:-abp-has(> form[action*="subscribe"])
 relationshiphero.com#?#div:-abp-has(> .EmailSubscriber)


### PR DESCRIPTION
Hides ad banner placeholder and newsletter form.
In addition with the provided test link, another can be accessed via `https://www.cuisineaz.com/articles/valentin-raffali-de-top-chef-un-chef-audacieux-a-l-univers-singulier-9749.aspx`.
This pull request fixes https://github.com/easylist/easylist/issues/16092.