### PR TITLE
removed redundant filter

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_block.txt
+++ b/fanboy-addon/fanboy_notifications_specific_block.txt
@@ -27,7 +27,6 @@
 ||newsukraine.rbc.ua/sworker.js
 ||nookazon.com/firebase-messaging-sw.js
 ||pcguide.com/sp-push-worker-fb.js
-||phys.org/push-sw.js
 ||push.cnnindonesia.com^
 ||push.ictsd.org^
 ||renaultsport.com/spip.php?page=sw.js


### PR DESCRIPTION
`/push-sw.js` already exists as a general blocking rule in `fanboy_notifications_general_block.txt`