### PR TITLE
Block the .alt special use domain (RFC 9476)

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -75,6 +75,7 @@
 ||alljapanesepass.com/ascripts/gcu.js
 ||alljapanesepass.com/rstat
 ||als-svc.nytimes.com^
+||alt^
 ||altruja.de/js/micro/integration-ga.js
 ||alwayslucky.com/platform/webvitals
 ||amazon.com/1/aiv-web-player/1/OE^


### PR DESCRIPTION
The .alt domain has been defined as a special use domain in RFC 9476.

In the [rfc](https://www.rfc-editor.org/rfc/rfc9476.html#name-privacy-considerations) they note privacy concerns of this assignment:

> For example, a value such as "example.alt" could easily cause a privacy issue for any names in that namespace that are leaked to the Internet. In addition, if a name ending in .alt is sufficiently unique, long-lasting, and frequently leaks into the global DNS, then regardless of how the name is constructed, it can act similar to a web cookie with all the associated downsides of identification or re-identification.

This can be considered preemptive, I am not aware of this being used maliciously at this time.