### PR TITLE
A: niche.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1382,7 +1382,7 @@ chucklingcheese.co.uk##.cookie-accept-bar-v2
 syrf.org.uk##.cookie-alert-banner
 investkorea.org##.cookie-area
 pinpointproperties.com##.cookie-authority
-crumb.pet,privacy.com##.cookie-banner
+crumb.pet,niche.com,privacy.com##.cookie-banner
 whitepages.com##.cookie-banner-container
 team.repair##.cookie-banner-inner
 businesscomparison.com##.cookie-banner-mask


### PR DESCRIPTION
Removing cookie banner from niche.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/501