### PR TITLE
A: `appstle.com`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -154,6 +154,8 @@
 ||api.ffm.to/sl/e/$image
 ||api.invideo.io/v3/send_analytics_event
 ||api.narrativ.com/favicon.ico
+||api.nextsale.io/client/ping?
+||api.nextsale.io/client/track?
 ||api.samsungfind.com/log-collector
 ||api.streamelements.com/science/
 ||api.takealot.com^$ping


### PR DESCRIPTION
Blocks event logging pings.
This pull request fixes https://github.com/easylist/easylist/issues/18237.