### PR TITLE
Update easylist_adservers_popup.txt

### DIFF
--- a/easylist/easylist_adservers_popup.txt
+++ b/easylist/easylist_adservers_popup.txt
@@ -553,7 +553,6 @@
 ||binaryoptionsgame.com^$popup
 ||bincatracs.com^$popup
 ||bingohall.ag^$popup
-||bingx.com^$popup
 ||binomnet.com^$popup
 ||binomnet3.com^$popup
 ||binomtrcks.site^$popup


### PR DESCRIPTION
Remove domain from EasyList due to widespread false positive reports

The domain `bingx.com` has been frequently reported by users as a false positive.  It is being incorrectly blocked, causing issues with legitimate content access.  Removing this entry will improve user experience and reduce unnecessary disruptions.