### PR TITLE
P: https://locataire.dossierfacile.logement.gouv.fr

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -15,6 +15,9 @@ tweetgen.com#@##tweetContainer
 nicovideo.jp#@#.FollowButton
 feedly.com#@#.ShareBar
 doodle.com#@#.SocialMediaLinks
+locataire.dossierfacile.logement.gouv.fr#@#.share-list
+locataire.dossierfacile.logement.gouv.fr#@#.share-row
+locataire.dossierfacile.logement.gouv.fr#@#.share-title
 free18.net#@#.addthis_default_style
 nrc.gov,schonmagazine.com#@#.addthis_toolbox
 heise.de#@#.article-footer__sharing


### PR DESCRIPTION
This French government website allows users to create a rental file by providing supporting documents, validating them, and sending them to landlords.

It is possible to generate one link per landowner.

The filter hides the link management interface, preventing old links from being deactivated.

Following https://github.com/easylist/easylist/pull/23080