### PR TITLE
Remove entry for monitoring route

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1506,7 +1506,6 @@
 /monitor/v1/log
 /monitor?rtype=
 /monitor_analytic.js
-/monitoring?o=$xmlhttprequest
 /monitus.js
 /monsido.js
 /mormont.js


### PR DESCRIPTION
Hey guys!

Some of our users' telemetry endpoints are currently being blocked by this EasyPrivacy list, preventing essential error and performance monitoring.

We have a [privacy by default policy](https://sentry.io/lp/privacy-by-default/) for respecting every user's privacy.

I have read the readme on your policy of blocking tracking but in this case this is directly benefiting end users:
- Faster bug fixes when apps crash or break
- Better app stability through proactive error detection
- Users get better software with fewer issues
- This isn't user tracking or analytics - it's purely for making software work better for everyone.

Would be great if you would consider getting this endpoint off the list!