### PR TITLE
A: `alignerr.com`

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -1238,6 +1238,7 @@
 ||loginfra.com^$third-party
 ||logmatic.io^$third-party
 ||lognormal.net^$third-party
+||logr-ingest.com^$third-party
 ||logrocket.com^$third-party
 ||logrocket.io^$third-party
 ||logz.io^$third-party


### PR DESCRIPTION
Proxy domain for LogRocket on the page `https://app.alignerr.com/signin?`

The domain is also mentioned on `https://docs.logrocket.com/docs/proxying-traffic-through-your-own-domain`