### PR TITLE
Add google.com rule for cookie consent hiding

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3441,6 +3441,7 @@ pagesix.com##.zephr-component
 material.angular.io##app-cookie-popup
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
+google.ae,google.at,google.be,google.bg,google.by,google.ca,google.ch,google.cl,google.co.id,google.co.il,google.co.in,google.co.jp,google.co.ke,google.co.kr,google.co.nz,google.co.th,google.co.uk,google.co.ve,google.co.za,google.com,google.com.ar,google.com.au,google.com.br,google.com.co,google.com.ec,google.com.eg,google.com.hk,google.com.mx,google.com.my,google.com.pe,google.com.ph,google.com.pk,google.com.py,google.com.sa,google.com.sg,google.com.tr,google.com.tw,google.com.ua,google.com.uy,google.com.vn,google.cz,google.de,google.dk,google.dz,google.ee,google.es,google.fi,google.fr,google.gr,google.hr,google.hu,google.ie,google.it,google.lt,google.lv,google.nl,google.no,google.pl,google.pt,google.ro,google.rs,google.ru,google.se,google.sk##div#xe7COe[role="dialog"]:-abp-has(a[href^="https://policies.google.com/technologies/cookies"])
 ! Multi-national sites
 globalblue.com,globalblue.ru##.gbnew-cookie-bar
 ! Include ubO specific


### PR DESCRIPTION
Hey, I created this rule to match and hide the cookie consent form on google. I tested it and it works as it intended.

`##div#xe7COe[role="dialog"]:-abp-has(a[href^="https://policies.google.com/technologies/cookies"])`


Here is the screenshot of the elements:
[screenshot](https://imgur.com/a/IeIwNVq)