### PR TITLE
A: qwickbirr.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2797,6 +2797,7 @@ access.login.nhs.uk##core-cookie-banner
 czds.icann.org##czds-cookie-notification
 c.realme.com##div > .cookie-privacy
 corrupt.wiki,developer.rocket.chat,docs.coreframework.com,docs.fluentbit.io,docs.flutterflow.io,docs.ibracorp.io,docs.jabref.org,electronforge.io,filebrowser.org,guides.cryptowat.ch,meshnet.nordvpn.com,support.saleae.com,wiki.valhelsia.net##div.r-1xcajam.css-175oi2r
+qwickbirr.com##div:has(> button[data-testid="cookies-gotIt-btn"])
 utrechtart.com##div[aria-label="cookie consent banner"]
 delish.com##div[aria-label^="Privacy Disclosure"]
 audiomack.com##div[class*="ConfirmMessage-module__cookie-"]


### PR DESCRIPTION
Hiding cookie banner on qwickbirr.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/599