### PR TITLE
A: cacaushow.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -201,7 +201,7 @@ nasdaq.com###consent-placeholder-onetrust
 audacityteam.org,tecadmin.net###consent-popup
 niwa.co.nz###consent-request
 store.steelcase.com###consent-skeleton
-altardstate.com,citizenwatch.com,manyavar.com,mechanix.com,michele.com###consent-tracking
+altardstate.com,cacaushow.com.br,citizenwatch.com,manyavar.com,mechanix.com,michele.com###consent-tracking
 nordvpn.com###consent-widget-container
 polymerclaylatvia.com###consent-window
 soccerladuma.co.za###consent-wrapper


### PR DESCRIPTION
Hiding cookies banner from cacaushow.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/558