### PR TITLE
A: ura.news

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1803,6 +1803,7 @@ fedex.com##.fxg-alert__fdx_cookie_notice
 fxstreet.com##.fxs_footer
 cgtn.com##.g-dialog
 replika.ai,replika.com##.gEQwvO
+ura.news##.gQ:has-text(cookie)
 whatsnewonthenet.com##.gaoop
 graviti.com##.gas-cookie-bar
 themeflood.com##.gatewayContainer


### PR DESCRIPTION
Hiding ura.news cookie banner

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2198