### PR TITLE
Add rule for cookie consent hiding for theguardian.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3441,6 +3441,7 @@ pagesix.com##.zephr-component
 material.angular.io##app-cookie-popup
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
+theguardian.com##div[style*="height: 100%"]:-abp-has(iframe[title="The Guardian consent message"] > div.message-container)
 ! Multi-national sites
 globalblue.com,globalblue.ru##.gbnew-cookie-bar
 ! Include ubO specific


### PR DESCRIPTION
Hey, another rule, this one is for theguardian.com . I tested it and works fine.

The rule:
`theguardian.com##div[style*="height: 100%"]:-abp-has(iframe[title="The Guardian consent message"] > div.message-container)`


Screenshot of the element:
[screenshot](https://imgur.com/a/HmaSZhF)