### PR TITLE
M: https://gonintendo.com/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -579,6 +579,7 @@ en.numista.com###fiche_buy_links
 getyarn.io###filtered-bottom
 finbold.com###finbold\.com_middle
 investing.com###findABroker
+gonintendo.com###first-leaderboard
 healthshots.com###fitnessTools
 healthshots.com###fitnessToolsAdBot
 thisismoney.co.uk###fiveDealsWidget
@@ -4728,7 +4729,6 @@ highspeedinternet.com##.provider-ads
 football365.com,planetf1.com,planetrugby.com,tennis365.com##.ps-block-a
 indiabusinessjournal.com##.pt--20
 kathmandupost.com##.pt-0
-gonintendo.com##.pt-5
 steamladder.com##.pt-large
 getyarn.io##.pt3p > div
 1980-games.com,coleka.com,gameslol.net,theportugalnews.com,tolonews.com##.pub


### PR DESCRIPTION
`###first-leaderboard` hides the leftover ad container at the top
<img width="1251" height="514" alt="image" src="https://github.com/user-attachments/assets/71d2060b-36bc-4b61-8530-094b02636206" />

Removed `##.pt-5` because it's not an ad container, but rather an empty container on desktop and a tab bar on mobile.
<img width="1208" height="239" alt="image" src="https://github.com/user-attachments/assets/f9c57e00-b696-46e8-8fa2-5cb4cb358a27" />
<img width="375" height="207" alt="image" src="https://github.com/user-attachments/assets/cf4c8a4b-2e7f-4b8c-986f-d039d6822453" />
