### PR TITLE
A: townandcountrymag.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2798,7 +2798,7 @@ czds.icann.org##czds-cookie-notification
 c.realme.com##div > .cookie-privacy
 corrupt.wiki,developer.rocket.chat,docs.coreframework.com,docs.fluentbit.io,docs.flutterflow.io,docs.ibracorp.io,docs.jabref.org,electronforge.io,filebrowser.org,guides.cryptowat.ch,meshnet.nordvpn.com,support.saleae.com,wiki.valhelsia.net##div.r-1xcajam.css-175oi2r
 utrechtart.com##div[aria-label="cookie consent banner"]
-delish.com##div[aria-label^="Privacy Disclosure"]
+delish.com,townandcountrymag.com##div[aria-label^="Privacy Disclosure"]
 audiomack.com##div[class*="ConfirmMessage-module__cookie-"]
 easyoffices.com##div[class*="CookiesBar_"]
 phot.ai##div[class*="styles_consentCard__"]


### PR DESCRIPTION
Hiding cookie banner from townandcountrymag.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/777