### PR TITLE
M: Update Google AI Overview

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -5,7 +5,6 @@
 !
 ! Credit: https://jonathansampson.github.io/filter/ai.txt
 !
-www.google.com###Odp5De:has-text(AI Overview)
 reddit.com###answers-suggested-queries-m3
 bing.com###b-scopeListItem-conv > [href^="https://www.bing.com/ck/a"]
 bing.com###chat_upsell_bubble_icon
@@ -13,6 +12,7 @@ geneticliteracyproject.org###chtl-open-chat-icon
 baidu.com###con-ar > [tpl="ai_accompanies"]
 baidu.com###content_left > .c-group-wrapper:has([tpl="ai_ask"])
 baidu.com###csaitab
+www.google.com###eKIzJc:has-text(AI Overview)
 consumerreports.org###gnav__mt-alert-wrapper
 mail.google.com###google-hats-survey
 mojeek.com###llm-link:has-text(Summarise these results)


### PR DESCRIPTION
On my search results page, the ID Odp5De is nowhere to be found. It seems the ID was changed.

<img width="1712" height="750" alt="image" src="https://github.com/user-attachments/assets/d83ac713-9515-4f5b-aca6-d8759d3c9d87" />
