### PR TITLE
A: espn.com

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -28477,6 +28477,7 @@
 ||digitalkites.com^$third-party
 ||digitalpush.org^$third-party
 ||digitalthrottle.com^$third-party
+||disneyadvertising.com^$third-party
 ||disqusads.com^$third-party
 ||dl-protect.net^$third-party
 ||dochase.com^$third-party


### PR DESCRIPTION
on homepage of `espn.com`, 'ICYMI' section on the right side has a pre-roll ad  
using US VPN

<img width="1613" alt="Screenshot 2025-06-05 at 6 12 37 PM" src="https://github.com/user-attachments/assets/765b540c-0066-4076-b538-a70fabe84c54" />
