### PR TITLE
A: appsflyersdk.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2923,6 +2923,9 @@
 ||websdk.appsflyer.com^
 ||wa.appsflyersdk.com^
 ||websdk.appsflyersdk.com^
+||banner.appsflyersdk.com^
+||fvalid.appsflyersdk.com^
+||onelinksmartscript.appsflyersdk.com^
 ||webservices.websitepros.com^
 ||webstats.thaindian.com^
 ||websuccess-data.com/tracker.js


### PR DESCRIPTION
As of March 10th AppsFlyer PBA Web SDK reports to wa.appsflyersdk.com and is delivered from websdk.appsflyersdk.com.