### PR TITLE
Remove nslookup.io/pl.js

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -1021,7 +1021,6 @@
 ||npa.thetimes.com/stats
 ||nr-data.noelleeming.co.nz^
 ||nr.noelleeming.co.nz^
-||nslookup.io/pl.js
 ||ntvid.online/cdn-cgi/trace
 ||nyt.com/ads/tpc-check.html$domain=nytimes.com
 ||nytimes.com/v1/purr-cache


### PR DESCRIPTION
This is Plausible analytics, which doesn't track PII, and doesn't use cookies: https://plausible.io/privacy-focused-web-analytics

It's also self-hosted, so it's not sent to a third party.

> EasyPrivacy is an optional supplementary filter list that completely removes all forms of tracking from the internet, including web bugs, tracking scripts and information collectors, thereby protecting your personal data.

So I'd say it doesn't belong on this list?