### PR TITLE
(Annoyances) Hide Brave download suggestion | Brave Search 

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -384,6 +384,7 @@ coconuts.co###coco-plus-membership-section
 theguardian.com###contact-the-guardian
 euractiv.com###contribs_banner
 search.brave.com###cta-make-default
+search.brave.com##.download-cta
 news9live.com###cube_spinner
 jweekly.com###custom_html-2
 marijuanamoment.net###custom_html-8


### PR DESCRIPTION
When opening Brave Search (`https://search.brave.com/`) a Brave Browser download suggestion is displayed.
Added Brave Search `.download-cta` selector to Fanboy's Annoyances specific hide.

<img width="1260" height="645" alt="download suggestion annoyance" src="https://github.com/user-attachments/assets/01dc5330-639f-4170-a4f3-0bd107c576c4" />
