### PR TITLE
A: casetify.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1440,6 +1440,7 @@ aptible.com##.cookie-notice_container__dJUAA
 tonyschocolonely.com##.cookie-notification-minimal
 exeterchiefs.co.uk##.cookie-notifier-container
 upornia.com##.cookie-notify
+casetify.com##.cookie-option
 kids.lego.com##.cookie-overlay_cookieOverlayContainer__V7Glz
 thirtyoneeight.org##.cookie-page-overlay
 rdu.com##.cookie-panel-wrapper


### PR DESCRIPTION
Hiding cookie banner on casetify.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1927