### PR TITLE
A: Block znsrc.com/o/*$image in easyprivacy_general_emailtrackers.txt

### DIFF
--- a/easyprivacy/easyprivacy_general_emailtrackers.txt
+++ b/easyprivacy/easyprivacy_general_emailtrackers.txt
@@ -269,6 +269,7 @@
 /wf/open?upn=$image
 /wizrocketmail.net/r?$image
 /znsrc.com/c/*$image
+/znsrc.com/o/*$image
 ://2ip.*/member_photo/$third-party
 ://cl.melonbooks.co.jp/c/$image
 ://e.*/open?$image


### PR DESCRIPTION
This domain is used in "invisible" tracking pixels in recruiter emails e.g.

```
<img=
 align=3D"left" width=3D"0" height=3D"0" style=3D"border:0;width:0px;height=
:0px;" alt=3D"" src=3D"https://znsrc.com/o/uxkbbmicyqmw">
```