### PR TITLE
address worldhistory.org ad script

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -660,6 +660,7 @@ asgg.php$domain=ghostbin.me|paste.fo
 ||windows.net/banners/$domain=hortidaily.com
 ||winxclub.com^*/dfp.js?
 ||wonkychickens.org/data/statics/s2g/$domain=torrentgalaxy.to
+||worldhistory.org/js/ay-ad-loader.js
 ||worldofmods.com/wompush-init.js
 ||wqah.com/images/banners/
 ||wsj.com/asset/ace/ace.min.js


### PR DESCRIPTION
`https://www.worldhistory.org/js/ay-ad-loader.js` is a unblocked ad script