### PR TITLE
M: PostHog evades event tracking block

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1951,7 +1951,6 @@
 ||postageapp.com/receipt/$third-party
 ||posthog.com/e$xmlhttprequest
 ||posthog.com/i/*/e$xmlhttprequest
-||posthog.com/static/array.js
 ||posthog.com/static/recorder-v2.js
 ||poweredbyeden.com/widget/tracker/
 ||ppx.com/tracking/


### PR DESCRIPTION
As discussed in #20838, PostHog circumvents the current rules blocking tracking event ingestion:
https://github.com/easylist/easylist/blob/852e4e89300dbecda13d7729739af9c47cc55819/easyprivacy/easyprivacy_thirdparty.txt#L331-L334

They rotate the host server, query parameter order, and URL path to evade the current filter.
This change closes those loopholes while keeping their dashboard fully functional.

Closes #20838

Before change:
<img width="1158" height="1294" alt="image" src="https://github.com/user-attachments/assets/e511ea3f-520c-4f04-a6a6-92de41f3d604" />

After change:
<img width="1157" height="1295" alt="image" src="https://github.com/user-attachments/assets/72792853-1e88-4127-a2a8-2c93e91d0fd2" />