### PR TITLE
A: https://gamesfree.com and A: https://telex.hu

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -272,6 +272,8 @@ israelnationalnews.com###banner-sticky
 bbcamerica.com,ifc.com,onlinesearches.com,sundancetv.com,wetv.com###banner-top
 4teachers.org###banner-wrapper
 gamesfree.com###banner300
+gamesfree.com##div#prerollad
+gamesfree.com##div#flashgame:style(visibility: visible !important; display: block !important)
 edn.com,planetanalog.com###bannerWrap
 webtoolhub.com###banner_719_105
 today.az###banner_750x90

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -274,6 +274,10 @@ bbcamerica.com,ifc.com,onlinesearches.com,sundancetv.com,wetv.com###banner-top
 gamesfree.com###banner300
 gamesfree.com##div#prerollad
 gamesfree.com##div#flashgame:style(visibility: visible !important; display: block !important)
+telex.hu##.banner-bottom
+telex.hu##.recommendation.recommendation--out
+telex.hu##.recommendation.recommendation--pr
+telex.hu##.title-section__sponsored
 edn.com,planetanalog.com###bannerWrap
 webtoolhub.com###banner_719_105
 today.az###banner_750x90


### PR DESCRIPTION
This removes the pre-roll ad on gamesfree.com when trying to play a game

Changed the method so it does not use :remove-attr() when removing the preroll ad. Flash support or ruffle need to be installed otherwise you get the black screen.

site to test it: https://www.gamesfree.com/game/shop_empire_rampage.html