### PR TITLE
A: `gamemonetize.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -576,6 +576,8 @@
 ||gak.webtoons.com^
 ||gamedistribution.com/collect?
 ||gamejolt.com/tick/
+||gamemonetize.com/account/event.php?
+||gamemonetize.com/account/eventvideo.php?
 ||gamivo.com/tcllc?
 ||gc.newsweek.com/front/js/counter.js
 ||gct.americanexpress.com^


### PR DESCRIPTION
Blocks pixel trackers.
A test page can be accessed via `https://gamemonetize.com/real-flight-simulator-game`.