### PR TITLE
A: the-scientist.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -9,6 +9,7 @@ snitcher.com###CoCon
 wineinvestmentfund.com###Contentplaceholder1_TAEB3815A051_Col00
 fruugo.co.nz###CookieBanner
 mauldineconomics.com###CookieControl
+the-scientist.com###CookiePolicy
 audiot.co.uk###CookieRequester
 lttstore.com###Cookies-wrapper
 cardmarket.com###CookiesConsent


### PR DESCRIPTION
Removing cookie banner from the-scientist.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/510