### PR TITLE
M: findagrave.com

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -63,7 +63,7 @@ bitly.com,knivesout.jp#@#.share-btn
 ida2at.com#@#.share-holder
 app.degoo.com#@#.share-icon-container
 pornhub.com#@#.share-link-container
-baidu.com#@#.share-list
+baidu.com,findagrave.com#@#.share-list
 deezer.com#@#.share-message
 podbean.com#@#.share-podcast
 osf.io#@#.share-row


### PR DESCRIPTION
example url: `https://www.findagrave.com/memorial/157250643/jeffrey_lyle-crooks/flower`
When clicking "save to" CTA, an empty modal opens and saving options are hidden
<img width="1268" alt="Screenshot 2024-10-15 at 10 21 07 AM" src="https://github.com/user-attachments/assets/060dc69e-29fc-4bc7-a968-3f04e0eae457">
