### PR TITLE
A: `lucida.to`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -982,6 +982,7 @@
 ||pixiedust.buzzfeed.com^
 ||pks-analytics.raenonx.cc^
 ||pl.letsblock.it^
+||pl.lucida.to^
 ||planetradio.co.uk/crystal/log
 ||plausible.bots.gg^
 ||plausible.dragonfru.it^


### PR DESCRIPTION
Blocks Plausible analytics endpoint.