### PR TITLE
Add rule for cookie consent hiding for wix.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3441,6 +3441,7 @@ pagesix.com##.zephr-component
 material.angular.io##app-cookie-popup
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
+wix.com##div[aria-label="Cookie Policy Information"]:-abp-has(a[href="https://www.wix.com/about/cookie-policy"])
 ! Multi-national sites
 globalblue.com,globalblue.ru##.gbnew-cookie-bar
 ! Include ubO specific


### PR DESCRIPTION
Another cookie consent hiding rule, this one is for wix.com . I tested it and works fine.

The rule added:
wix.com##div[aria-label="Cookie Policy Information"]:-abp-has(a[href="https://www.wix.com/about/cookie-policy"])

[Screenshot](https://imgur.com/a/euKDvTd)