### PR TITLE
A: golem.de

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7105,6 +7105,7 @@ livetv.sx##tr[height] ~ tr > td[colspan][height][bgcolor="#000000"]
 morningagclips.com##ul.logo-nav
 greyhound-data.com##ul.ppts
 greatandhra.com##ul.sortable-list > div
+golem.de##article[class*="-variant-affiliate"]
 !!! top-level domain wildcard
 autoscout24.*##img[referrerpolicy="unsafe-url"]
 costco.*##div[data-testid="AdSet-all-sponsored_products"]


### PR DESCRIPTION
Not sure if I put this in the correct file and place. I couldn't find any guidelines for this, but I hope this change is fine.

This hides ad 'news' articles that are marked as such. URL for testing: https://www.golem.de/

<img width="1082" height="906" alt="golem" src="https://github.com/user-attachments/assets/c0e3e626-33fc-4c19-8394-a15d7f4ba704" />
