### PR TITLE
M+P: jigsawplanet.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -414,7 +414,6 @@ academictorrents.com###carbon
 downforeveryoneorjustme.com###carbonDiv
 csdb.dk###casdivhor
 csdb.dk###casdivver
-jigsawplanet.com###cb984b30f2-4
 cbn.com###cbn_leaderboard_atf
 cloudwards.net,guitaradvise.com###cbox
 linuxinsider.com###cboxOverlay
@@ -6338,8 +6337,7 @@ daily-choices.com##[id^="sticky_"]
 alternet.org##[id^="story_page_incontent_"]
 thesaurus.com##[id^="tco"]
 topcpu.net##[id^="topcpu_net_in_page_repeat_responsive"][style="min-height: 300px;"]
-jigsawplanet.com##[id^="tsi-"][style="height:90px;margin:0"]
-jigsawplanet.com##[id^="tsi-"][style="height:90px;margin:var(--block-vertical-spacing) 0"]
+jigsawplanet.com##div[id^="cb"]:not(.ts-gmspc)
 everythingrf.com##[id^="wallpaper_"]
 wuxiaworld.site##[id^="wuxia-"]
 samfw.com##[name="chimera_b"]


### PR DESCRIPTION
The previous filter (implemented at https://github.com/easylist/easylist/commit/3c2f1f55da878b1fa33cf2d6affe154226aaa0a9) has become outdated. Though, it didn't actually filter all of the anti-ad-block notices anyways.

This PR fixes both issues.

A few questions I expect might be asked:

* Why can't we just target specific IDs?
  1. The anti-ad-block notices on each type of page have different IDs. For example, the anti-ad-block notice on the homepage has a different ID from the jigsaw-playing page.
  2. The website deliberately breaks itself if we attempt to target specific IDs. In particular, the website swaps two element's IDs on the jigsaw-playing page, depending on whether you're logged in. This alone would prevent us from targeting specific IDs.
  3. Including the hash in the filter makes it incredibly easy to bypass - all one needs do is make a new hash.
* Why target just `div`s?
  * The settings page has several elements that would be hidden if we didn't target `div`s.
* Why exclude `.ts-gmspc`?
  * This is a class for the gameplay field, on the page where you play the actual jigsaw puzzle. If we didn't exclude this, it would end up blocking the gameplay field as well.