### PR TITLE
M: msn.com

### DIFF
--- a/easylist/easylist_allowlist_general_hide.txt
+++ b/easylist/easylist_allowlist_general_hide.txt
@@ -229,6 +229,7 @@ doda.jp,tubefilter.com#@#.mainAd
 austurfrett.is,boards.4chan.org,boards.4channel.org#@#.middlead
 thespruce.com#@#.mntl-leaderboard-spacer
 sankei.com#@#.module_ad
+msn.com#@#.native-ad
 seura.fi,www.msn.com#@#.nativead
 platform.liquidus.net#@#.nav_ad
 dogva.com#@#.node-ad


### PR DESCRIPTION
The slide show is broken when user tried to navigate to next/prev slides

Example url: `https://www.msn.com/en-ca/money/other/retiring-in-bc-on-a-budget-the-10-best-small-towns-for-seniors/ss-AA1RTfil?ocid=msedgntp&pc=U531&cvid=6946ec40d41b417c88eff6425c7b2c34&ei=24#image=12`