### PR TITLE
Update easylist_specific_hide_abp.txt

### DIFF
--- a/easylist/easylist_specific_hide_abp.txt
+++ b/easylist/easylist_specific_hide_abp.txt
@@ -108,3 +108,5 @@ wayfair.com,wayfair.co.uk#?#div[data-hb-id="Grid.Item"]:-abp-has(div.FeaturedPro
 ! top-level domain wildcard
 walmart.*#?#div > div[io-id]:-abp-contains(Sponsored)
 wayfair.*#?#div[data-hb-id="Grid.Item"]:-abp-has(div.FeaturedProductFlag:-abp-contains(Sponsored))
+
+ziperto.com##a[href*="aixodostemon.click"]


### PR DESCRIPTION
Fake download buttons with ad links
Fake download buttons are deceptive elements designed to trick users into clicking on them, thinking they are legitimate download links. Instead of initiating a download, these buttons often redirect users to advertisement pages or potentially malicious websites. Such buttons typically appear on file-sharing or freeware websites, blending in with the actual download links to confuse users. To avoid falling for these tricks, users should carefully inspect the URL and hover over the button to see where it leads before clicking.
