### PR TITLE
Remove the Amazon Prime auto-renew disabled nag screen

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -236,6 +236,7 @@ sony.net##.ly_pagetop-main
 cheknews.ca##.mailchimp-form
 rogerebert.com##.mailing-list
 amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##.maple-banner
+amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##div[data-csa-c-widget-id="prime-pcr-autorenew-risk-widget"]
 fandom.com##.marketing-notifications
 motherless.com##.media-action-networks
 hotklix.com##.menu

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -236,7 +236,7 @@ sony.net##.ly_pagetop-main
 cheknews.ca##.mailchimp-form
 rogerebert.com##.mailing-list
 amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##.maple-banner
-amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##div[data-csa-c-widget-id="prime-pcr-autorenew-risk-widget"]
+amazon.ae,amazon.ca,amazon.cn,amazon.co.jp,amazon.co.uk,amazon.com,amazon.com.au,amazon.de,amazon.es,amazon.fr,amazon.in,amazon.nl,amazon.sg##div[data-csa-c-painter="prime-risk-message-cx-cards"]
 fandom.com##.marketing-notifications
 motherless.com##.media-action-networks
 hotklix.com##.menu


### PR DESCRIPTION
Amazon is hoping that I'll accidentally click this after not accidentally clicking 3 times on "yes I want to disable auto renew". 🤷

![image](https://github.com/user-attachments/assets/099cb5d1-17b1-4f31-bbb6-6826028655b5)

Go away, nag screen!