### PR TITLE
A: `gazetememur.com`

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -1401,6 +1401,7 @@
 ###caseys-cookie-modal
 ###caspian_cookiebar
 ###catapult-cookie-bar
+###cb-cookie-banner
 ###cb-cookie-holder
 ###cb-cookie_consent
 ###cb_cookie_policy_default


### PR DESCRIPTION
Hides cookie banner.
This pull request fixes https://github.com/easylist/easylist/issues/17546.