### PR TITLE
A: EFF Cover Your Tracks

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -482,6 +482,7 @@
 ||discover-metrics.cloud.seek.com.au^
 ||dls-account.di.atlas.samsung.com^
 ||dmtgvn.com/wrapper/js/common-engine.js$domain=rt.com
+||do-not-tracker.org^
 ||docs.github.com/events
 ||dollartree.com/ccstoreui/*/analytics/
 ||domainit.com/scripts/track.js
@@ -599,6 +600,7 @@
 ||events.turbosquid.com^
 ||events2.www.edenfantasys.com^
 ||everywatch.com/ingest/
+||eviltracker.net^
 ||evs.icy-lake.kickstarter.com^
 ||evs.sgmt.loom.com^$script
 ||excess.duolingo.com/batch
@@ -1732,6 +1734,7 @@
 ||tracker.nbcuas.com^
 ||tracker.ranker.com^
 ||tracker.shopclues.com^
+||trackersimulator.org^
 ||tracking.bloomberg.com^
 ||tracking.carsales.com.au^
 ||tracking.christianpost.com^


### PR DESCRIPTION
Add the EFF marketing stunt to the list. Cover Your Tracks [expects tools to include their URLs](https://coveryourtracks.eff.org/about#:~:text=we%20strive%20to%20have%20our%20test%20domains%20included%20in%20such%20tools%E2%80%99%20lists) in their filtering...

Inclusion to EasyList will stop the extremely misleading "partial protection" result from showing up in all major web browser using an ad-blocker and put an end to misinformation campaigns like this one from everyone's favorite ~~adware~~ browser: https://x.com/brave/status/1914122556375986422