### PR TITLE
A: [Breakage] https://tile.expert/

### DIFF
--- a/easylist/easylist_allowlist_dimensions.txt
+++ b/easylist/easylist_allowlist_dimensions.txt
@@ -6,6 +6,7 @@
 @@||crystalmark.info/wp-content/uploads/sites/$image,~third-party
 @@||government-and-constitution.org/images/presidential-seal-300-250.gif$image,~third-party
 @@||hiveworkscomics.com/frontboxes/300x250_$image,~third-party
+@@||img.tile.expert/*/*_120x240_$image,~third-party
 @@||img.tile.expert/*/*_300x600_$image,~third-party
 @@||leerolymp.com/_nuxt/300-250.$script,~third-party
 @@||leffatykki.com/media/banners/tykkibanneri-728x90.png$image,~third-party


### PR DESCRIPTION
Dimension generic filter blocking images at https://tile.expert/fr/tile/fondovalle/acidic
<img width="1511" alt="Screenshot 2025-04-04 at 11 21 35" src="https://github.com/user-attachments/assets/fccf375d-514d-4122-880e-c96da43307fe" />
