### PR TITLE
A: `unibling.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1491,6 +1491,7 @@
 ||ultimedia.com/deliver/statistiques/
 ||um.contentstudio.io^
 ||umami.wakarimasen.moe^
+||unibling.com/eclytics/
 ||unity3d.com/v1/events
 ||unsplash.com/nmetrics
 ||untappd.com/profile/impression?

--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -293,6 +293,7 @@
 ||busuanzi.ibruce.info^$third-party
 ||bzclk.baidu.com^
 ||c.holmesmind.com^
+||cartx.cloud^
 ||cbsi.com.cn/js/dw.js
 ||cdnmaster.com/sitemaster/sm360.js
 ||chuzushijian.cn/c.php


### PR DESCRIPTION
Tracking and third-party event logging

Visiting `cartx.cloud` redirects to `cartsee.com`, a Chinese website