### PR TITLE
A: `id.investing.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1048,6 +1048,7 @@
 ||privacypolicies.com/track/
 ||prod-events.nykaa.com^
 ||progressive.com/Log/
+||promos.investing.com/*/digibox.gif?
 ||proporn.com/ajax/log/
 ||pulpulyy.club/cdn-cgi/trace
 ||pulsar.ebay.com^


### PR DESCRIPTION
Blocks Digioh pixel tracker.