### PR TITLE
D: convertexperiments.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -509,7 +509,6 @@
 ||conversionruler.com^$third-party
 ||convertagain.net^$third-party
 ||convertcart.com^$third-party
-||convertexperiments.com^$third-party
 ||convertglobal.com^$third-party
 ||convertro.com^$third-party
 ||cooladata.com^$third-party


### PR DESCRIPTION
Hey @ryanbr,

This addresses https://github.com/easylist/easylist/issues/21244, it is to remove that false positive, it's legit, we are an AB testing service (convert.com) that just run AB tests by our customers on their own websites, for them and by them, we also run permanent personalizations for them, the only metrics we collect are related to the AB tests like Conversion Rates and Revenue per Visitors, we're the most private and conscious in the whole industry, and our worst competitors are not banned, while we are. We are not an analytics service, we are a web experimentation service.

All is explained in the issue. As an open-source maintainer myself, **I wouldn't lose your time tagging you if I didn't have a solid case**. 

Thank you for your consideration.