### PR TITLE
A: https://tldr.tech/

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_uBO.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_uBO.txt
@@ -663,3 +663,5 @@ aulart.com##body:style(overflow: auto !important; max-height: unset !important;)
 palestinechronicle.com###newsletter_subscribition_box
 palestinechronicle.com##.jquery-modal
 palestinechronicle.com##body,html:style(overflow: auto !important; position: initial !important;)
+! tldr.tech
+tldr.tech##article:has(:is(h1,h2,h3,h4,h5,h6):has-text(Sponsor))


### PR DESCRIPTION
Removes `<article>` based of text `(Sponsor)` within h1-h6 element

<img width="676" height="502" alt="image" src="https://github.com/user-attachments/assets/200f4efd-5fe1-42c9-9a71-3c4b06652426" />
