### PR TITLE
A: `bigthink.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5635,6 +5635,7 @@ americaoutloud.com,analyticsindiamag.com,artificialintelligence-news.com,autoact
 elitepvpers.com##[width="729"]
 elitepvpers.com##[width="966"]
 presearch.com##[x-data*="kwrdAdFirst"]
+bigthink.com##[x-data*="slotHasRendered"]
 mobiforge.com##a > img[alt="Ad"]
 eztv.tf,eztv.yt##a > img[alt="Anonymous Download"]
 cript.to##a.btn[target="_blank"][href^="https://cript.to/"]


### PR DESCRIPTION
Hides ad banner placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/18119.