### PR TITLE
Remove fd.cleantalk.org from easyprivacy_thirdparty.txt

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1075,7 +1075,6 @@
 ||fbsbx.com/paid_ads_pixel/
 ||fcmatch.google.com^
 ||fcmatch.youtube.com^
-||fd.cleantalk.org^
 ||feed.informer.com/fdstats
 ||feedblitz.com/imp?$third-party
 ||feedblitz.com^*.gif?$third-party


### PR DESCRIPTION
Removed fd.cleantalk.org from the third-party list, as it breaks bot detection of some websites. See more at the following issue: https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/2021