### PR TITLE
A: whitelist `docs.sentry.io` in EasyPrivacy allowlist (#21643)

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -500,3 +500,5 @@
 ! Heatmap
 @@||heatmap.it^$domain=heatmap.com|heatmap.it|heatmap.me|heatmap.org
 @@||komas19.xyz/cdn-cgi/apps/$script,~third-party
+! Allow Sentry documentation site (Issue #21643)
+@@||docs.sentry.io^$third-party


### PR DESCRIPTION
resolve #21643