### PR TITLE
A: `animetrilogy.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -352,7 +352,7 @@ curseforge.com###cdm-zone-03
 inquirer.net###cdn-life-mrec
 godbolt.org###ces
 romsmania.games###click-widget-banner
-xcalibrscans.com###close-teaser
+animetrilogy.com,xcalibrscans.com###close-teaser
 oneindia.com###closePopupDiv
 slashdot.org###cloud
 globalconstructionreview.com###cm-jobs-block-inner
@@ -481,6 +481,7 @@ cnx-software.com###fixeddbar
 topsporter.net###fl-ai-widget-placement
 vscode.one###flamelab-convo-widget
 nanoreview.net###float-sb-right
+animetrilogy.com###floatcenter
 editpad.org###floorad-wrapper
 clintonherald.com,ottumwacourier.com,thetimestribune.com###floorboard_block
 streams.tv###flowerInGarden
@@ -786,7 +787,7 @@ megacloud.tv###overlay-center
 mzzcloud.life,rabbitstream.net###overlay-container
 mp4upload.com###overlayads
 drivevideo.xyz###overlays
-animexin.vip###overplay
+animetrilogy.com,animexin.vip###overplay
 vure.cx###page-inner > div > div > a[href^="https://www.vure.cx/shorten-link.php/"]
 vure.cx###page-inner > div > div > div > a[href^="https://www.vure.cx/shorten-link.php/"]
 cyclenews.com###pamnew


### PR DESCRIPTION
Hides ad banner leftovers.
This pull request fixes https://github.com/easylist/easylist/issues/17623.