### PR TITLE
Remove featuregates.org

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -131,7 +131,6 @@
 ||fastfinch.co^
 ||fastgull.io^
 ||fasttiger.io^
-||featuregates.org^
 ||ffbbbdc6d3c353211fe2ba39c9f744cd.com^
 ||ffe390afd658c19dcbf707e0597b846d.de^
 ||fn-pz.com^


### PR DESCRIPTION
FeatureGates.org is a domain used by [statsig](https://www.statsig.com/), a feature flag provider. This domain provides end user functionality, and blocking it can potentially breaks sites that rely on this service for feature flagging.