### PR TITLE
A: `poki.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1273,6 +1273,7 @@
 ||t.pagesix.com^
 ||t.paypal.com^$image
 ||t.perigold.com^
+||t.poki.io^
 ||t.regionsjob.com^
 ||t.wayfair.ca^
 ||t.wayfair.co.uk^


### PR DESCRIPTION
Blocks analytics endpoint.
This pull request fixes https://github.com/easylist/easylist/issues/17520.