### PR TITLE
A: (umami.is) pikapod.net

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -1566,6 +1566,7 @@
 ||phone-analytics.com^$third-party
 ||photorank.me^$third-party
 ||pi-stats.com^$third-party
+||pikapod.net^$third-party
 ||ping-fast.com^$third-party
 ||pingdom.net^$third-party
 ||pingil.com^$third-party


### PR DESCRIPTION
`pikapod.net` host `umami.is` tracking script.

examples: 

```
https://groovy-manul.pikapod.net/script.js
https://celadon-seriema.pikapod.net/script.js
https://darandil.pikapod.net/script.js
https://df-analytics.pikapod.net/script.js
https://energetic-swan.pikapod.net/script.js
https://jstats.pikapod.net/script.js
https://nebulous-lyrebird.pikapod.net/script.js
https://none-analytics.pikapod.net/script.js
https://platinum-ibis.pikapod.net/script.js
https://qodeer-analytics.pikapod.net/script.js
https://sondercare-umami.pikapod.net/script.js
https://splendid-stingray.pikapod.net/script.js
```