### PR TITLE
fix: add filter for haxmac.cc

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8165,3 +8165,4 @@ checkfelix.com,kayak.*,swoodoo.com##div[class*="-ad-card"]
 checkfelix.com,kayak.*,swoodoo.com##div[class*="-adInner"]
 checkfelix.com,kayak.*,swoodoo.com##div[data-resultid]:has(a.IZSg-adlink)
 checkfelix.com,kayak.*,swoodoo.com##div[id^="inline-"]
+haxmac.cc##.code-block a[href="javascript:void(0)"][onclick^="window.open"]


### PR DESCRIPTION
Closes https://github.com/easylist/easylist/issues/23195

This PR adds a filter to hide a fake download button on `haxmac.cc`.

### URL(s) where the issue occurs

`https://haxmac.cc/4k-video-downloader-crack-mac/`

### Describe the issue

The button mimics the site's design but uses an inline `onclick` event to trigger a popup to a spam domain (`5anhw90hg140825oa.cfd`) rather than a legitimate download.

### Screenshot(s)

Before:
<img width="493" height="651" alt="Snímek obrazovky 2026-02-18 v 12 01 45" src="https://github.com/user-attachments/assets/5663e889-e126-421c-836e-c45950140032" />

After:
<img width="493" height="607" alt="Snímek obrazovky 2026-02-18 v 11 59 50" src="https://github.com/user-attachments/assets/009f64cd-5a75-4bfb-aef4-d0b0bf06d618" />

### Versions

- Browser/version: Firefox 147.0.4
- Ad block extension/version: uBlock Origin 1.69.0