### PR TITLE
P: https://ananas.rs/ - Fix broken cookie notice rules (Serbian section)

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -2730,6 +2730,7 @@
 ||alationsulafat.cfd^
 ||alatsbhblpwlp.website^
 ||albeedunged.shop^
+||albinicakasa.cfd^
 ||albinosbergut.cyou^
 ||albonsa.com^
 ||alburnunpetal.help^
@@ -9202,6 +9203,7 @@
 ||crumberislamic.cfd^
 ||crumbtypewriterhome.com^
 ||crummydevioussucculent.com^
+||crummynitos.shop^
 ||crumpetprankerstench.com^
 ||crumpetuntaint.cyou^
 ||crumpygodsons.cfd^
@@ -19693,6 +19695,7 @@
 ||imasdk.googleapis.com^
 ||imbandptoses.world^
 ||imbedsclopped.qpon^
+||imberbebromian.shop^
 ||imbet.site^
 ||imbfsidnchope.site^
 ||imbosvatakyvt.site^
@@ -27901,6 +27904,7 @@
 ||nouliseestazoul.net^
 ||nounrespectively.com^
 ||nourishmentdivorcedflock.com^
+||nourishmenttrivialfiasco.com^
 ||noutaiboowafee.net^
 ||nouwhauwazooted.net^
 ||nouwhoocougy.net^
@@ -29711,6 +29715,7 @@
 ||outherdale.shop^
 ||outhermouther.qpon^
 ||outhulem.net^
+||outjestinciter.cfd^
 ||outkickbeforespireas.cyou^
 ||outlaidethanim.qpon^
 ||outlandish-bread.pro^
@@ -33608,6 +33613,7 @@
 ||quilblb545nxqho8ku2bukuu3bh4i2.cfd^
 ||quilezbutles.help^
 ||quilezzymes.qpon^
+||quillonuncleft.qpon^
 ||quillshut.com^
 ||quillsoons.qpon^
 ||quintesmarek.help^
@@ -34557,6 +34563,7 @@
 ||renkycarene.com^
 ||rennetscubitus.cyou^
 ||rennstrudel.qpon^
+||renovatepaperworkunion.com^
 ||renowncooperatepat.com^
 ||renownsteeringscholar.com^
 ||rensipmsqnpdd.space^
@@ -37690,6 +37697,7 @@
 ||snubberanahao.help^
 ||snuff-brownsprintcountry.com^
 ||snuffarguments.com^
+||snufflepesspilfers.cfd^
 ||snugglethesheep.com^
 ||snugwednesday.com^
 ||snurpdisring.cyou^
@@ -40254,6 +40262,7 @@
 ||tlcfhttbxdbhc.site^
 ||tldiozcisbbbu.site^
 ||tlejxoaojbq.xyz^
+||tlemlnuudkowf.com^
 ||tlfeivdeybass.store^
 ||tlhargslcdwpk.space^
 ||tlhbzimbrhqbg.online^
@@ -41088,6 +41097,7 @@
 ||tubicenpokeful.qpon^
 ||tubifertorgoch.cyou^
 ||tubroaffs.org^
+||tubsterbetoya.shop^
 ||tuckbrows.com^
 ||tuckedcurtain.com^
 ||tuckedtransmitterwizards.com^


### PR DESCRIPTION
**Website**: https://ananas.rs/
**File**: easylist_cookie/easylist_cookie_international_specific_hide.txt
**Section**: Serbian

**Issue**:
The existing rules for `ananas.rs` target volatile Styled Component class hashes (e.g., `.cOMKpv`) which have changed, causing the cookie wall to reappear.

**Proposed Fix**:
I have removed the obsolete hash-based selectors and replaced them with a procedural cosmetic filter set.
1. Target the banner content using `:-abp-contains`.
2. Target the overlay backdrop using the adjacent sibling combinator (`+`) as it renders immediately after the banner in the DOM.

**Verification**:
Tested locally in Brave (using uBO syntax `:has-text` for verification) and refactored to ABP syntax (`:-abp-contains`) for this submission to ensure strict list compatibility.