### PR TITLE
A: Block Meta AI widget on Facebook

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -116,8 +116,10 @@ duckduckgo.com##li:first-child:has([data-testid="duckassist-answer-content"])
 www.google.com##li[data-attrid$="Prediction"]:has([aria-description="AI Mode"])
 op.gg##section:has-text("AI Chatbot")
 www.youtube.com##yt-video-description-youchat-section-view-model
+facebook.com##a[href*="meta.ai"]
 ! Network items
 ||askmiso.com^$third-party
 ||cdn.gist.ai^$third-party
 ||mfgpt.milanofinanza.it/widget/widget.js
 ||widget.kapa.ai^$third-party
+||meta.ai^


### PR DESCRIPTION
Tested on facebook.com. Filter targets the anchor href pattern rather than 
hardcoded class names or tracking parameters which change frequently.