### PR TITLE
A: ts-analysis.shoalter.com

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -1064,6 +1064,7 @@
 ||trackcommon.hujiang.com^
 ||tracker.ai.xiaomi.com^
 ||trail.53kf.com^
+||ts-analysis.shoalter.com^
 ||udblog.huya.com^
 ||uestat.video.qiyi.com^
 ||urbtix.hk/api/internet/log/add?


### PR DESCRIPTION
Tracking server used by HKTV, a popular Hong Kong ecommerce platform