### PR TITLE
Update tracking server entry for swetrix

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -2114,7 +2114,7 @@
 ||surveywriter.com^$third-party
 ||survicate.com^$third-party
 ||sweetgum.io^$third-party
-||swetrix.com^$third-party
+||api.swetrix.com^$third-party
 ||swetrix.org^$third-party
 ||swiss-counter.com^$third-party
 ||synergy-e.com^$third-party


### PR DESCRIPTION
Hi! I'm a maintainer of Swetrix - an [OSS](https://github.com/swetrix/swetrix) web analytics platform.

Replaced swetrix.com with api.swetrix.com in tracking servers list.

Having it as just `swetrix.com` causes issues with assets loading on our websites like `docs.swetrix.com`. The root domain is NOT used for tracking. It's the UI where the users are able to access their stats.

We only use `api.swetrix.com` domain for data ingestion