### PR TITLE
A: reebok.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -707,7 +707,7 @@ pqimemory.com###simple-notice-wrap-content
 centurion-magazine.com###simple-notification
 isa.org###simplemodal-container
 mercedesamgf1.com###simplemodal-overlay
-fredericks.com,rvca.com###site-cb-footer
+fredericks.com,reebok.com,rvca.com###site-cb-footer
 spamhero.com###site-wide-cookie-notice
 openstylelab.org###site-wide-legal-notice
 hidive.com###siteMsgSlideUpBG


### PR DESCRIPTION
Hiding cookie banner on reebok.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/606