### PR TITLE
A: wolframalpha.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2908,6 +2908,7 @@ huntington.northwell.edu##nwhlit-gdpr-banner
 playpaxdei.com##paxdei-cookie-consent
 proactua.com##proactua-cookie-consent
 lookup.icann.org##rwc-cookie-notification
+wolframalpha##section:has-text(This website uses cookies)
 reddit.com##shreddit-async-loader[bundlename="reddit_cookie_banner"]
 reddit.com##shreddit-cookie-banner
 remotehub.com##smp-cookies-banner


### PR DESCRIPTION
Hiding cookie banner on wolframalpha.com. This issue is reproducible when browsing from the UK

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/639