### PR TITLE
Allow Snap Inc owned websites to load static assets from snap.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -38142,7 +38142,7 @@
 ||smowtion.com^$third-party
 ||smpgfx.com^$third-party
 ||snack-media.com^$third-party
-||snap.com^$third-party,domain=~forbusiness.snapchat.com
+||snap.com^$third-party,domain=~(.arcadiacreativestudio.com|.bitmoji.com|.bitmojipaint.com|.addlive.io|.bitstrips.com|.enhancedworld.com|.eqalpha.ca|.eqalpha.com|.eqalpha.net|.eqalpha.org|.feelinsonice.com|.futurefreshman.com|.futurefreshman.org|.gfycat.com|.keydb.org|.larasagetyoga.com|.lensfest.live|.lensstudio.com|.letsplayirl.com|.local-playcanvas.com|.looksery.com|.metamarkets.com|.moresnapchat.com|.next-mind.com|.pinelabsapps.com|.pixy.com|.playcanv.as|.playcanvas.com|.qc-core.net|.qc-corp.net|.s.co|.sc-cdn.net|.sc-gw.com|.sc-jpl-internal.com|.sc-jpl.com|.sc-jpl.net|.sc-prod.net|.sc-proxy.net|.sc-snap.net|.sc-st.net|.sc-static.net|.sc.co|.seene.co|.sn.ht|.snap-cn.com|.snap.com|.snapads.com|.snapagencyadventure.co.uk|.snapagencyadventure.com|.snapar.com|.snapchat-blog.com|.snapchat.com|.snapchat.me|.snapchatagencyadventure.co.uk|.snapchatagencyadventure.com|.snapchatcoin.com|.snapcreativechallenge.com|.snapdeveloper.com|.snapfoundation.org|.snaphelpline.com|.snapkit.com|.snapmap.com|.snapmap.org|.snapmaps.com|.snappartnersummit.com|.snappcm.com|.snappixelgateway.com|.snappublisher.com|.snapstore.com|.spectacles.com|.suproo.com|.toyopagroup.com|.vertebrae.io|.voisey.app|.voisey.ar|.waveoptics.co|.waveoptics.co.uk|.wavetopics.ar|.yellowla.com)
 ||sndkorea.co.kr^$third-party
 ||sni.ps^$third-party
 ||snigelweb.com^$third-party


### PR DESCRIPTION
For unknown to us reason, `snap.com` is blocked in easylist. This is the main domain for "Snap Inc" and hosts many domains, endpoints, services and static files. 

This rule breaks many of our sites by not loading fonts or allowing us to check if the user should see the cookie consent popup.

As far as we can tell, this rule does not help anyone on the web because we don't serve ads, popups or annoying content from this domain. Let us know why this entry is on easylist, so we can move just that to a different domain. Blocking an entire company's domain feels like overkill.

Here's our previous attempt at unbreaking our sites: https://github.com/easylist/easylist/pull/18537 which didn't get any comments on it.

This PR adds more of Snap Inc's domains to what I presume is the allowlist where this rule doesn't apply.