### PR TITLE
A: observador.pt

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8198,3 +8198,5 @@ checkfelix.com,kayak.*,swoodoo.com##div[class*="-ad-card"]
 checkfelix.com,kayak.*,swoodoo.com##div[class*="-adInner"]
 checkfelix.com,kayak.*,swoodoo.com##div[data-resultid]:has(a.IZSg-adlink)
 checkfelix.com,kayak.*,swoodoo.com##div[id^="inline-"]
+! observador.pt
+observador.pt##.obs-ad-placeholder


### PR DESCRIPTION
Hide the enormous ad placeholder on `https://observador.pt/2025/09/17/psp-apreende-taser-levado-por-aluno-para-escola-da-marinha-grande/` (and other articles).

<img width="1436" height="559" alt="image" src="https://github.com/user-attachments/assets/d3c03f98-0e4c-4d0a-ab75-da2bfe4c014a" />

(“Publicidade” means advertising)