### PR TITLE
M: smct.io tracking domain used with existing smct.co

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -1979,6 +1979,7 @@
 ||smartracker.net^$third-party
 ||smartzonessva.com^$third-party
 ||smct.co^$third-party
+||smct.io^$third-party
 ||smileyhost.net^$third-party
 ||smrk.io^$third-party
 ||smtrk.net^$third-party


### PR DESCRIPTION
Added a new domain used by intent.ly (Smarterclick) for user tracking.

Detailed analysis https://github.com/ad-blocker-hunter/adblock-research/blob/main/intent.ly/README.md