### PR TITLE
A: joom.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2795,6 +2795,7 @@ axis.com##cookie-consent
 azbtr.portalus.thentiacloud.net##cookie-dialog
 access.login.nhs.uk##core-cookie-banner
 czds.icann.org##czds-cookie-notification
+joom.com##dialog:has(> div[data-testid="CookieBannerConditionalWrapper"])
 c.realme.com##div > .cookie-privacy
 corrupt.wiki,developer.rocket.chat,docs.coreframework.com,docs.fluentbit.io,docs.flutterflow.io,docs.ibracorp.io,docs.jabref.org,electronforge.io,filebrowser.org,guides.cryptowat.ch,meshnet.nordvpn.com,support.saleae.com,wiki.valhelsia.net##div.r-1xcajam.css-175oi2r
 utrechtart.com##div[aria-label="cookie consent banner"]


### PR DESCRIPTION
Hiding cookie message on joom.com (reproducible from the UK)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/677

