### PR TITLE
A: `havas.net`

### DIFF
--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -50,6 +50,7 @@ docs.aws.amazon.com###view-__module-context__-_amzn_conversational-experience-mo
 ||callpage.io^$third-party
 ||carchat24.com^$third-party
 ||carrotquest.io^$third-party
+||cbot.ai^$third-party
 ||cdn.asksuite.com/infochat.js
 ||cdn.shopify.com/extensions/*/assets/inbox-chat-loader.js
 ||chat-widget.hiverhq.com^


### PR DESCRIPTION
Blocks third-party chatbot.
This pull request fixes https://github.com/easylist/easylist/issues/17656.