### PR TITLE
R: calendly.com bot detection script

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -468,7 +468,6 @@
 ||c3metrics.medifast1.com^
 ||cache2.delvenetworks.com^
 ||cafemedia.com/topics/clickstream-event
-||calendly.com/telemetry.js
 ||californiatimes.com/privacy/$image
 ||calltrack.co^
 ||calltrk.com/companies/


### PR DESCRIPTION
Hello,

Before I discuss the content of the PR, in the interest of full disclosure: I'm a staff engineer at Calendly and tech lead for its Trust & Safety team. Inside and outside of work, I use EasyList offerings personally via the uBlock Origin extension for Firefox. My team is responsible for the integration of the script in question and we review all related code, but realize that I'm asking you all to take us at our word.

The Calendly product is not ad-supported in any way. We encourage our users' to run ad blockers if they prefer (as I personally do). Unfortunately, the inclusion of this particular script breaks critical account security apparatus, making it more difficult for us to continue that recommendation.

`telemetry.js` is our vendor's device fingerprinting script (Stytch). We use it exclusively for its [marketed use case](https://stytch.com/docs/fraud/guides/device-fingerprinting/overview) - preventing fraud and other abuse against our account holders by bad actors. Fingerprinting is necessary for this product because the actors (account holders' own users) are anonymous. The script is used for "tracking" only in the general sense: internally by our system for the purpose of determining if an incoming request is a bot. There are no cookies dropped nor is our user's personally identifiable information handled by the script/vendor backend system. This script and vendor relationship were heavily vetted by my engineering team, as well as independently by our security, legal, and procurement teams.

Let me know if it would be more appropriate to use `$third-party` rather than removing the entry, since `booking-dfp.calendly.com/telemetry.js` will only be loaded on `calendly.com` and not any other domain. Not sure if I am understanding [these docs I found](https://adguard.com/kb/general/ad-filtering/create-own-filters/#third-party-modifier) correctly or not but:

eg. `||calendly.com/telemetry.js^$third-party`