### PR TITLE
A: `deel.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -297,6 +297,7 @@
 ||collect.alipay.com^
 ||collect.asics.com^
 ||collect.banggood.com^
+||collect.deel.com^
 ||collect.hollisterco.com^
 ||collect.klove.com^
 ||collect.reagroupdata.com.au^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1440,6 +1440,7 @@
 ||mzbcdn.net/mngr/mtm.js
 ||nastydollars.com/trk/
 ||native-ads-events-api.c4s-rd.services^
+||navattic.com/api/events/
 ||naver.net/wcslog.js
 ||navlink.com/__utmala.js
 ||nbcudigitaladops.com/hosted/housepix.gif


### PR DESCRIPTION
Event logging on the page `https://www.deel.com/hire-employees/`

Scroll down the page to the `Experience the seamless process of hiring globally` section for the third-party event logging.

Can't use `||capture.navattic.com^` because it breaks the demo.
