### PR TITLE
A: pixfixture.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2270,6 +2270,7 @@ essayshark.com,pixlr.com##.policies
 designs.ai,globe.com.ph,parcfrontenac.com,protipster.com,riverterracegardens.com,star.com.tr,tvbs.com.tw,viber.com##.policy
 esquire.com##.policy-bar
 toooon.com##.policy-bottom-bar
+pixfuture.com##.policy-container
 cgtn.com##.policy-dialog
 pxhere.com,wallhere.com##.policy-info
 shazam.com##.policy-label


### PR DESCRIPTION
Hiding cookie banner from pixfixture.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1782