### PR TITLE
A: stheadline.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1395,6 +1395,7 @@ klatchcoffee.com##.cookie-bar_cookieBar__H25h4
 ninerocksgames.com##.cookie-bar_overlay__0y49X
 tightvnc.com##.cookie-block
 n-ix.com##.cookie-block-wrapper
+stheadline.com##.cookie-box
 betking.com##.cookie-box-container
 navigare-yachting.com##.cookie-box-popup
 goodlawproject.org##.cookie-card


### PR DESCRIPTION
Hiding cookie message on stheadline.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/508