### PR TITLE
Fix loading embedded article content on beobachter.ch

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -83,7 +83,7 @@
 ||cookieinformation.com^$third-party
 ||cookieinfoscript.com^$third-party
 ||cookielab.dk^$third-party
-||cookielaw.org^$third-party
+||cookielaw.org^$third-party,domain=~beobachter.ch
 ||cookiemanager.onm.de^
 ||cookiemanager1.contentforces.com^$third-party
 ||cookiemonster.is^$third-party


### PR DESCRIPTION
Fixes embedded article content like diagrams which are hidden behind an "allow cookies" placeholder. Without this change, clicking "allow cookies" has no effect and the embedded content isn't loaded.

Site to test: https://www.beobachter.ch/magazin/wohnen/so-gibts-platz-fur-alle-777408