### PR TITLE
Fix overly strict rule for social share buttons

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -986,7 +986,7 @@ sordum.org##.sbar_social_div
 sasktoday.ca##.sc-expanded
 radio-canada.ca##.sc-sa6od2-0
 shopclues.com##.sc_socialconnection
-pornbox.com##.scene-data__prop
+pornbox.com##.scene-data__share
 oracle.com##.scl-icons
 bestnewshere.com,politicalwire.com##.scriptlesssocialsharing
 cars.com##.sds-social-share


### PR DESCRIPTION
The old rule was hiding relevant scene properties such as the release date and duration, this will just hide the annoying "Share" button