### PR TITLE
A: Reddit search AI answers preview

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -7,6 +7,7 @@
 !
 www.google.com###Odp5De:has-text(AI Overview)
 reddit.com###answers-suggested-queries-m3
+reddit.com##search-telemetry-tracker .search-answers-preview-section,search-telemetry-tracker:has(.search-answers-preview-section) + hr
 bing.com###b-scopeListItem-conv > [href^="https://www.bing.com/ck/a"]
 bing.com###chat_upsell_bubble_icon
 geneticliteracyproject.org###chtl-open-chat-icon


### PR DESCRIPTION
This rule blocks the AI "Answers" section (and the `<hr>` element right after it) that appears on Reddit search results.

<img width="839" height="883" alt="image" src="https://github.com/user-attachments/assets/059395cc-a74e-4c04-8dcb-9082b41dfd3e" />

Page shown above is https://www.reddit.com/search/?q=Sony+XM5+headphones

I would also love some help removing the "Ask" button from the search input itself, but it is behind a shadow root so I'm not sure how to do that.