### PR TITLE
A: `sudokupad.app`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1300,6 +1300,7 @@
 ||stubhub.com/a/icph
 ||stytch.com/sdk/v1/events
 ||suaurl.com/adblock/js/smarttag.js
+||sudokupad.app/api/event
 ||support.github.com/_event
 ||support.github.com/_stats
 ||support.github.com/session/event


### PR DESCRIPTION
Blocks Plausible analytics endpoint.
A test page can be accessed via `https://sudokupad.app/6dP4FN27HB`.