### PR TITLE
bing.com breakage

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7596,7 +7596,6 @@ bing.com##cs-native-ad-card
 bing.com##div[aria-label$="ProductAds"]
 bing.com##div[class="ins_exp tds"]
 bing.com##div[class="ins_exp vsp"]
-bing.com##li.b_ans[data-partnertag][role="presentation"]
 bing.com##li[data-idx]:has(#mm-ebad)
 ! kayak
 checkfelix.com,kayak.*,swoodoo.com###resultWrapper > div > div > [role="button"][tabindex="0"] > .yuAt-pres-rounded


### PR DESCRIPTION
bing.com breakage - results blocked with the rule `bing.com##li.b_ans[data-partnertag][role="presentation"]`

![image](https://github.com/user-attachments/assets/b2de4471-9c19-4bd5-86d5-f0c5d0441b36)
![image](https://github.com/user-attachments/assets/eff94cec-9f8c-4e80-b403-382357109d2b)
