### PR TITLE
Update easylist_specific_hide.txt for edhrec.com 2024-08 redesign

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -6270,6 +6270,8 @@ yandex.*##.search-snippet-view:has(span.search-advert-badge__advert)
 yandex.*##a[href^="https://yandex.ru/an/count/"]
 yandex.*##li[class*="_card"]:has(a[href^="https://yabs.yandex.ru/count/"])
 yandex.*##li[class*="_card"]:has(a[href^="https://yandex.com/search/_crpd/"])
+edhrec.com##div:has(>div>div>div[class^="PleaseSupportUs"])
+edhrec.com##div:has(>div>a>img[class^="Ad"])
 ! curseforge/modrinth
 modrinth.com##.normal-page__content [href*="bisecthosting.com/"] > img
 modrinth.com##.normal-page__content [href^="https://billing.ember.host/"] > img


### PR DESCRIPTION
Add edhrec.com `has` elements for top of site ads and mid-scroll-loading ads on content pages.

Without:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/3f6ead21-fd44-4cd3-a012-b803eae77ff9">

With:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/97bab8c2-fc54-40eb-93ee-04f580d78239">
