### PR TITLE
Add libanswers.com chat widget

### DIFF
--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -32,7 +32,7 @@ healthshots.com##.healthshotsChannels
 amazon.com##.rufus-panel-container
 healthshots.com##.secBannerWidget
 therealdeal.com##.woot-widget-bubble
-libguides.wmich.edu###lcs_slide_out-11002
+libguides.wmich.edu,hosted.exlibrisgroup.com##[id^=lcs_slide_out]
 ||today.com/oli/
 ! Third-party chat
 ||247-inc.net^$third-party

--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -32,7 +32,6 @@ healthshots.com##.healthshotsChannels
 amazon.com##.rufus-panel-container
 healthshots.com##.secBannerWidget
 therealdeal.com##.woot-widget-bubble
-libguides.wmich.edu,hosted.exlibrisgroup.com##[id^=lcs_slide_out]
 ||today.com/oli/
 ! Third-party chat
 ||247-inc.net^$third-party
@@ -129,6 +128,7 @@ libguides.wmich.edu,hosted.exlibrisgroup.com##[id^=lcs_slide_out]
 ||leadback.ru^$third-party
 ||leadbooster-chat.pipedrive.com^$third-party
 ||leadgenic.ru^$third-party
+||libanswers.com/load_chat.php
 ||live2support.com^$third-party
 ||livechatinc.com^$third-party
 ||livehelpnow.net^$third-party

--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -32,6 +32,7 @@ healthshots.com##.healthshotsChannels
 amazon.com##.rufus-panel-container
 healthshots.com##.secBannerWidget
 therealdeal.com##.woot-widget-bubble
+libguides.wmich.edu###lcs_slide_out-11002
 ||today.com/oli/
 ! Third-party chat
 ||247-inc.net^$third-party


### PR DESCRIPTION
Adds a chat widget at libguides.wmich.edu to the filter list
Blocking this script from loading will remove the chat widget, without having any adverse side effects.