### PR TITLE
A: woocommerce.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2672,6 +2672,7 @@ lyst.com##.w5yGp
 foundico.com##.warn-wrap
 netio-products.com##.warning-modal
 ada.com##.wbl72e-0-footer
+woocommerce.com##.wccom-comp-privacy-banner
 capterra.com##.welcome-banner
 inflight.pacwisp.net##.wisp-modal
 wizards.com##.wizardCookieBanner


### PR DESCRIPTION
Hiding cookie banner on woocommerce.com

Fix suggested here: https://github.com/uBlockOrigin/uAssets/pull/32263#issuecomment-4095571364

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/633