### PR TITLE
A: 11freunde.de

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -30,6 +30,7 @@
 @@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|metal-hammer.de|rollingstone.de|stylebook.de
 @@||pruefernavi.de/vendor/elasticsearch/elastic-apm-rum.umd.min.js$~third-party
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
+@@||sams.11freunde.de/ee/irl1/v1/interact?$domain=11freunde.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at
 @@||showheroes.com/publishertag.js$domain=rollingstone.de
 @@||showheroes.com/pubtag.js$domain=rollingstone.de


### PR DESCRIPTION
overblocking self-promo
<img width="1552" alt="Screenshot 2025-01-17 at 10 21 29 AM" src="https://github.com/user-attachments/assets/632c6e6d-eeae-4590-92f7-ac23402bd024" />
