### PR TITLE
P: Removal of adrsbl analytics pixel

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -23,7 +23,6 @@
 ||aditude.cloud^
 ||admaxium.com^
 ||adnext.co^
-||adrsbl.io^
 ||adrtx.net^
 ||adscore.com^
 ||adsmeasurement.com^


### PR DESCRIPTION
GOAL:
Removal of adrsbl pixel from list

REASON:
The adrsbl pixel is an analytics pixel, much the same as Google Analytics or Amplitude. 

This pixel does not serve ads nor create them. And has nothing to do with pushing advertising directly.