### PR TITLE
fix: remove wildcard end from fingerprint.js filter

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -868,7 +868,7 @@
 /fbpixel.js
 /fe_logger?
 /figanalytics-short-ttl.js
-/fingerprint.js
+/fingerprint.js|
 /fingerprint.min.js
 /fingerprint2.js
 /fingerprint2.min.js


### PR DESCRIPTION
This resolves https://github.com/lucide-icons/lucide/issues/1675#issuecomment-2147119821 where the fingerprint icon failed to load.