### PR TITLE
M: 11freunde.de

### DIFF
--- a/easyprivacy/easyprivacy_allowlist_international.txt
+++ b/easyprivacy/easyprivacy_allowlist_international.txt
@@ -30,7 +30,7 @@
 @@||outbrainimg.com^$third-party,domain=computerbild.de|fitbook.de|metal-hammer.de|rollingstone.de|stylebook.de
 @@||pruefernavi.de/vendor/elasticsearch/elastic-apm-rum.umd.min.js$~third-party
 @@||responder.wt-safetag.com/resp/api/get/$script,domain=myhermes.de
-@@||sams.11freunde.de/ee/irl1/v1/interact?$domain=11freunde.de
+@@||sams.11freunde.de$domain=11freunde.de
 @@||sams.spiegel.de/ee/irl1/v1/interact?$domain=spiegel.de
 @@||script-at.iocnt.net/iam.js$domain=oe24.at
 @@||showheroes.com/publishertag.js$domain=rollingstone.de


### PR DESCRIPTION
My previous PR did not fix the issue: https://github.com/easylist/easylist/pull/21074/commits so I'd like to propose an updated filter.
Currently, EasyPrivacy overblocks this self-promo banner
![image](https://github.com/user-attachments/assets/256dcc5f-5264-4cfc-8ed9-bb0b50aee8a2)
