### PR TITLE
Revert 14c14e5. Blocking discord root domain breaks service

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -7690,7 +7690,6 @@
 ||disconnectedlasting.com^
 ||disconnectfrequentinvalid.com^
 ||disconnectthirstyron.com^
-||discord.com^
 ||discospiritirresponsible.com^
 ||discountplacidlysymphony.com^
 ||discountstickersky.com^


### PR DESCRIPTION
Reverting 14c14e5 as it breaks all of discord's functionality