### PR TITLE
A: siepe.educacao.pe.gov.br

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -861,6 +861,7 @@ cybervisiontech.com##.Cookies-module--cookie--2ydR3
 traderjoes.com##.CookiesAlert_cookiesAlert__3qSl1
 yesim.app##.CookiesAlert_wrapper__Al0h2
 fitline.com##.CookiesGDPR_initial__2ePNF
+siepe.educacao.pe.gov.br##.CookiesModalContainer
 fireflyz.com.my,malaysiaairlines.com##.CookiesNotificationBtmOverlaySticky
 andersenlab.com##.CookiesPolicy-module--wrapper--8pHca
 hoorayteams.com##.CookiesPopUp_CookiesPopUp__z7bHv


### PR DESCRIPTION
Hiding cookie message from siepe.educacao.pe.gov.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2206