### PR TITLE
A: https://act.campax.org

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -337,6 +337,7 @@ jpc.de##.cookieconsent--container
 proaurum.de##.cookiefirst-root
 optimatours.de##.cookies-confirm-bg
 optimatours.de##.cookies-confirm-bg-backdrop
+campax.org##.cookies-consent
 weddyplace.com##.core-modal
 aok-erleben.de##.csm_wrapper
 barfuss.it##.css-1ienoy8.e1gi2aal2


### PR DESCRIPTION
Note that campax.org is multilingual (FR and IT besides DE). Also, there's another rule for a hebrew site with the same selector:

https://github.com/easylist/easylist/blob/f434e9fafed029d0391496ec805d93c761c48a60/easylist_cookie/easylist_cookie_international_specific_hide.txt#L1515

So, these rules could be merged and moved to [`easylist_cookie/easylist_cookie_specific_hide.txt`](https://github.com/easylist/easylist/blob/master/easylist_cookie/easylist_cookie_specific_hide.txt), I guess. Let me know if I should file a PR.