### PR TITLE
A: `mongodb.com`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -229,6 +229,7 @@
 ||mdstats.info^
 ||mediamathrdrt.com^
 ||mgln.ai^
+||michiganrobotflower.com^
 ||mirabelanalytics.com^
 ||mircheigeshoa.com^
 ||mitour.de^


### PR DESCRIPTION
Blocks CHEQ analytics endpoint.
This pull request fixes https://github.com/easylist/easylist/issues/17553.