### PR TITLE
A: google.com: AI hyperlink in logo 

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -9,6 +9,7 @@
 ###gist-answers-widget
 ###kapa-widget-container
 ! Specific Cosmetics
+www.google.co.jp,www.google.com,www.google.com.hk###LS8OJ > .k1zIA.kKvsb > a[href*="&udm=50"]:remove-attr(href)
 www.google.com###Odp5De:has-text(AI Overview)
 agoda.com###QuickAnswersContainer
 develop.sentry.dev###ai-list-entry


### PR DESCRIPTION
Remove AI hyperlinks from Google Logo. (Clicking on the Google logo during the Olympics goes to an AI Question page) (https://www.google.com/)