### PR TITLE
A: `health.harvard.edu`

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1489,6 +1489,7 @@ nexusmods.com##[title="Back to top"]
 urlgalleries.net##[title="Go to top"]
 kitguru.net##[title="Scroll To Top"]
 wallpaperflare.com##[title="back to top"]
+harvard.edu##[x-data^="alpine_scroll_to_top"]
 albayan.ae,antennebrandenburg.de,autoscout24.it,billboard.it,calendario-365.it,chinadialogue.net,dagospia.com,dz-algerie.info,israeltoday.co.il,lvh.it,nca.aero,regione.marche.it,repsol.com,tradetracker.com,vodafone.de##a[href="#top"]
 rottentomatoes.com##back-to-top
 dole.com##dole-back-to-top


### PR DESCRIPTION
Hides scroll-to-top button.
This pull request fixes https://github.com/easylist/easylist/issues/18142.