### PR TITLE
address autotrader.com tracking ping

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -166,6 +166,7 @@
 ||aurum.tirto.id^
 ||auth.services.adobe.com/signin/v1/audit
 ||autotrader.com/pixall/
+||autotrader.com/*/pep?pixallId
 ||avitop.com/aviation/hitlist.asp
 ||b629.electronicdesign.com^
 ||ba-bamail.com/handlers/stats.ashx


### PR DESCRIPTION
`https://www.autotrader.com/cars-for-sale/electric/cars-between-17000-and-26000/alpharetta-ga`