### PR TITLE
A: https://ga4.com/: Chat icon

### DIFF
--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -40,6 +40,7 @@ singtel.com##.ux-faq-singtel
 therealdeal.com##.woot-widget-bubble
 support.carousell.com##[style*="display: flex; flex-direction: column; z-index: 999999;"]
 healthhub.sg##ai-chatbot
+ga4.com##button:has(> [alt="Chat"])
 simba.sg##button:has([alt="Chat with SIMBA"])
 m1.com.sg##div:has(> [class^="ChatWindow"])
 ! Specific


### PR DESCRIPTION
Hides floating chat icon in bottom right

<img width="1886" height="911" alt="image" src="https://github.com/user-attachments/assets/9c8f4191-553d-4191-9f6a-f5a0e3aae9d2" />
