### PR TITLE
A: perfomax.cz

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -55884,6 +55884,7 @@
 ||penuma.com^$third-party
 ||pepperjamnetwork.com^$third-party
 ||perfdrive.com^$third-party
+||performax.cz^$third-party
 ||perkcanada.com^$third-party
 ||persevered.com^$third-party
 ||pgammedia.com^$third-party


### PR DESCRIPTION
This PR adds blocking for the ad network "Performax" (https://www.performax.cz/).

Seen serving sticky banner ads for mobile devices on:
https://www.tiscali.cz/
https://www.extra.cz/

<img width="385" height="834" alt="image" src="https://github.com/user-attachments/assets/6b1aa9d9-cb79-4ebd-8ae3-e7049544a6a6" />

Example request:
https://dale.performax.cz/?slotId=27615&client=flexo:v4.46.0

Proposed rule:
||performax.cz^$third-party