### PR TITLE
A: test cookie banner rule for example.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3942,3 +3942,4 @@ tiktok.com##tiktok-cookie-banner
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt
+example.com###cookie-banner


### PR DESCRIPTION
Test rule added to easylist_cookie_specific_hide.txt to hide a cookie banner element.

Rule:
example.com###cookie-banner

This is a simple test contribution to verify the contribution workflow.