### PR TITLE
M: https://www.sofascore.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1822,7 +1822,7 @@ bramptonguardian.com##.adSlot___3IQ8M
 drive.com.au##.adSpacing_drive-ad-spacing__HdaBg
 thestockmarketwatch.com##.adSpotPad
 healthnfitness.net##.adTrack
-sofascore.com##.adUnitBox
+sofascore.com##.ad-unit-container
 dailyo.in##.adWrapp
 romper.com##.adWrapper
 barrons.com##.adWrapperTopLead
@@ -2224,7 +2224,6 @@ piokok.com##.as-bar
 arcadespot.com##.as-incontent
 arcadespot.com##.as-label
 arcadespot.com##.as-unit
-sofascore.com##.as_stretch
 theinertia.com##.asc-ad
 rentry.co##.asd_1
 asianjournal.com##.asian-widget
@@ -3325,7 +3324,6 @@ chess.com##.game-over-ad-component
 pokernews.com##.gameCards
 monstertruckgames.org##.gamecatbox
 yourstory.com##.gap-\[10px\]
-sofascore.com##.gap_2xs
 home-assistant-guide.com##.gb-container-429fcb03
 home-assistant-guide.com##.gb-container-5698cb9d
 home-assistant-guide.com##.gb-container-bbc771af
@@ -5742,7 +5740,6 @@ howstuffworks.com##.z-999
 culturemap.com,rightwingnews.com##.z-ad
 giphy.com##.z-stickyAd
 tekdeeps.com##.zAzfDBzdxq3
-sofascore.com##.z_fixed
 ign.com,mashable.com,pcmag.com##.zad
 windows101tricks.com##.zanui-container
 techspot.com##.zenerr
@@ -7101,7 +7098,6 @@ andronicos.com,haggen.com,randalls.com##.pc-grid-prdItem:has(span[data-qa="prd-i
 sainsburys.co.uk##.pd-merchandising-product:has(.product-header--citrus[data-testid="product-header"])
 hannaford.com##.plp_thumb_wrap:has([data-citrusadimpressionid])
 niagarathisweek.com##.polarBlock:has(.polarAds)
-sofascore.com##.pos_initial.ta_center:has-text(Advertisement)
 404media.co##.post__content > p:has(a[href^="https://srv.buysellads.com/"])
 404media.co##.post__content > p:has-text(This segment is a paid ad)
 myntra.com##.product-base:has(.product-waterMark)


### PR DESCRIPTION
Hi, your latest additions motivated by this issue https://github.com/uBlockOrigin/uAssets/issues/29046 break `sofascore.com` site features. That is because you target classes which are used for content styling.

Because of this, we at Sofascore have decided to add a class which will transparently target all ads content on the site, but won't break any of the features.

Comparison between your targeting and what I commit can be seen on the screen recording.
You can see that by using the old targets the user can't see player statistics for the match (targeted by `z_fixed` class) and can't change seasons on competition page (also targeted by `z_fixed` class). Using this new class will target only ad content and won't break any of the features.

https://github.com/user-attachments/assets/ab65470d-c1c6-4732-a3a0-2c54d9bc8189
https://github.com/user-attachments/assets/39743d01-2485-4d75-bde4-9566c0fe01df


