### PR TITLE
A: intent.ly to adserver list

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -30875,6 +30875,8 @@
 ||smbzsbsahhxaj.online^
 ||smcdxffhlkifc.site^
 ||smcpvvmflcmlc.store^
+||smct.co^
+||smct.io^
 ||smdvonlykudsb.com^
 ||smearconventional.com^
 ||smeartagger.cfd^


### PR DESCRIPTION
As well as valid self-promotion functionality these domains are used to serve ads for other retailers. The feature is advertised on their website here: [brand partnerships](https://intent.ly/inpage-campaigns/#:~:text=Create%20a%20new%20revenue%20stream%20from%20your%20existing%20traffic%20with%20brand%20partnerships)

Detailed analysis: https://github.com/ad-blocker-hunter/adblock-research/blob/main/intent.ly/README.md