### PR TITLE
M: https://genius.com/ (annoyances)

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -249,6 +249,7 @@ instagram.com##._acc8
 m.webtoons.com##._appDownloadPopup
 smartfren.com##.alert-download
 skysports.com##.android-banner
+genius.com##.android_banner
 coincodex.com##.app
 washingtonpost.com##.app-adoption-banner
 flypgs.com##.app-b
@@ -593,7 +594,6 @@ cvs.com##cvs-smart-app-banner
 trademe.co.nz##div.responsive-wrapper[aria-label="App promotion banner"]
 web.nhk##div[class*=" _"][role="region"][aria-labelledby="_r_1_"]
 m.bilibili.com##div[class*="-openapp"]
-genius.com##div[class*="AndroidBannermobile_"]
 thescore.com##div[class*="GetTheAppModal_"]
 giphy.com##div[class*="OpenInAppContainer-"]
 thescore.com##div[class^="GetTheApp__fullScreenContainerScrolldown--"]

--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -310,3 +310,5 @@ s.tabelog.com##body,html:style(overflow-y: auto !important;)
 ! trial-net.co.jp (mobile app)
 trial-net.co.jp##.app-remind
 trial-net.co.jp##.header-app-remind:remove-class(header-app-remind)
+! genius.com (mobile app)
+genius.com##.android_interstitial:remove()

--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -217,7 +217,6 @@ whatcar.com##.ReviewSocialSection_reviewSocialSection__qzV0o
 abc.net.au##.ShareBanner_container__OX63I
 aleteia.org##.ShareBar_link__3gR4V
 manofmany.com##.ShareBar_listItem__6t0E_
-genius.com##.ShareButtons__Root-sc-8c8eaea4-0
 thescore.com##.ShareLinks__container--3C8C4
 meduza.io##.SharePanel-module-root
 hoorayteams.com##.Share_share__FQTKw
@@ -1630,6 +1629,7 @@ theguardian.com##div > gu-island[name="ShareButton"]
 photorumors.com##div[align="RIGHT"]
 fifa.com##div[class*="article-section_shareButton_"]
 theatlantic.com##div[class^="ArticleShare_"]
+genius.com##div[class^="ShareButtons_"]
 kcrw.com##div[class^="SocialLinks_"]
 cnbc.com##div[class^="SocialShare-"]
 kcrw.com##div[class^="SocialShare_"]


### PR DESCRIPTION
From https://github.com/easylist/easylist/pull/23190#issuecomment-3922198762:
> Removed `##div[class*="AndroidBannermobile_"]` since I couldn't reproduce it anywhere on multiple devices and pages.
> 
> `##.android_banner` blocks the mobile app banner found [here](https://genius.com/artists/Radiohead) for example: <img alt="image" width="357" height="176" src="https://private-user-images.githubusercontent.com/71973804/551684335-aca1d2b1-01b0-49e6-8bd6-ca74e46d2c65.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzIzMjA0MjgsIm5iZiI6MTc3MjMyMDEyOCwicGF0aCI6Ii83MTk3MzgwNC81NTE2ODQzMzUtYWNhMWQyYjEtMDFiMC00OWU2LThiZDYtY2E3NGU0NmQyYzY1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMjglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjI4VDIzMDg0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZkYmZlNmQ3ZDBjOTExNjU0ZWRmYjRkMTAxOTA2NTE4NjRjMWYxOWU1Y2VlNmQyMjhhZmRlYzY4MTYwZWU5M2EmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.T4Ebw7PbLS8jhkL_J8ex0FmCMZaoGN8y1K35D1Fl9kc">
> 
> `##.android_interstitial:remove()` removes [this](https://genius.com/tags/grunge) other banner: <img alt="image" width="357" height="306" src="https://private-user-images.githubusercontent.com/71973804/551684795-89c50458-600d-4c71-b846-190990631629.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzIzMjA0MjgsIm5iZiI6MTc3MjMyMDEyOCwicGF0aCI6Ii83MTk3MzgwNC81NTE2ODQ3OTUtODljNTA0NTgtNjAwZC00YzcxLWI4NDYtMTkwOTkwNjMxNjI5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMjglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjI4VDIzMDg0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTVkOWI4NmJmYzUwMTkwMGQzZGQ4MGM0MzlkNGNjMzdlMzUyYjhjNDJlYzY2ZmUzYzMzNTUwZDE2Y2I4N2RjZjUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.fgMhK3LHr-XG6aa3dXHRYx4ezFBt3XISgq4DPCmqWBI">
> 
> `:remove()` is necessary because the banner layout is broken, and if only hidden with `##.android_interstitial` the close button cannot be pressed, leaving the layout broken without a way to close the banner.

Alongside the banners, also updated the rule `##.ShareButtons__Root-sc-8c8eaea4-0` since the class changed. [Example](https://genius.com/Radiohead-creep-lyrics):
<img width="774" height="180" alt="image" src="https://github.com/user-attachments/assets/e531d2bd-c7b4-4d64-946c-ac25ce78d8da" />
