### PR TITLE
P: Removed do7go.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -7100,7 +7100,6 @@
 ||dnlqcffvhqvgdh.com^
 ||dntigerly.top^
 ||dnvgecz.com^
-||do7go.com^
 ||doabbrews.shop^
 ||doadacefaipti.net^
 ||doaipomer.com^


### PR DESCRIPTION
added here https://github.com/easylist/easylist/commit/de5a0e9d95de41990a28a8e40ab6969a7b718c07

`do7go.com` is used by `doodstream.com` to embed there video player.

e.g. `do7go.com/e/v5b8y2ibxw0x`