### PR TITLE
A: `webmasterworld.com`

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1395,7 +1395,8 @@ cryptoglobe.com##.js-go-to
 airliquide.com##.js-scroll-down
 pbtech.co.nz##.js-show-up-arrow
 gettr.com##.jss82 > svg > circle
-buyee.jp##.jump
+buyee.jp,webmasterworld.com##.jump
+webmasterworld.com##.jump-bottom
 roadiscalling.com,slothytech.com,theinvisibletourist.com##.kadence-scroll-to-top
 scandi.travel##.kapee-back-to-top
 klook.com##.klook-icon-Top


### PR DESCRIPTION
Hides scroll-to-top and scroll-to-bottom buttons.
This pull request fixes https://github.com/easylist/easylist/issues/18189.