### PR TITLE
M: cnn.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -453,6 +453,7 @@
 ||media-amazon.com/images/S/apesafeframe/ape/sf/$script
 ||media.babylonbee.com/ads/
 ||media.max.com/*/dash.mpd^$domain=cnn.com
+||media.max.com/*/main.mpd^$domain=cnn.com
 ||media.notthebee.com/ads/
 ||media.tickertape.in/websdk/*/ad.js
 ||mediatrias.com/assets/js/vypopme.js


### PR DESCRIPTION
pre-roll ads on homepage video content 
"Watch the latest headlines" section
<img width="1600" height="775" alt="cnn-homepage" src="https://github.com/user-attachments/assets/36b9ae09-1beb-44e4-ae96-5093bc8042da" />
