### PR TITLE
A: plantetf1.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -763,6 +763,7 @@ visionworks.com###transcend-consent-manager
 undercurrentnews.com###ucn-gdpr-overlay
 strikermanager.com###ue
 netflix.com###uma > div > .message
+planetf1.com###uniccmp
 mcdonalds.com###usTnCBanner
 search.brave.com,search.brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion###usage-metrics
 search.brave.com###usage-metrics-notice


### PR DESCRIPTION
Hiding cookie popup from plantetf1.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/681