### PR TITLE
P: Remove join.tlon.io - app deep linking, not tracking

### DIFF
--- a/easyprivacy/easyprivacy_specific_cname_branch.txt
+++ b/easyprivacy/easyprivacy_specific_cname_branch.txt
@@ -2368,7 +2368,6 @@
 ||join.stuypend.com^
 ||join.talker.network^
 ||join.thekrishi.com^
-||join.tlon.io^
 ||join.travelxp.com^
 ||join.vibely.io^
 ||join.vtail.co^


### PR DESCRIPTION
## Summary

Requesting removal of `||join.tlon.io^` from EasyPrivacy (easyprivacy_specific_cname_branch.txt).

## What is Tlon?

[Tlon](https://tlon.io) is a peer-to-peer messaging application built on [Urbit](https://urbit.org), a decentralized identity and hosting network.

## What join.tlon.io does

- Routes invite links to open the Tlon app (e.g., `join.tlon.io/abc123`)
- If the app isn't installed, redirects to the App Store / Play Store
- Passes an invite token so the user lands in the right group after install

## What it doesn't do

- ❌ No cross-site tracking
- ❌ No fingerprinting  
- ❌ No third-party analytics collection
- ❌ No advertising or retargeting

## Why it was flagged

The domain uses Branch.io for deferred deep linking (passing tokens through app install), which is why it appears in the CNAME tracker list. However, Tlon does not use Branch for tracking or analytics—only for the deep link routing.

## Impact of blocking

When `join.tlon.io` is blocked, users with privacy extensions cannot:
- Accept group invitations
- Join communities shared via link
- Complete the onboarding flow when invited by friends

This breaks core functionality for privacy-conscious users—ironically, the users most aligned with a decentralized, privacy-focused messaging app.

## Migration plan

We are building first-party deep linking infrastructure to eliminate the Branch.io dependency entirely. However, we're requesting removal now as the current blocking incorrectly categorizes functional app infrastructure as tracking.

Thank you for maintaining these lists and for your work protecting user privacy.