### PR TITLE
A: lanacion.com.ar

### DIFF
--- a/fanboy-addon/fanboy_annoyance_international.txt
+++ b/fanboy-addon/fanboy_annoyance_international.txt
@@ -531,6 +531,7 @@ elcomercio.pe##.go-up
 elgrupoinformatico.com##.relatednext
 cnnchile.com##.scroll-button
 applesencia.com,capitalibre.com,frenomotor.com,placeralplato.com,sportadictos.com,winphonemetro.com,xombit.com,xombitgames.com,xombitmusic.com##.top-button
+||lanacion.com.ar/pf/api/v3/content/fetch/rankingArticlesSource
 !
 ! ---------- Swedish Site Specific Hiding Rules ----------
 !


### PR DESCRIPTION
Blocks the "most read articles" popup on mobile (`https://www.lanacion.com.ar/deportes/automovilismo/lando-norris-se-vencio-a-si-mismo-un-campeon-merecido-pese-a-sus-grietas-psicologicas-nid07122025/`)
<img width="409" height="319" alt="image" src="https://github.com/user-attachments/assets/5e840578-f579-45f7-8ff8-39d5a574c7e2" />
