### PR TITLE
M: cnn.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -491,6 +491,7 @@
 ||mbauniverse.com/sites/default/files/shree.png
 ||media-amazon.com/images/S/apesafeframe/ape/sf/$script
 ||media.babylonbee.com/ads/
+||media.max.com/*/dash.mpd^$domain=cnn.com
 ||media.notthebee.com/ads/
 ||media.tickertape.in/websdk/*/ad.js
 ||mediatrias.com/assets/js/vypopme.js


### PR DESCRIPTION
on `https://www.cnn.com/2025/10/01/politics/video/hakeem-jeffries-ai-video-trump-government-shutdown-ldn-digvid`, there are pre-roll ads before the video news content begins

<img width="1507" height="981" alt="pre-roll-cnn" src="https://github.com/user-attachments/assets/2357a78e-aadb-43ff-bf50-5e4445e7893a" />
