### PR TITLE
A: `monarchmoney.com`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1164,6 +1164,7 @@ goodlawproject.org##.cookie-card
 allyouplay.com##.cookie-card_container
 chronoodyssey.com##.cookie-con
 moneycontrol.com##.cookie-concern-wrapper
+monarchmoney.com##.cookie-consent-banner--container
 dreamingreece.com##.cookie-consent-inner
 cameronhouse.co.uk,postimees.ee##.cookie-container
 ford.co.uk,news.northeastern.edu,theatlantic.com##.cookie-disclaimer

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1584,6 +1584,7 @@ straitstimes.com##.st-newsletter
 statnews.com##.stat-hubspot-signup
 oceana.mi.us##.stay_connected
 alaraby.co.uk,fbi.gov,newarab.com,puck.news##.sticky-footer
+monarchmoney.com##.sticky-signup
 tn.com.ar##.sticky_top
 interacnetwork.com##.stripe--newsletter
 barrons.com##.style--newsletter-signup-bottom--1Spc175x

--- a/fanboy-addon/fanboy_newsletter_specific_uBO.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_uBO.txt
@@ -550,7 +550,10 @@ logicool.co.jp##body[style="overflow: hidden;"]:style(overflow: auto !important;
 ! https://launer.com/c/women
 launer.com##.modal:has([style^='background-image: url("/assets/newsletter-'])
 launer.com##html:style(overflow: auto !important)
-!
+! soundproofcow.com
 soundproofcow.com##.sgpb-popup-overlay
 soundproofcow.com##.sgpb-popup-dialog-main-div-wrapper
 soundproofcow.com##body,html:style(overflow: auto !important; position: initial !important;)
+! monarchmoney.com
+monarchmoney.com##.modal__overlay
+monarchmoney.com##body:style(overflow: auto !important; position: initial !important;)


### PR DESCRIPTION
Hides newsletter popup, newsletter banner, and cookie banner.
This pull request fixes https://github.com/easylist/easylist/issues/17705.