### PR TITLE
A: dailyrecord.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -614,6 +614,7 @@ growthtechnology.com###popupbanner
 melaniemartinezmusic.com###pp-footer
 paperlesspost.com###pp-global-third-party-cookie-banner
 r-studio.com,r-tt.com###pp-info
+dailyrecord.co.uk###pp-prompt
 tapatalk.com,walfordweb.com###pp_b
 gainward.com,palit.com###pp_info
 gainward.com,palit.com###pp_overlay


### PR DESCRIPTION
Hiding cookie message from dailyrecord.co.uk

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/904
