### PR TITLE
A: wolt.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5816,6 +5816,7 @@ slickdeals.net##.bp-p-filterGrid_item:has(.bp-c-label--promoted)
 homedepot.com##.browse-search__pod:has([id^="plp_pod_sponsored"])
 doordash.com##.carousel-virtual-wrapper:has([href*="collection_type=sponsored_brand"])
 doordash.com##.ccdtLs:has([data-testid="sponsored:Sponsored"])
+wolt.com##div:has( > div > div > div > div > div > p:has-text(Sponsored))
 asda.com##.cms-modules:has([data-module*="Sponsored Products"])
 tvinsider.com#@#.cnx-player-wrapper
 asda.com##.co-item:has(.co-item__sponsored-label)


### PR DESCRIPTION
Wolt.com have some sponsored restaurants that should be hide.

![image](https://github.com/easylist/easylist/assets/4103710/9f2ece27-e6bb-4dca-972c-cf873267cfff)
