### PR TITLE
A: funnyordie.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -793,6 +793,7 @@ iflicks.in###welcome
 taiwanplus.com###welcomeMsg
 weverse.io###wevConsentManagerLayer
 johnfrederick.co.uk###wp-notification
+funnyordie.com###wpautoterms-bottom-fixed-container
 f1forgottendrivers.com###wpcg-box
 acoup.blog###wpconsent-root
 wpx.net###wpx-cookie-agreement


### PR DESCRIPTION
Hiding cookie banner on funnyordie.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/574