### PR TITLE
Remove 37signals.com from Fanboy 3rd Party List

### DIFF
--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -1,7 +1,6 @@
 ! fanboy_annoyance_thirdparty.txt
 ||1worldonline.com^$third-party
 ||24smi.org^$third-party
-||37signals.com^$third-party
 ||a.mailmunch.co/app/$script,third-party
 ||actionbutton.co^$third-party
 ||activehosted.com^$third-party


### PR DESCRIPTION
37signals.com is a company responsible for Basecamp and Ruby on Rails. Given a lack of a reason for its inclusion via `git blame` I recommend removing it.