### PR TITLE
Fix WordPress admin WPConsent plugin blocking rule

### DIFF
--- a/easylist_cookie/easylist_cookie_general_block.txt
+++ b/easylist_cookie/easylist_cookie_general_block.txt
@@ -938,7 +938,7 @@
 /wp-content/plugins/cookies-and-content-security-policy
 /wp-content/plugins/real-cookie-banner-pro/*
 /wp-content/plugins/webtoffee-cookie-consent/*
-/wp-content/plugins/wpconsent-premium/*
+/wp-content/plugins/wpconsent-premium/build/frontend*
 /wp-gdpr-compliance/assets/js/front.min.js
 /wp-tarteaucitron-js-self-hosted/js/main.js
 /wp-tarteaucitron-js/js/tarteaucitron/tarteaucitron.js


### PR DESCRIPTION
Fixes the rule to allow users to still use the WP consent plugin admin area for WordPress sites. While still blocking the cookie banner on the front end of the sites.