### PR TITLE
Isolates sardine.ai tracking script to 3P only

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -246,7 +246,7 @@
 ||api.collarity.com/cws/*http
 ||api.country.is^$third-party
 ||api.iris.tv/update
-||api.sardine.ai/assets/loader.min.js^$third-party
+||api.sardine.ai/assets/loader.min.js$third-party
 ||api.wipmania.com^
 ||apibaza.com/pixel/
 ||apm-engine.meteor.com^$third-party,xmlhttprequest

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -246,7 +246,7 @@
 ||api.collarity.com/cws/*http
 ||api.country.is^$third-party
 ||api.iris.tv/update
-||api.sardine.ai/assets/loader.min.js
+||api.sardine.ai/assets/loader.min.js^$third-party
 ||api.wipmania.com^
 ||apibaza.com/pixel/
 ||apm-engine.meteor.com^$third-party,xmlhttprequest


### PR DESCRIPTION
This makes it such that the script is available for loading when on a first party site such as https://crypto.sardine.ai/buy where the page breaks if this script doesn't load.

In this case, it's 1P fingerprinting occuring, but in all other contexts this script gets loaded as a 3P tracker and should be blocked.

Fixes https://github.com/easylist/easylist/issues/19401 and follows on from https://github.com/easylist/easylist/commit/ff59ff5f0b6009bfd0881669fa9268ed044388d5 which was meant to fix it, but introduced a webcompat issue on https://crypto.sardine.ai/buy