### PR TITLE
https://fit1.gr/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -490,6 +490,7 @@
 ||event-tracker-library.mediaownerscloud.com^
 ||glami.gr/js/compiled/pt.js
 ||kwikmotion.com^*/videojs-kwikstat.min.js
+||metrics.find.gr^
 ||stats-real-clients.zentech.gr^
 ! Hebrew
 ||tag.weezmo.com^


### PR DESCRIPTION

`analytics.skroutz.gr` was not added to the filter because it caused breakage

https://github.com/easylist/easylist/commit/a700c43010c10514e0f7d887542174eeac4ed919
https://github.com/uBlockOrigin/uAssets/issues/15697