### PR TITLE
A: Block Adobe helix rum-collector

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2988,7 +2988,7 @@ _WebVitalsReporter_
 /*JmVu.js?sp=
 /*JmVu.js?tg=
 /.netlify/scripts/rum
-/.rum
+/.rum/@adobe/helix-
 /ns.html?id=GTM-
 /send_ga4_params?
 /tag/proxy?id=G-


### PR DESCRIPTION
Sample page:  https://www.hersheyland.com/?rum=on

This loads a tracking script from:  https://www.hersheyland.com/.rum/@adobe/helix-rum-js@%5E2/dist/rum-standalone.js
And then sends tracking information to https://www.hersheyland.com/.rum/1