### PR TITLE
A: `wordreference.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3722,10 +3722,12 @@ putlockers.do##.mobile-btn
 birdwatchingdaily.com##.mobile-incontent-ad-label
 businessplus.ie##.mobile-mpu-widget
 forbes.com##.mobile-sticky-ed-placeholder
+wordreference.com##.mobileAd_holderContainer
 pcmacstore.com##.mobileHide
 serverstoplist.com##.mobile_ad
 tipranks.com##.mobile_displaynone.flexccc
 thedailybeast.com##.mobiledoc-sizer
+wordreference.com##.mobiletopContainer
 criminaljusticedegreehub.com##.mobius-container
 etxt.biz##.mod-cabinet__sidebar-adv
 etxt.biz##.mod-cabinet__sidebar-info
@@ -6174,6 +6176,7 @@ pcstats.com##table[width="866"]
 schlockmercenary.com##td[colspan="3"]
 geekzone.co.nz##td[colspan="3"].forumRow[style="border-right:solid 1px #fff;"]
 titantv.com##td[id^="menutablelogocell"]
+wordreference.com##td[style^="height:260px;"]
 itnewsonline.com##td[width="120"]
 greyhound-data.com##td[width="160"]
 eurometeo.com##td[width="738"]


### PR DESCRIPTION
Hides desktop and mobile ad placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/18081.