### PR TITLE
A: `frogmobile.gr`

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1302,7 +1302,7 @@ lartigiano.gr###CookiesSection
 traderetail.gr###NMCookie_container
 restiasuites.gr###advert-once
 stigmap.gr###btm_terms
-whatsup.gr###ck_cookies
+frogmobile.gr,whatsup.gr###ck_cookies
 eudoxus.gr###consentPlaceholder
 dod.gr###cookies_component
 kteohellas.gr###cookiesettings-dialog


### PR DESCRIPTION
Hides cookie banner.
This pull request fixes https://github.com/easylist/easylist/issues/17580.