### PR TITLE
Update easyprivacy_thirdparty.txt

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2815,10 +2815,6 @@
 ||fastly.net/i?
 ||fastly.net/sp.js
 ||vwonwkaqvq-a.global.ssl.fastly.net^
-! CPU abuse
-! https://publicwww.com/websites/%22cloudfront.net%2Fscript.js%22/
-||cloudfront.net./script.js
-||cloudfront.net/script.js
 ! Seals, Websecurity, Protection etc. Unnecessary third-party scripts
 ||antillephone.com^$third-party
 ||beyondsecurity.com^$third-party


### PR DESCRIPTION
This rule blocks anyone on the entire internet from naming a file script.js on all Cloudfront domains. 
This rule should at least include the specific subdomain. 

Imagine one bad actor placing a malicious file inside index.html on a Cloudfront container, you wouldn't block all index.html pages on Cloudfront either. To make matters worse, Brave resolved the DNS and scopes down to the CNAME record domain so any domain that uses Cloudfront behind their own domain is even being flagged.

This entry causes major false positives as this list is consumed by Brave and is not specific enough.