### PR TITLE
A: `cookpad.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -336,6 +336,7 @@
 ||console-telemetry.oci.oraclecloud.com^
 ||consumer.org.nz/session/ping/
 ||containers.appdomain.cloud/api/send-log$domain=ibm.com
+||cookpad.com/*/activity_logs
 ||copilot-telemetry.githubusercontent.com^
 ||count.darkreader.app^
 ||count.rin.ru^

--- a/easyprivacy/easyprivacy_specific_perimeterx.txt
+++ b/easyprivacy/easyprivacy_specific_perimeterx.txt
@@ -24,6 +24,7 @@
 ||carolsdaughter.com/IZ/uaPO0cuk/init.js
 ||carters.com/0F3091f3/init.js
 ||chron.com/413gkwMT/init.js
+||cookpad.com/FqtAw5et/init.js
 ||couchsurfing.com/bEcn7fQX/init.js
 ||crunchbase.com/rw7M6iAV/init.js
 ||ctinsider.com/413gkwMT/init.js


### PR DESCRIPTION
Blocks PerimeterX script initialiser and event logging endpoint.
A test page can be accessed via `https://cookpad.com/us/search/mac%20n%20cheese`.