### PR TITLE
A: target.com.au

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -10,6 +10,7 @@ wineinvestmentfund.com###Contentplaceholder1_TAEB3815A051_Col00
 fruugo.co.nz###CookieBanner
 mauldineconomics.com###CookieControl
 audiot.co.uk###CookieRequester
+target.com.au###CookieUseAgreement
 lttstore.com###Cookies-wrapper
 cardmarket.com###CookiesConsent
 saleappliancesltd.co.uk###CybotCookiebotDialogWrapper


### PR DESCRIPTION
Hiding cookie banner on target.com.au

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2065