### PR TITLE
A: `genius.com` (mobile UA)

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4970,6 +4970,8 @@ bitcoinist.com,captainaltcoin.com,cryptonews.com,cryptonewsz.com,cryptopotato.co
 manabadi.co.in##[class*="dsc-banner"]
 douglas.at,douglas.be,douglas.ch,douglas.cz,douglas.de,douglas.es,douglas.hr,douglas.hu,douglas.it,douglas.lt,douglas.lv,douglas.nl,douglas.pl,douglas.pt,douglas.ro,douglas.si,douglas.sk,nocibe.fr##[class="cms-criteo"]
 bloomberg.com##[class^="FullWidthAd_"]
+genius.com##[class^="InnerSectionAd__"]
+genius.com##[class^="InreadContainer__"]
 uploader.link##[class^="ads"]
 weather.us##[class^="dkpw"]
 dallasnews.com##[class^="dmnc_features-ads-"]


### PR DESCRIPTION
Hides ad banner placeholders.
A test page can be accessed via `https://genius.com/Kendrick-lamar-not-like-us-lyrics`.