### PR TITLE
A: vissle.me

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2826,3 +2826,4 @@
 ||jsrdn.com/s/cs.js
 ! Rewrite to internal resources filters for Adblock Plus
 ||d1z2jf7jlzjs58.cloudfront.net^$rewrite=abp-resource:blank-js,domain=voici.fr
+||vissle.me^

--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -381,6 +381,7 @@
 ||venture-365-inspired.com^
 ||venusrevival.com^
 ||veozn3f.com^
+||vissle.me^
 ||vfghe.com^
 ||vfgte.com^
 ||videocdnmetrika.com^


### PR DESCRIPTION
Add vissle.me to blocking lists

- Reason: Performs user tracking (visit logger log at https://vissle.me/track), injects code to read first-party cookies (id.chatango.com containing user name when loaded from <subdomain>.chatango.com)
- Injected code hides itself with ASCII art when accessed directly

Example injected script: https://vissle.me/profile/512
Example profile with injection: https://andrejplaysgames.chatango.com/
