### PR TITLE
A: https://proxima.midjourney.com/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1076,6 +1076,7 @@
 ||progressive.com/Log/
 ||promos.investing.com/*/digibox.gif?
 ||proporn.com/ajax/log/
+||proxima.midjourney.com^
 ||pulpulyy.club/cdn-cgi/trace
 ||pulsar.ebay.com^
 ||pulse.delta.com^


### PR DESCRIPTION
Midjourney Event/Analytics service. The `proxima` subdomain is likely a proxy for [Amplitude Analytics](https://amplitude.com/). Attaching screenshot below of an excerpt of a request my browser sent.

I also confirmed that the filter explicitly blocks analytics without altering the functionality of the site.

<img width="208" alt="Screenshot 2024-09-17 at 1 41 59 AM" src="https://github.com/user-attachments/assets/997071f8-2232-4367-908f-d7679b130e89">
