### PR TITLE
A: hide substack newsletter subscribe popup and opaque layer

### DIFF
--- a/fanboy-addon/fanboy_newsletter_general_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_general_hide.txt
@@ -1197,6 +1197,8 @@
 ##.markup.body > .subscribe-widget
 ##.pc-reset > ._container_cjrxc_1
 ##.single-post-container > .subscribe-footer
+##article.newsletter-post div[role="dialog"][aria-label="Subscribe modal"]
+##article.newsletter-post div[role="dialog"][aria-label="Subscribe modal"] + div[class^="background-"]
 ! alextimes.com
 ##.cpcta-flyin
 ! nlgate Newsletter


### PR DESCRIPTION
Remove the newsletter subscription popup (and the opaque background obscuring the article text) appearing after scrolling down the page on a Substack article.

No domain is specified in the filter rule because sites can have custom domain.

This is my first contribution, so please let me know if the filter needs to be modified or needs to be moved to another file. 🙏🏼

## Sites to test this on
- https://www.chalmermagne.com/p/rearranging-the-deckchairs
- https://www.worksinprogress.news/p/why-ai-isnt-replacing-radiologists
- https://www.siliconcontinent.com/p/designed-for-weakness

I tested this on Brave Browser.

## Before
<img width="991" height="798" alt="image" src="https://github.com/user-attachments/assets/bf34a6fe-61b2-429e-9dd6-5eb7eb733234" />

## After
<img width="1054" height="948" alt="image" src="https://github.com/user-attachments/assets/b4b48e56-c9d8-4604-8a8b-547ccfbd4bdc" />
