### PR TITLE
A: duckduckgo.com: AI

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -79,6 +79,7 @@ support.google.com##.helpPanelContainerRoot:has-text(Help guide)
 androidpolice.com,backyardboss.net,carbuzz.com,cbr.com,collider.com,dualshockers.com,fextralife.com,footballfancast.com,footballleagueworld.co.uk,gamerant.com,givemesport.com,hotcars.com,makeuseof.com,movieweb.com,pocket-lint.com,screenrant.com,simpleflying.com,thegamer.com,therichest.com,thesportster.com,thethings.com,thetravel.com,topspeed.com,xda-developers.com##.i-sensa
 develop.sentry.dev,docs.sentry.io##.kapa-ai-class
 search.brave.com##.llm.suggestion:has-text(Answer with AI)
+duckduckgo.com##.nav-menu__item:has(> a[href="https://duck.ai"])
 amazon.com##.nav-rufus-disco
 olivela.com##.oli-chat-bubble-popup
 olivela.com##.oli_popup_button
@@ -89,6 +90,7 @@ amazon.com##.s-ask-rufus-mshop-suggestion-container
 amazon.com##.s-suggestion-nile-desktop-container
 www.reddit.com##.search-answers-preview-section:has-text(Answers)
 docs.sentry.io##.search_sgs-ai-button__sUsjD
+duckduckgo.com##.sideMenu_sectionLink__2zUPb[href="https://duck.ai/?origin=funnel_home_website"]
 search.brave.com##.subutton-tooltip-wrapper[aria-label="Answer with AI"]
 ecosia.org##.tab--icon:has-text(AI Search)
 britannica.com##.toc-sticky-header-ai-container


### PR DESCRIPTION
Adds two filters for DuckDuckGo.
* On homepage, "Duck.ai" link in right sidebar, "More from DuckDuckGo" (https://duckduckgo.com/)
* On search results, "Duck.ai" link in right sidebar, "More from DuckDuckGo" (https://duckduckgo.com/?q=test)

Filters from https://github.com/Stevoisiak/Stevos-GenAI-Blocklist