### PR TITLE
A: mail.sapo.pt

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8198,3 +8198,5 @@ checkfelix.com,kayak.*,swoodoo.com##div[class*="-ad-card"]
 checkfelix.com,kayak.*,swoodoo.com##div[class*="-adInner"]
 checkfelix.com,kayak.*,swoodoo.com##div[data-resultid]:has(a.IZSg-adlink)
 checkfelix.com,kayak.*,swoodoo.com##div[id^="inline-"]
+! mail.sapo.pt
+mail.sapo.pt##.addsTaboola


### PR DESCRIPTION
Remove add leftover on mail.sapo.pt, in the inbox. (You have to create an email account to access the inbox.)

The removed ad leftover is the following blue box:
<img width="868" height="395" alt="image" src="https://github.com/user-attachments/assets/7626e4ea-36c8-4a58-a59c-932b3ccde9b8" />
