### PR TITLE
Remove ad-placeholders from multiple websites

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5163,11 +5163,12 @@ caixinglobal.com,chicagobusiness.com,chronicle.co.zw,clinicaltrialsarena.com,dai
 newegg.com##.sponsored-brands
 crypto.news##.sponsored-button-group
 cheknews.ca##.sponsored-by
-pcgamer.com##.sponsored-card
+gamesradar.com,livescience.com,pcgamer.com,space.com,techradar.com,tomsguide.com,tomshardware.com##.sponsored-card
 washingtontimes.com##.sponsored-heading
 itweb.co.za##.sponsored-highlights
 breakingdefense.com##.sponsored-inline
 freesvg.org##.sponsored-main-detail
+fitandwell.com,homesandgardens.com,idealhome.co.uk,marieclaire.com##.sponsored-post--placeholder
 dermstore.com,lookfantastic.com##.sponsored-product-plp
 crn.com##.sponsored-resources
 coincarp.com##.sponsored-td


### PR DESCRIPTION
`gamesradar.com,livescience.com,pcgamer.com,space.com,techradar.com,tomsguide.com,tomshardware.com` all these websites are from the same owner and have the same ad-placeholders, so the same ##.sponsored-card rule works for all of them.

`fitandwell.com,homesandgardens.com,idealhome.co.uk,marieclaire.com` also seem to have the same owner and the rule ##.sponsored-post--placeholder works for all of them.

Example sites, 
`https://www.space.com/space-exploration/launches-spacecraft/spacex-starlink-launch-group-17-10-vandenberg-space-force-base` 

`https://www.tomsguide.com/ai/i-used-googles-nano-banana-to-transform-my-kids-artwork-here-are-the-5-prompts-that-worked-best`

`https://www.marieclaire.com/fashion/celebrity-style/lily-collins-calvin-klein-new-york-fashion-week-front-row/` 

`https://www.fitandwell.com/exercise/flexibility/i-tried-this-one-simple-stretch-and-its-completely-changed-the-way-i-recover-post-workout`