### PR TITLE
A: cloud.google.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1847,6 +1847,7 @@ telenor.com##.global-overlay-background
 matrixgames.com,slitherine.com##.globalAnnouncement
 starhub.com##.globalimportantmessage
 levy.co.uk,wisehosting.com##.glow-banner
+cloud.google.com##.glue-cookie-notification-bar
 gw2mists.com##.gm-cookie-consent
 stealthex.io##.gmEwWa
 ecospaints.net##.gmt_block_screen


### PR DESCRIPTION
This issue is reproducible from Belgium

Hiding cookie bar from cloud.google.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/665