### PR TITLE
A: `orico.cc`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1376,6 +1376,7 @@ transamerica.com##.dmb-notifications-ajax-wrapper
 bbc.com##.domestic-header-wrapper
 mla.org##.donate-banner
 dotvvm.com##.dotvvm-contrib-cookie-bar
+orico.cc##.down-nav
 vesselfinder.com##.downfooter
 kdanmobile.com##.dqgoYn
 dreame.com##.drawer-wrapper


### PR DESCRIPTION
Hides cookie banner.
This pull request fixes https://github.com/easylist/easylist/issues/17817.