### PR TITLE
A: uconn.edu

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -761,6 +761,7 @@ stingray.com###tracking-popup
 privacy.org.nz###trackingmessage
 visionworks.com###transcend-consent-manager
 undercurrentnews.com###ucn-gdpr-overlay
+uconn.edu###uconn-c-notice
 strikermanager.com###ue
 netflix.com###uma > div > .message
 mcdonalds.com###usTnCBanner


### PR DESCRIPTION
hiding cookie message from uconn.edu

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1053