### PR TITLE
A: digitalcaramel.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -837,6 +837,7 @@ gobranded.com##.CookieBar_cookieBar__3qk4d
 dashfight.com##.CookieBox_safety__pt5AH
 push.org##.CookieComponent__CookieContainer-sc-thf5lr-0
 bstage.in##.CookieConfirm_container__7A6dW
+digitalcaramel.com##.CookieConsent
 tsi.com##.CookieConsent > .o-container
 tunemymusic.com##.CookieConsent-module-scss-module__piaogq__CookieAlert
 rebrandly.com##.CookieConsent__container


### PR DESCRIPTION
Hiding cookie banner from digitalcaramel.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2063