### PR TITLE
A: `bestcrazygames.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1086,6 +1086,7 @@ gamepur.com###top-sticky-sidebar-wrapper
 sporcle.com###top-unit
 nytimes.com,nytimesn7cgmftshazwhfgzm37qxb44r64ytbb2dj3x62d2lljsciiyd.onion###top-wrapper
 investing.com###topBroker
+bestcrazygames.com###topGamePageAds
 digitalartsonline.co.uk###topLeaderContainer
 mautofied.com###topLeaderboard
 krunker.io###topLeftAdHolder
@@ -4940,7 +4941,7 @@ bitcoinist.com,captainaltcoin.com,cryptonews.com,cryptonewsz.com,cryptopotato.co
 manabadi.co.in##[class*="dsc-banner"]
 douglas.at,douglas.be,douglas.ch,douglas.cz,douglas.de,douglas.es,douglas.hr,douglas.hu,douglas.it,douglas.lt,douglas.lv,douglas.nl,douglas.pl,douglas.pt,douglas.ro,douglas.si,douglas.sk,nocibe.fr##[class="cms-criteo"]
 bloomberg.com##[class^="FullWidthAd_"]
-uploader.link##[class^="ads"]
+bestcrazygames.com,uploader.link##[class^="ads"]
 weather.us##[class^="dkpw"]
 dallasnews.com##[class^="dmnc_features-ads-"]
 romhustler.org##[class^="leaderboard_ad"]


### PR DESCRIPTION
Hides ad placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/17455.