### PR TITLE
A: acrobat.adobe.com

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -32,6 +32,7 @@ baidu.com###csaitab
 docs.google.com###docs-sidekick-gen-ai-promo-button-container
 amazon.com###dpx-rex-nice-widget-container
 www.youtube.com###flexible-item-buttons > .ytd-menu-renderer > .ytd-menu-renderer:has-text("Ask")
+acrobat.adobe.com###genai-assistant-button
 consumerreports.org###gnav__mt-alert-wrapper
 mail.google.com###google-hats-survey
 www.youtube.com###header > .ytd-expandable-metadata-renderer:has-text("Summary")


### PR DESCRIPTION
Removes this AI assistant button and nothing else.

<img width="784" height="123" alt="image" src="https://github.com/user-attachments/assets/9b45ac3f-6870-4910-8110-687c2de846cf" />

Test on this URL (public document): https://acrobat.adobe.com/id/urn:aaid:sc:US:95af942c-2ff5-424b-a3b1-521f7800a347?viewer%21megaVerb=group-discover