### PR TITLE
A: `northlandfence.com`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -438,6 +438,7 @@
 ||cdn-ds.com/analytics/
 ||cdn.clkmc.com/cmc.js
 ||cdn.one.store/xdomain_cookie.html
+||cdn.ravm.tv^
 ||cdn.sourcesync.io/open-pixel/source-pixel.js
 ||cdn.statically.io/gh/opcdn/analytics/main/script.js
 ||cdn.usefathom.com^
@@ -1780,6 +1781,7 @@
 ||s.logsss.com^
 ||s.pinimg.com/ct/core.js
 ||s.srvsynd.com^
+||s.vibe.co^
 ||sa.scorpion.co^
 ||saasexch.com/bapi/fe/usd/report/
 ||safe-iplay.com/logger
@@ -2053,6 +2055,7 @@
 ||tag.lexer.io^
 ||tag.mtrcs.samba.tv^
 ||tag.myplay.com^
+||tag.pearldiver.io^
 ||tag.rightmessage.com^
 ||tag.rmp.rakuten.com^
 ||tag.statshop.fr^

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -449,7 +449,8 @@ geekdashboard.com##.section--download
 fdownload.app##.section-app-fb
 investing.com##.seeThisInPopup
 startpage.com##.serp-toast-container.css-163yqy2
-comicsvalley.com##.sgpb-popup-dialog-main-div-wrapper
+comicsvalley.com,northlandfence.com##.sgpb-popup-dialog-main-div-wrapper
+northlandfence.com##.sgpb-popup-overlay
 oneplus.com##.side-download-dialog
 the42.ie,thejournal.ie##.sidebar > .widget
 sportskeeda.com##.sidebar-app-download


### PR DESCRIPTION
Blocks tracker loaders and hides promotion notification.
This pull request fixes https://github.com/easylist/easylist/issues/17805.