### PR TITLE
P: wfmz.com

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -250,6 +250,7 @@ geekwire.com#@#.sponsor_post
 toimitilat.kauppalehti.fi#@#.sponsored-article
 zdnet.com#@#.sponsoredItem
 kingsofchaos.com#@#.textad
+wfmz.com#@#.tnt-dmp-reactive
 k24tv.co.ke#@#.top-ad
 pramborsfm.com#@#.top-ads
 bibliaon.com#@#.top-banner-ad


### PR DESCRIPTION
on `https://www.wfmz.com/news/#tncms-source=Top-Navigation-News` the "make account/sign up" CTAs in the side bar are not visible

<img width="1321" height="755" alt="wfmz-20250827-221316" src="https://github.com/user-attachments/assets/fa1df401-7da0-4a4e-a15c-288418ca9a70" />
