### PR TITLE
A: hiding cookie banners from various sites

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2813,7 +2813,7 @@ czds.icann.org##czds-cookie-notification
 c.realme.com##div > .cookie-privacy
 corrupt.wiki,developer.rocket.chat,docs.coreframework.com,docs.fluentbit.io,docs.flutterflow.io,docs.ibracorp.io,docs.jabref.org,electronforge.io,filebrowser.org,guides.cryptowat.ch,meshnet.nordvpn.com,support.saleae.com,wiki.valhelsia.net##div.r-1xcajam.css-175oi2r
 utrechtart.com##div[aria-label="cookie consent banner"]
-biography.com,countryliving.com,delish.com,harpersbazaar.com,pitchfork.com,prevention.com,townandcountrymag.com##div[aria-label^="Privacy Disclosure"]
+biography.com,caranddriver.com,cosmopolitan.com,countryliving.com,delish.com,elle.com,elledecor.com,esquire.com,goodhousekeeping.com,harpersbazaar.com,housebeautiful.com,menshealth.com,pitchfork.com,popularmechanics.com,prevention.com,roadandtrack.com,runnersworld.com,thepioneerwoman.com,townandcountrymag.com,womenshealthmag.com##div[aria-label^="Privacy Disclosure"]
 audiomack.com##div[class*="ConfirmMessage-module__cookie-"]
 easyoffices.com##div[class*="CookiesBar_"]
 phot.ai##div[class*="styles_consentCard__"]


### PR DESCRIPTION
I noticed all of these sites have the same cookie message. I have hidden the cookie message from them.

esquire.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1824
menshealth.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/763
womenshealthmag.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1829
popularmechanics.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/764
roadandtrack.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2143
runnersworld.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1842
elle.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1820
caranddriver.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1828
cosmopolitan.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1825
housebeautiful.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/775
elledecor.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/779
goodhousekeeping.com - Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1826