### PR TITLE
Fix: Cookie consent on weather.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -179,3 +179,5 @@
 ||cookiepro.com^$domain=urbandictionary.com
 ! fundingchoicesmessages (consents)
 ||fundingchoicesmessages.google.com^
+||privacy-mgmt.com^$xhr,domain=weather.com
+||cdn.privacy-mgmt.com^$script,domain=weather.com


### PR DESCRIPTION
Resolves https://github.com/easylist/easylist/issues/22873

Blocks the privacy-mgmt.com consent scripts and XHR requests on weather.com to suppress persistent cookie notices. This addresses issues tracked in automated scanning (e.g., https://github.com/brave-experiments/cookiecrumbler-issues/issues/1992).