### PR TITLE
A: wilsoncenter.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1814,7 +1814,7 @@ greatbigcanvas.com##.gbc-notifications
 audi.com##.gbp-overlay
 petercallandermd.com##.gdpCookie
 leapyear.io##.gdpr--modal
-brainandlife.org,thebaffler.com##.gdpr-alert
+brainandlife.org,thebaffler.com,wilsoncenter.org##.gdpr-alert
 principledtechnologies.com##.gdpr-check
 fast-poll.com##.gdpr-cookie-message-wrapper
 advocate.com##.gdpr-cookie-wrapper


### PR DESCRIPTION
Hiding cookie popup from wilsoncenter.org

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2010