### PR TITLE
A: [Breakage] rawstory.com

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -204,6 +204,7 @@ thestudentroom.co.uk#@#.fixed_ad
 songlyrics.com#@#.footer-ad
 megumi-jyosanin.com#@#.footer_ad
 634929.jp,d-hosyo.co.jp#@#.footer_ads
+rawstory.com#@#.full-ad
 guloggratis.dk#@#.gallery-ad
 davidsilverspares.co.uk#@#.greyAd
 deep-edge.net,forums.digitalspy.com,marketwatch.com#@#.has-ad


### PR DESCRIPTION
Entire top section is hidden by the following EasyList filter: ##.full-ad Although website serves a wall/paywall this part of the website content is mistakenly hidden by EasyList.
<img width="353" height="809" alt="rawstory_blocked-debugModeON-20250812-214757" src="https://github.com/user-attachments/assets/9ebfaeef-6b5a-4259-9ed5-fe78564fd54d" />

Debugging steps:
When EasyList filter is enabled the website content starts from Big Stories section instead.

When EasyList is disabled the website content starts from Trending / Opinion / Featured sections (expected behavior).