### PR TITLE
A: lynnwoodtimes.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8085,6 +8085,7 @@ geekzone.co.nz##div.cornered.box > center
 taboolanews.com##div[class*=" trc_elastic_sponsored-"]
 apkmirror.com##div[id^="adtester-container-"]
 yandex.com##div[id^="yandex_ad"]
+lynnwoodtimes.com##div.g:has(a.gofollow[data-track])
 ! Google
 www.google.*###tads[aria-label]
 www.google.*###tadsb[aria-label]


### PR DESCRIPTION
Hides sponsored link containers

<img width="1391" height="548" alt="image" src="https://github.com/user-attachments/assets/4f743293-fba7-4702-bca2-7f8cfa35fbf0" />
