### PR TITLE
A: `soundproofcow.com`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -1741,9 +1741,9 @@ bulk.com##body,html:style(overflow: auto !important; position: initial !importan
 argos-tradein.co.uk,maandag.be,flixable.com,nmsu.edu,higcapital.es###cookieModal
 argos-tradein.co.uk,maandag.be,flixable.com,nmsu.edu,higcapital.es##body,html:style(overflow: auto !important; position: initial !important;)
 !! .sgpb-popup-overlay
-ematic.co.za##.sgpb-popup-overlay
-ematic.co.za##.sgpb-popup-dialog-main-div-wrapper
-ematic.co.za##body,html:style(overflow: auto !important; position: initial !important;)
+ematic.co.za,soundproofcow.com##.sgpb-popup-overlay
+ematic.co.za,soundproofcow.com##.sgpb-popup-dialog-main-div-wrapper
+ematic.co.za,soundproofcow.com##body,html:style(overflow: auto !important; position: initial !important;)
 !! .gdprOverlay
 epilog.net,skb-leasing.si,amzs.si##.gdprOverlay
 epilog.net,skb-leasing.si,amzs.si##.cookiesSplash


### PR DESCRIPTION
Hides cookie notice.
This pull request fixes https://github.com/easylist/easylist/issues/17593.