### PR TITLE
A: (NSFW) Tube8: Sponsored tabs

### DIFF
--- a/easylist_adult/adult_specific_hide.txt
+++ b/easylist_adult/adult_specific_hide.txt
@@ -724,6 +724,7 @@ hot.co.uk,hot.com##.p-search__action-results.badge-absolute.text-div-wrap.top
 empflix.com##.pInterstitialx
 hobby.porn##.pad
 dessi.co##.pages__BannerWrapper-sc-1yt8jfz-0
+tube8.com,tube8.es,tube8.fr##.paidTab
 xxxdan3.com##.partner-site
 hclips.com,hotmovs.tube##.partners-wrap
 xfantazy.com##.partwidg1


### PR DESCRIPTION
Convers the navbar tabs for "Live Sex", "Ai Girls" and "Zz Premium".

The "Zz Premium" tab was partially covered by a block rule for `tube8.*##[href^="https://ads.trafficjunky.net/ads"]`, but it left a blank space and did not cover the other sponsored tabs.