### PR TITLE
Remove applicationinsights.io

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -204,7 +204,6 @@
 ||appboycdn.com^$third-party
 ||appcast.io^$third-party
 ||appdynamics.com^$third-party
-||applicationinsights.io^$third-party
 ||appn.center^$third-party
 ||aprtn.com^$third-party
 ||aprtx.com^$third-party


### PR DESCRIPTION
Was added in 12032dcc9501b382e0464a2e3496bd4328eced08

Reason:
This breaks Azure Data Explorer - A tool by Microsoft to look at telemetry. The URL is present in the learning material by Microsoft.
https://learn.microsoft.com/en-us/azure/data-explorer/query-monitor-data#add-a-log-analytics-workspaceapplication-insights-resource-to-azure-data-explorer-client-tools

Issue: #21268