### PR TITLE
A: m.sport-express.net

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -682,6 +682,7 @@ smcworld.com###s-modal
 sanitas.com###sanitasCookieAlert
 larksuite.com###sc-cookie-banner
 gizmodo.com###sd-cmp
+m.sport-express.net###se-cookie-popup
 seetickets.com###seeGdprCookieConsent
 fcc-group.eu###set-win-coo
 sentaifilmworks.com###sfw-msg


### PR DESCRIPTION
Hiding cookie popup on m.sport-express.net

Fixed https://github.com/brave-experiments/cookiecrumbler-issues/issues/612