### PR TITLE
A: `cilipadi.mygostore.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -746,6 +746,7 @@
 ||bukalapak.com/track-external-visit
 ||bukalapak.com/track_external.json
 ||ktracker.kumparan.com^
+||mygostore.com/api/log
 ||t.bukalapak.com^
 ||ta.tokopedia.com/promo/v1/views
 ||tokopedia.com/helios-client/client-log


### PR DESCRIPTION
Blocks performance logging.