### PR TITLE
M: jigsawplanet.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -6335,7 +6335,7 @@ daily-choices.com##[id^="sticky_"]
 alternet.org##[id^="story_page_incontent_"]
 thesaurus.com##[id^="tco"]
 topcpu.net##[id^="topcpu_net_in_page_repeat_responsive"][style="min-height: 300px;"]
-jigsawplanet.com##.content div[id^="cb"]:not(.ts-gmspc)
+jigsawplanet.com##div[id^="cb"]:not(.ts-gmspc)
 everythingrf.com##[id^="wallpaper_"]
 wuxiaworld.site##[id^="wuxia-"]
 samfw.com##[name="chimera_b"]


### PR DESCRIPTION
Jigsawplanet updated their website to allow their anti-adblock notice to bypass the attempts to block the notice.

This PR updates the easylist filter to block the anti-adblock notice anew.

The new filter is structured as follows:
* `div` - The website has some elements that have an ID starting with `cb`, that should not be blocked (such as elements on the user settings page). As far as I can tell, they are all non-divs.
* `[id^="cb"]` - The anti-adblock notice uses an ID formatted as `cb{hash}-{num}`.
  * Unfortunately, we can't target a singular ID, as the website swaps the anti-adblock notice's ID with the puzzle field's ID, depending on whether the user is logged in or out.
  * Additionally, the home page uses a similarly-formatted ID with a different hash - so targetting the ID wouldn't work well anyways.
* `:not(.ts-gmspc)` - explicitly exempts the puzzle field from being targeted.

Perhaps there's a better way to do this? But this seems to fix it for now.

That said, if there's a better way to handle this, please don't be afraid to edit into this PR - or close this PR and commit it directly.

See also my previous attempt at this: https://github.com/easylist/easylist/pull/23101