### PR TITLE
A: la7.it

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -101,6 +101,7 @@
 ||jzzo.com/jss/cp01.js
 ||kayak.*/privacy/
 ||kotaku.com/wrapper/*/gdpr/$xmlhttprequest,domain=kotaku.com
+||la7.it/la7_iabtcf2/cmp.js
 ||lacompagnie.com/Content/dist/templates/common/popupCookies/
 ||lilysilk.com^*/cookie.min.js
 ||liquidweb.com/ajax/dataconsentcookies
@@ -120,6 +121,7 @@
 ||pepper.com/assets/js/CookiesMessage_
 ||prada.com/utag/prada/
 ||privacy.claytonhomes.com^
+||privacymanager.io^$domain=la7.it
 ||privacypolicy.trgr.be^
 ||propcom.co.uk/cookie/
 ||purevpn.com/loadGdprView


### PR DESCRIPTION
Blocking cookies from la7.it

This change was suggested from uBlock here: https://github.com/uBlockOrigin/uAssets/pull/32247#issuecomment-4083309645

This fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2230