### PR TITLE
P: bpstat.bportugal.pt

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_allowlist_general_hide.txt
@@ -261,6 +261,7 @@ facebook.com,messenger.com#@#div[data-testid="cookie-policy-banner"]
 cookielaw.org#@#section.cookie-banner
 ul.se#@#section.cookie-bar
 yoigo.com#@#thor-cookies
+bpstat.bportugal.pt#@#.cookies_bar
 ! truste fixes
 concursolutions.com,forbes.com,formula1.com,fortune.com,proximus.be,proximustv.be,sap.com,tmz.com,tripit.com#@##consent_blackbar
 concursolutions.com,forbes.com,formula1.com,fortune.com,proximus.be,proximustv.be,sap.com,tmz.com,tripit.com#@##truste-consent-track

--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2928,3 +2928,5 @@ anjunadeep.co##.privacy-notice-gdpr-container
 anjunadeep.co###body,html:style(overflow: auto !important; position: initial !important;)
 ! gpiaaf.gov.pt
 gpiaaf.gov.pt##+js(set-cookie, WarningsAndPolicyAccepted, true)
+! bpstat.bportugal.pt
+bpstat.bportugal.pt##+js(set-cookie, bdp_use_cookies, notagree)


### PR DESCRIPTION
Fixes the website being broken, in the same vein as #22329.

<img width="929" height="681" alt="image" src="https://github.com/user-attachments/assets/53782168-df0f-4636-bdae-b971cabd0d54" />

(note there is no way to close this broken cookie banner, making the site unusable)

The consent bar is unhidden on all browsers and a set-cookie rule is added for uBO.

The set-cookie rule does not work yet, because "notagree" is not yet added as a safe set-cookie value. I’ve requested it to be added in <https://github.com/uBlockOrigin/uBlock-issues/issues/3815>. Until then, uBO users would just see the normal consent bar.