### PR TITLE
A: https://nodejs.org/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7890,3 +7890,5 @@ checkfelix.com,kayak.*,swoodoo.com##div[class*="-ad-card"]
 checkfelix.com,kayak.*,swoodoo.com##div[class*="-adInner"]
 checkfelix.com,kayak.*,swoodoo.com##div[data-resultid]:has(a.IZSg-adlink)
 checkfelix.com,kayak.*,swoodoo.com##div[id^="inline-"]
+! nodejs.org homepage sponsored button
+nodejs.org##a[href^="https://www.herodevs.com/"][role="button"]


### PR DESCRIPTION
this rule removes the sponsored button on nodejs' homepage, but leaves the sponsor's mention on other pages (such as https://nodejs.org/en/about/previous-releases#commercial-support)

before:
<img width="506" alt="image" src="https://github.com/user-attachments/assets/27acf733-edf2-4251-8b6f-bdab03c5415c" />

after:
<img width="513" alt="image" src="https://github.com/user-attachments/assets/63189397-117d-4441-b022-4cf0a500cc9a" />