### PR TITLE
A: https://gamesfree.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8,6 +8,8 @@ seafoodsource.com###Ad1-300x250
 seafoodsource.com###Ad2-300x250
 seafoodsource.com###Ad3-300x250
 boredbro.com###AdBox728
+gamesfree.com##div#prerollad
+gamesfree.com##div#flashgame:remove-attr(style)
 moviekhhd.biz,webcarstory.com###Ads
 search.avast.com###AsbAdContainer
 ranker.com###BLOG_AD_SLOT_1


### PR DESCRIPTION
Remove preroll ad on gamesfree.com and fix the game window not showing up due to it being hidden while the ad plays.  Website to test: https://www.gamesfree.com/game/pre_civilization.html

Before: 
![easylist_before](https://github.com/user-attachments/assets/8edbe5c9-905d-4878-a6ba-70d9431c99ae)

After: (ignore ruffle error, it is normal for this site) 

![easylist_after](https://github.com/user-attachments/assets/cfe60206-8df4-4509-b682-34b13ba30d79)
