### PR TITLE
A: `toms.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1350,6 +1350,8 @@
 ||tms.hft.greenchef.com^
 ||tms.hft.hellofresh.com^
 ||tnaflix.com/stats.php
+||toms.com/*/FacebookCAPI-Event
+||toms.com/*/PinterestCAPI-Event
 ||tongji-res.meizu.com^
 ||top.gg/api/auctions/i
 ||top.wn.com^


### PR DESCRIPTION
Blocks page-view analytics.
The endpoints submitted logs event type and current page url.