### PR TITLE
P: Problem fix for godtlevert.no

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2474,9 +2474,8 @@ canto.com##body,html:style(overflow: auto !important; position: initial !importa
 craft-conf.com###headlessui-dialog-overlay-19
 craft-conf.com###headlessui-dialog-17
 craft-conf.com##body,html:style(height: auto !important; overflow: auto !important)
-! godtlevert.n
-godtlevert.no###headlessui-portal-root
-godtlevert.no##body,html:style(height: auto !important; overflow: auto !important)
+! godtlevert.no
+godtlevert.no##+js(set-local-storage-item, force_hide_cookie_dialog, 1)
 ! 116117.fi
 116117.fi##+js(set-local-storage-item, cookie-consent, 1)
 ! klassik-stiftung.de


### PR DESCRIPTION
The filter for [godtlevert.no](godtlevert.no) currently blocks _all_ dialogs and modals from displaying (targets portal root), which breaks most site functionality.

Adjusted the filter to only block the cookie dialog via local storage value.