### PR TITLE
M: allow fathom.video embed

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -146,6 +146,7 @@
 @@||extreme-ip-lookup.com^$script,domain=bulkbarn.ca
 @@||ezodn.com/cmp/gvl.json$xmlhttprequest
 @@||fast.fonts.net/jsapi/core/mt.js$script,domain=abeautifuldominion.com|bkmedical.com|eclecticbars.co.uk|gables.com|itsolutions-inc.com|kinsfarmmarket.com|senate.gov
+@@||fathom.video^$subdocument
 @@||fdi.fiduciarydecisions.com/a/lib/gtag/gtag.js$script,~third-party
 @@||fdi.fiduciarydecisions.com/v/app/components/*/Analytics.js$script,~third-party
 @@||fichub.com/plugins/adobe/lib/AppMeasurement.js$domain=natgeotv.com


### PR DESCRIPTION
Allows fathom.video content as embed. fathom.video is already allowed in general https://github.com/easylist/easylist/blob/b27f4028438489998dd2cf5238c4f7bed058e066/easyprivacy/easyprivacy_general.txt#L2830

To test, observe the embedded fathom.video frame which is blocked without this PR's change https://iframely.com/domains/fathom-video