### PR TITLE
A: Hide ad containers on wionews.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1867,7 +1867,7 @@ dnaindia.com,wionews.com##.ads-box-d90-m300
 hubcloud.club##.ads-btns
 thefinancialexpress.com.bd##.ads-carousel-container
 gosunoob.com,indianexpress.com,matrixcalc.org,philstarlife.com,phys.org,roblox.com,spotify.com##.ads-container
-pcquest.com##.ads-div-style
+pcquest.com,wionews.com##.ads-div-style
 samehadaku.email##.ads-float-bottom
 thetruthaboutcars.com##.ads-fluid-wrap
 spambox.xyz##.ads-four


### PR DESCRIPTION
Site to test: https://www.wionews.com/world/trumps-deportation-flights-costing-852000-for-every-80-migrants-report-8656141