### PR TITLE
P: https://www.engadget.com/

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7014,7 +7014,7 @@ everythingrf.com,natureworldnews.com##label
 tellows-au.com,tellows-tr.com,tellows.*##li > .comment-body[style*="min-height: 250px;"]
 cgpress.org##li > div[id^="cgpre-"]
 bestbuy.com##li.embedded-sponsored-listing
-engadget.com##li.lg\:min-h-\[234px\]
+engadget.com##li.sm\:min-h-\[113px\].lg\:min-h-\[234px\]
 cultbeauty.co.uk,dermstore.com##li.sponsoredProductsList
 laredoute.*##li[class*="sponsored-"]
 linkedin.com##li[data-is-sponsored="true"]


### PR DESCRIPTION
`##li.lg\:min-h-\[234px\]` hides all the elements on the "latest stories" section:
<details><summary>Screenshot</summary>

<img width="1502" height="3068" alt="image" src="https://github.com/user-attachments/assets/662cc71f-c123-4c95-b630-ec350d2528c7" />

</details>

Made the filter more specific to only hide the ad placeholders.
<details><summary>Screenshot</summary>

<img width="1340" height="5715" alt="image" src="https://github.com/user-attachments/assets/4f188dc2-14f1-4c0f-952c-324914dbca36" />

</details> 

Fixes https://github.com/easylist/easylist/issues/23261