### PR TITLE
A: `usatoday.com` (mobile UA)

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2875,6 +2875,7 @@ goodmenproject.com##.gmp-instream-wrap
 givemesport.com##.gms-ad
 givemesport.com##.gms-billboard-container
 givemesport.com##.gms-sidebar-ad
+usatoday.com##.gnt_xmst
 guides.gamepressure.com##.go20-pl-guide-right-baner-fix
 coinmarketcap.com##.goXFFk
 dallasinnovates.com,thecoastnews.com,watchesbysjx.com##.gofollow


### PR DESCRIPTION
Hides ad banner placeholder.
This pull request fixes https://github.com/easylist/easylist/issues/17109.