### PR TITLE
M: namu.wiki

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -6732,7 +6732,7 @@ spin.com##div[id*="-promo-mrec-"]
 chrome-stats.com##div[id*="billboard_responsive"]
 thenewspaper.gr##div[id*="thene-"]
 diskingdom.com##div[id="diski-"]
-ja.namu.wiki,en.namu.wiki##div[id][class]:empty
+en.namu.wiki,ja.namu.wiki##div[id][class]:empty
 thewire.in##div[id^="ATD_"]
 geeksforgeeks.org##div[id^="GFG_AD_"]
 kisshentai.net,onworks.net##div[id^="ad"]


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/AdguardFilters/issues/199174
The namu.wiki (https://namu.wiki) performs their designed adblock misbehavior to annoy an adblocker.
This PR limits the cosmetic filter's application range to its translation website.