### PR TITLE
address tracking on NSFW sites

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1884,6 +1884,7 @@
 /rwtag.js
 /s-pcjs.php
 /s.gif?
+/s/js/ta-2.3.js?
 /s/vestigo/measure
 /s_code_global_context.js
 /s_trans.gif?


### PR DESCRIPTION
tracking used on multiply porn sites like `jzzo.com` & `xxxvogue.net`