### PR TITLE
M: Update Google AI Overview ID

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -8,7 +8,6 @@
 ! Generic Cosmetics
 ###kapa-widget-container
 ! Specific Cosmetics
-www.google.com###Odp5De:has-text(AI Overview)
 develop.sentry.dev###ai-list-entry
 reddit.com###answers-suggested-queries-m3
 bing.com###b-scopeListItem-conv > [href^="https://www.bing.com/ck/a"]
@@ -20,6 +19,7 @@ baidu.com###content_left > .c-group-wrapper:has([tpl="ai_ask"])
 baidu.com###csaitab
 docs.google.com###docs-sidekick-gen-ai-promo-button-container
 amazon.com###dpx-rex-nice-widget-container
+www.google.com###eKIzJc:has-text(AI Overview)
 www.youtube.com###flexible-item-buttons > .ytd-menu-renderer > .ytd-menu-renderer:has-text("Ask")
 consumerreports.org###gnav__mt-alert-wrapper
 mail.google.com###google-hats-survey

--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -19,7 +19,7 @@ baidu.com###content_left > .c-group-wrapper:has([tpl="ai_ask"])
 baidu.com###csaitab
 docs.google.com###docs-sidekick-gen-ai-promo-button-container
 amazon.com###dpx-rex-nice-widget-container
-www.google.com###eKIzJc:has-text(AI Overview)
+www.google.com###eKIzJc:has-text(AI Overview),#Odp5De:has-text(AI Overview)
 www.youtube.com###flexible-item-buttons > .ytd-menu-renderer > .ytd-menu-renderer:has-text("Ask")
 consumerreports.org###gnav__mt-alert-wrapper
 mail.google.com###google-hats-survey


### PR DESCRIPTION
On my search results page, the ID Odp5De is nowhere to be found. It seems the ID was changed.

<img width="3424" height="1500" alt="image" src="https://github.com/user-attachments/assets/a245ca2a-74cc-4a5f-89de-9e07d58c5fc1" />

(sorry for duplicate PR, made a mistake in the previous one.)