### PR TITLE
A: https://br.puma.com/

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -321,6 +321,7 @@
 ||selphiu.com^
 ||seoab.io^
 ||sf-insights.io^
+||sgmntfy.com^
 ||sgstats.com^
 ||site24x7rum.eu^
 ||sitecounter.site^


### PR DESCRIPTION
Another domain of segmentify.com


```
https://br.puma.com/
https://sa.puma.com/en/
https://ae.puma.com/
https://cl.puma.com/
https://tr.puma.com/
https://mx.puma.com/
```