### PR TITLE
Remove-zeotap-com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -28235,7 +28235,6 @@
 ||zenkreka.com^
 ||zenoviaexchange.com^
 ||zenoviagroup.com^
-||zeotap.com^
 ||zepazupi.com^
 ||zephyronearc.com^
 ||zerads.com^

--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -2460,7 +2460,6 @@
 ||zdtag.com^$third-party
 ||zedwhyex.com^$third-party
 ||zeerat.com^$third-party
-||zeotap.com^$third-party
 ||zesep.com^$third-party
 ||zeustechnology.com^$third-party
 ||zoomanalytics.co^$third-party


### PR DESCRIPTION

Why Zeotap Should Not Be Included in the EasyList Adblocker?

Zeotap is a globally recognized Customer Data Platform (CDP) that operates with the highest standards of transparency, data privacy, and compliance. As a company deeply committed to ethical data practices, we believe our inclusion in the EasyList adblocker is unwarranted. Here's why:

Privacy-First Approach: Zeotap has always prioritized consumer privacy. We comply with global data protection regulations like GDPR and CCPA and ensure that all our data handling practices are transparent, secure, and ethical.

No Intrusive Advertising:
Zeotap is not an advertising platform. We do not engage in intrusive or disruptive advertising tactics that typically lead to inclusion in adblocker lists. Our focus is on enabling brands to deliver personalized and data-driven experiences while respecting user preferences and privacy.

Reputable Partnerships:
Zeotap partners with trusted organizations, including leading cloud providers like Google Cloud, to ensure the highest quality standards in data processing and management. Our solutions are trusted by global brands like Audi, McDonald's, and Virgin Media.

Commitment to Compliance:
As a pioneer in data privacy, Zeotap has consistently upheld the principles of user consent and data security. Our platform is designed to respect and protect user data rather than exploit it for unsolicited advertising.

Positive Industry Impact:
Zeotap contributes positively to the digital ecosystem by enabling brands to improve customer experiences without resorting to spam or intrusive advertising. Our mission aligns with creating a better, more user-centric internet.

Misrepresentation of Purpose:
The inclusion of Zeotap in EasyList seems to stem from a misunderstanding of our operations. We are a data solutions provider, not an ad network or platform that disrupts user experiences.

We request EasyList to reevaluate our inclusion and remove Zeotap from its list. As a trusted data partner to global enterprises, our presence in the adblocker list undermines our reputation and is inconsistent with our mission to create ethical and privacy-centric solutions.