### PR TITLE
A: mail.yahoo.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7200,6 +7200,7 @@ booking.com##.sr-motivate-messages
 yahoo.com###Horizon-ad
 yahoo.com###Lead-0-Ad-Proxy
 yahoo.com###adsStream
+mail.yahoo.com###commerce_card_group_container:has([data-test-id*="affiliate"])
 yahoo.com###defaultLREC
 finance.yahoo.com###mrt-node-Lead-0-Ad
 sports.yahoo.com###mrt-node-Lead-1-Ad


### PR DESCRIPTION
Banner ads are appearing in Yahoo inbox - only in emails from specific companies (i.e. Amazon, TurboTax)

![3118d8ee-2cb0-46a5-82b4-2228b3782762](https://github.com/user-attachments/assets/6a0947c9-2029-476b-9a40-a5749e09a291)
<img width="1645" alt="Screenshot 2025-02-11 at 1 12 04 PM" src="https://github.com/user-attachments/assets/48956d5f-9786-4dde-8495-8776595b1e29" />
