### PR TITLE
A: `fellahe.com`

### DIFF
--- a/fanboy-addon/fanboy_social_international.txt
+++ b/fanboy-addon/fanboy_social_international.txt
@@ -184,6 +184,7 @@ albayan.ae##.follow-google
 trtarabi.com##.google-news-button-wrapper
 alekhbariya.net##.icon-bar
 qatarradio.qa##.icon-social
+fellahe.com##.mh_share_footer
 kharphonk.com##.pinit
 hannibaltv.com.tn##.rs_bas
 pramgnet.com##.sbnr


### PR DESCRIPTION
Hides social container.
This pull request fixes https://github.com/easylist/easylist/issues/17515.