### PR TITLE
A: cht.com.tw

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1461,6 +1461,7 @@ cloud.vmware.com##.cookie-usage-banner
 chatspin.com,flingster.com##.cookie-use-notice
 rebeltech.co.za##.cookie-wall
 fishermap.org,ittelo.ru##.cookie-window
+cht.com.tw##.cookie-wrap
 btimesonline.com##.cookieAcceptBar
 woktowalk.com##.cookieAceptance
 swinglifestyle.com##.cookieAckContainer


### PR DESCRIPTION
Hiding cookie banner from cht.com.tw

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2200