### PR TITLE
Add rule for cookie consent for whatsapp

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3441,6 +3441,7 @@ pagesix.com##.zephr-component
 material.angular.io##app-cookie-popup
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
+whatsapp.com##div[data-testid="wa_cookies_banner_modal"]:-abp-has(a[href="https://www.whatsapp.com/legal/cookies"])
 ! Multi-national sites
 globalblue.com,globalblue.ru##.gbnew-cookie-bar
 ! Include ubO specific


### PR DESCRIPTION
Hey, another rule, this one is for whatsapp.com. I tested it and works fine.


the rule: 
`whatsapp.com##div[data-testid="wa_cookies_banner_modal"]:-abp-has(a[href="https://www.whatsapp.com/legal/cookies"])`


The screenshot of the element:
[screenshot](https://imgur.com/a/m48EeEe)