### PR TITLE
A: `thomasnet.com`

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1883,6 +1883,7 @@ takimag.com##[style^="width: 100vw; height: 100vh; background-image: linear-grad
 factcheck.org##a[href*="/subscribe/"]
 quantamagazine.org##a[href="#newsletter"]
 time.com##a[href^="https://cloud.newsletters.time.com/signup?"]
+thomasnet.com##appcues-container
 refinery29.com##aside
 cars.com##cars-newsletter-signup
 blockworks.co##div > .p-10.gap-4


### PR DESCRIPTION
Hides newsletter form.
This pull request fixes https://github.com/easylist/easylist/issues/17637.