### PR TITLE
A: https://gamesfree.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -9,7 +9,7 @@ seafoodsource.com###Ad2-300x250
 seafoodsource.com###Ad3-300x250
 boredbro.com###AdBox728
 gamesfree.com##div#prerollad
-gamesfree.com##div#flashgame:remove-attr(style)
+gamesfree.com##div#flashgame:style(visibility: visible !important; display: block !important)
 moviekhhd.biz,webcarstory.com###Ads
 search.avast.com###AsbAdContainer
 ranker.com###BLOG_AD_SLOT_1


### PR DESCRIPTION
Removes fake loading screen with a static ad before showing the game content window.

Site to test this:

https://www.gamesfree.com/game/shop_empire_rampage.html

You need to have ruffle extension installed when testing this otherwise you get a black window instead which will look like this, it is due to mainstream browsers no longer supporting flash not because these rules breaking the site.

<img width="1032" height="747" alt="Képernyőkép 2025-09-29 110740" src="https://github.com/user-attachments/assets/a62b0093-7e4c-4b68-b695-3d1c03f4f0ce" />


Without:

<img width="803" height="700" alt="485584901-c9acdd56-e547-44b8-b053-5b71d5a3a198" src="https://github.com/user-attachments/assets/b4e9b7c2-a29f-4d97-bf31-4db3e3d309aa" />


https://github.com/user-attachments/assets/798fa572-12d1-4aa2-a320-de179fa014ec

With these rules:

<img width="797" height="704" alt="485585147-124d829c-a36f-4880-b94a-7380b77c8781" src="https://github.com/user-attachments/assets/b962bd7a-9a77-4255-9009-4a0580503009" />


https://github.com/user-attachments/assets/d2db5f9f-1e32-41b7-b2cf-1519dda747b0

I could not possibly provide more info that this does not break anything on this site.

