### PR TITLE
A: thomasnet.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2784,6 +2784,7 @@ sard.ac##app-cookie-status
 iryo.eu##app-cookies-manager
 e-aperam.com##app-privacy-policy
 duelz.com##app-tiny-alert
+thomasnet.com##aside[data-sentry-component="CookieBanner"]
 essential.gg##banner-content
 cherytr.com,cine-max.sk##body .cc-nb-main-container
 facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]


### PR DESCRIPTION
Hiding cookie dialog for thomasnet.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/471