### PR TITLE
A: `skial.com`

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1353,6 +1353,7 @@ newrepublic.com##.upArrow
 wondershare.com##.wsc-gotop
 tiktok.com##[aria-label="Scroll to the top"]
 motorsport.com##[data-id="documentScrollToTop"]
+skial.com##[data-xf-click="scroll-to"]
 kimcartoon.li##[href="#"]
 nordstrom.com##[href="#back-to-top"]
 nexusmods.com##[title="Back to top"]


### PR DESCRIPTION
Hides scroll-to-top button.
This pull request fixes https://github.com/easylist/easylist/issues/17695.