### PR TITLE
A: `tokopedia.com` (mobile UA)

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -728,6 +728,8 @@
 ||bukalapak.com/banner-redirector/impression
 ||ktracker.kumparan.com^
 ||t.bukalapak.com^
+||ta.tokopedia.com/promo/v1/views
+||tokopedia.com/helios-client/client-log
 ! Italian
 /~shared/do/~/count/?$image
 ||alfemminile.com/logpix.php


### PR DESCRIPTION
Blocks client error logging and pixel tracker.

<details>

<summary>Steps to reproduce:</summary>

Using .id IP should not be necessary, but try using one if needed.

1. Disable `uBlock filters – Ads` if checked.
2. Open `tokopedia.com` using mobile UA.
3. Using the search bar on the top, search for the keyword "ringke".
4. After the search completed, both connection should appear.

</details>