### PR TITLE
A: https://gamesfree.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8,6 +8,8 @@ seafoodsource.com###Ad1-300x250
 seafoodsource.com###Ad2-300x250
 seafoodsource.com###Ad3-300x250
 boredbro.com###AdBox728
+gamesfree.com##div#prerollad
+gamesfree.com##div#flashgame:remove-attr(style)
 moviekhhd.biz,webcarstory.com###Ads
 search.avast.com###AsbAdContainer
 ranker.com###BLOG_AD_SLOT_1


### PR DESCRIPTION
Removes preroll ad before loading games on gamesfree.com


Before: 

<img width="803" height="700" alt="kép" src="https://github.com/user-attachments/assets/c9acdd56-e547-44b8-b053-5b71d5a3a198" />

After (ruffle fails on this site even without this rule, but it instantly loads):

<img width="797" height="704" alt="kép" src="https://github.com/user-attachments/assets/124d829c-a36f-4880-b94a-7380b77c8781" />
