### PR TITLE
A: gvtc.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1431,6 +1431,7 @@ deriv.com##.cookie-middle-wrapper
 bitbox.swiss##.cookie-monster
 app.respondent.io##.cookie-monster-component
 privacy.samsung.com##.cookie-noneu
+gvtc.com##.cookie-notice
 allofapps.com,bstock.com,sociedadeonline.com,spacofm.com.br##.cookie-notice-container
 ydns.io##.cookie-notice-outer
 jobs.wavy.com,trustee-connect.com##.cookie-notice-v2


### PR DESCRIPTION
Hiding cookie banner from gvtc.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/575