### PR TITLE
A: https://docs.redhat.com/

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -54,6 +54,7 @@ gitlab.com##.ai-nav-icon
 straitstimes.com##.ai-summary
 stackoverflow.com##.as-start.fd-column:has-text(Get instant answers)
 nutraingredients.com##.ask-ia-widget
+docs.redhat.com##.ask-red-hat-button-container
 dictionary.cambridge.org##.assistant-pwa-bar
 collinsdictionary.com##.assistantIcon
 app.slack.com##.autoSummaryCard__UEStF:has-text(AI thread summaries)


### PR DESCRIPTION
I've added an filter in AI Suggestions to hide Ask Red Hat in Red Hat documentation website
<img width="761" height="758" alt="image" src="https://github.com/user-attachments/assets/4608d493-c24b-4bfa-95ed-7e05b8c87529" />
