### PR TITLE
P: chrome-devtools-frontend.appspot.com

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1414,7 +1414,7 @@
 /metrics/event?
 /metrics/ga.js
 /metrics/init?
-/metrics/metrics$domain=~docs.datadoghq.com|~github.com|~source.dot.net|~spatineo.com
+/metrics/metrics$domain=~docs.datadoghq.com|~github.com|~source.dot.net|~spatineo.com|~chrome-devtools-frontend.appspot.com
 /metrics/onload
 /metrics/ping?
 /metrics/rum


### PR DESCRIPTION
#19767 but without the inconsistency. :)

---

chrome-devtools-frontend.appspot.com hosts the official deployment of Chrome DevTools. This is used in various tools. Typically iframed, but not always.  Within it is a new file `/models/trace/lantern/metrics/metrics.js` that is responsible for computing Core Web Vitals metrics from a trace.. it's used by the Performance panel. (This has nothing to do with RUM or clientside reporting). 

URL that's broken: https://chrome-devtools-frontend.appspot.com/serve_rev/@38e6e04f0d033785f99977fe0622c2a5cb6c4358/worker_app.html?loadTimelineFromURL=https%253A%252F%252Ffirebasestorage.googleapis.com%252Fv0%252Fb%252Ftum-permatraces2%252Fo%252Fpermatraces%25252F7qvReGZ6RU%253Falt%253Dmedia%2526token%253D934388e9-421b-471b-8f26-eebbf97d75e0 (it might take ~60 sec to load as this version isn't cached well, sorry)



![image](https://github.com/user-attachments/assets/c0bf7ddc-9372-4ee3-9a87-97455c830157)

![image](https://github.com/user-attachments/assets/55fc807f-44e0-41fe-9b03-17b4adae9a99)
