### PR TITLE
P: Disable /metrics/rum rule on Datadog websites

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -1498,7 +1498,7 @@
 /metrics/init?
 /metrics/onload
 /metrics/ping?
-/metrics/rum
+/metrics/rum$domain=~datadoghq.com|~datadoghq.eu|~ddog-gov.com
 /metrics/statsd/*
 /metrics/survey/*
 /metrics/track/*


### PR DESCRIPTION
Update the rule so it doesn't block some Datadog API endpoints when navigating Datadog own websites