### PR TITLE
A: block digitec-Galaxus pageview (including european version)

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -420,6 +420,7 @@
 ||dhresource.com/dhs/fob/js/common/track/$domain=dhgate.com
 ||digg.com/library/tracker.js
 ||digital.flytedesk.com/js/head.js
+||digitec.ch/api/graphql/track-pageview
 ||discover-metrics.cloud.seek.com.au^
 ||discover.com/QaiuqHH6L7OpQ2dSZzdDRhs6/
 ||dls-account.di.atlas.samsung.com^
@@ -617,6 +618,13 @@
 ||gadgets360.com/analytics.js
 ||gaiaonline.com/internal/mkt_t.php?
 ||gak.webtoons.com^
+||galaxus.at/api/graphql/track-pageview
+||galaxus.be/api/graphql/track-pageview
+||galaxus.ch/api/graphql/track-pageview
+||galaxus.de/api/graphql/track-pageview
+||galaxus.fr/api/graphql/track-pageview
+||galaxus.it/api/graphql/track-pageview
+||galaxus.nl/api/graphql/track-pageview
 ||gamedistribution.com/collect?
 ||gamejolt.com/tick/
 ||gamemonetize.com/account/event.php?


### PR DESCRIPTION
Digitec and Galaxus.ch are owned by the same company.
They recently expanded to Europe too, so I included the european sites too.