### PR TITLE
P: https://locataire.dossierfacile.logement.gouv.fr

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -70,11 +70,12 @@ bitly.com,knivesout.jp#@#.share-btn
 ida2at.com#@#.share-holder
 app.degoo.com#@#.share-icon-container
 pornhub.com#@#.share-link-container
-baidu.com,findagrave.com#@#.share-list
+baidu.com,findagrave.com,locataire.dossierfacile.logement.gouv.fr#@#.share-list
 deezer.com#@#.share-message
 podbean.com#@#.share-podcast
-osf.io#@#.share-row
+locataire.dossierfacile.logement.gouv.fr,osf.io#@#.share-row
 inman.com,simpletax.ca#@#.share-section
+locataire.dossierfacile.logement.gouv.fr#@#.share-title
 am800cklw.com#@#.share-tools
 card.discover.com#@#.share-widget
 ranking.sanrio.co.jp#@#.shareButtons


### PR DESCRIPTION
This French government website allows users to create a rental file by providing supporting documents, validating them, and sending them to landlords.

It is possible to generate one link per landowner.

The filter hides the link management interface, preventing old links from being deactivated.

Following https://github.com/easylist/easylist/pull/23080