### PR TITLE
reverting tinybird.co

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -2131,7 +2131,6 @@
 ||thinktot.com^$third-party
 ||thoughtmetric.io^$third-party
 ||tinb.net^$third-party
-||tinybird.co^$third-party
 ||tinycounter.com^$third-party
 ||tiser.com.au^$third-party
 ||tkqlhce.com^$third-party


### PR DESCRIPTION
Hello, Tinybird.co founder here.

We are not a tracking company, you can use [our API](https://www.tinybird.co/docs/ingest/events-api) to send events from anywhere (and in this case is being used to get analytics events from a web) but our service is not related to tracking users, ads or anything like that, we are more a database on steroids platform.

Thanks!
