### PR TITLE
A: gamingbible.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1312,6 +1312,7 @@ blik.com##.cm-overlay
 moddrop.com##.cm-z-4
 radioplayer.org##.cm__blocked
 noblecorp.com##.cm_disclaimer
+gamingbible##.cmp-banner
 ford.co.nz##.cmp-cookiebanner
 manulife.com##.cmp-ntfbanner
 polygon.technology##.cmp-overlay


### PR DESCRIPTION
Hiding cookie popup/overlay from gamingbible.com (this issue was reproducible from the UK)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/731