### PR TITLE
A: teams.live.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -17,6 +17,7 @@ epdf.tips###EPDFTIPS_cookie_box
 franchisegator.com###EUWarning
 ecufiles.com###EcufilesCookie
 firstcallmotorbreakdown.co.uk,pattheduck.com###FISLCC
+teams.live.com###GATHER_COOKIE_BANNER
 megabus.com###GB_overlay
 gamivo.com###GTM-cookie-consent
 idoc.tips###IDOCTIPS_cookie_box


### PR DESCRIPTION
Removing cookie banner from teams.live.com
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/707