### PR TITLE
A: `bukalapak.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -726,6 +726,8 @@
 ! Indonesian
 ||analytic20.detik.com^
 ||bukalapak.com/banner-redirector/impression
+||bukalapak.com/track-external-visit
+||bukalapak.com/track_external.json
 ||ktracker.kumparan.com^
 ||t.bukalapak.com^
 ! Italian


### PR DESCRIPTION
Blocks event logging.
The blocked endpoints at the very least logs client id, user platform, user action, and page referrer.