### PR TITLE
A: Update admiral tracking servers

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -21390,6 +21390,7 @@
 ||mpay69.com^
 ||mpbrz.com^
 ||mpbsunbusk.com^
+||mpdsdrjdbrl.com^
 ||mpeowvqnbeoah.online^
 ||mpfgnmfw.com^
 ||mpgnodally.qpon^
@@ -26164,6 +26165,7 @@
 ||poireabbot.cfd^
 ||poised-fear.pro^
 ||poised-layer.pro^
+||poisedbuilding.pro^
 ||poisegel.com^
 ||poisegenetically.com^
 ||poisingalong.shop^
@@ -38861,6 +38863,7 @@
 ||ypvibqgydnejr.space^
 ||yqfbofrwqqukn.online^
 ||yqftcpvaynfq.com^
+||yqgyfmjmtnace.online^
 ||yqjshgx.bar^
 ||yqjsyabpzegzd.space^
 ||yqkvvecmwpu.com^


### PR DESCRIPTION
Admiral's adwall request domain: `haikusoap.com`

<img width="1171" height="894" alt="image" src="https://github.com/user-attachments/assets/1f95fbcc-3aee-4d41-8183-7ac875a1a739" />
