### PR TITLE
A: capitaloneshopping.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2495,6 +2495,7 @@ sonic.com##.snc-consent-banner
 microcad.xyz##.snn-cookie-banner
 hotukdeals.com##.softMessages-item
 sonos.com##.sonoscontent-banner
+capitaloneshopping.com##.sp-cookie-consent-slide-up-el
 thermofisher.com##.specialMsg
 drdenim.com##.spicegems_gdpr_bottom_banner
 spreadshirt.com##.sprd-consent


### PR DESCRIPTION
Hiding cookies from capitaloneshopping.com -- this is reproducible from the UK

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/729