### PR TITLE
M: Unbreak https://music.163.com/st/webplayer

### DIFF
--- a/easyprivacy/easyprivacy_specific_international.txt
+++ b/easyprivacy/easyprivacy_specific_international.txt
@@ -971,7 +971,6 @@
 ||msgsndr.com/funnel/event
 ||mtrace.qq.com^
 ||music.163.com/device/signature/create/deviceid.js
-||music.163.com/weapi/feedback/weblog
 ||netstat.yunnan.cn^
 ||nex.163.com^
 ||nmc.cn/static/nmclog/nmclog.js


### PR DESCRIPTION
This rule breaks Netease Cloud Music's new web player, https://music.163.com/st/webplayer

And according to third party API docs, this URL is for direct messages, not telemetry: https://binaryify.github.io/NeteaseCloudMusicApi/#/?id=%e7%a7%81%e4%bf%a1%e5%92%8c%e9%80%9a%e7%9f%a5%e6%8e%a5%e5%8f%a3 (in Chinese)