### PR TITLE
A: appsflyer.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2936,6 +2936,7 @@
 ||webmasters.ksalsocial.online/pixel/
 ||websdk.appsflyer.com^
 ||onelinksmartscript.appsflyer.com^
+||impression.appsflyer.com^
 ||websdk.appsflyersdk.com^
 ||webservices.websitepros.com^
 ||webstats.thaindian.com^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2935,6 +2935,7 @@
 ||webgames.io/imp/
 ||webmasters.ksalsocial.online/pixel/
 ||websdk.appsflyer.com^
+||onelinksmartscript.appsflyer.com^
 ||websdk.appsflyersdk.com^
 ||webservices.websitepros.com^
 ||webstats.thaindian.com^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2935,6 +2935,7 @@
 ||webgames.io/imp/
 ||webmasters.ksalsocial.online/pixel/
 ||websdk.appsflyer.com^
+||sdk.appsflyer.com^
 ||onelinksmartscript.appsflyer.com^
 ||impression.appsflyer.com^
 ||websdk.appsflyersdk.com^

--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1355,6 +1355,7 @@
 ||impdesk.com/smartpix/
 ||impel.io/releases/analytics/
 ||impress.vcita.com^
+||impression.appsflyer.com^
 ||impressionmedia.cz/statistics/
 ||in.treasuredata.com^
 ||inbound-analytics.pixlee.co^
@@ -1801,6 +1802,7 @@
 ||ondigitalocean.app/insight-analytics.js
 ||one.store/v1/analytics/
 ||onecount.net/onecount/oc_track/
+||onelinksmartscript.appsflyer.com^
 ||onelinksmartscript.appsflyersdk.com^
 ||onescreen.net/os/static/pixels/
 ||onesignal.com/api/v*/apps/
@@ -2199,6 +2201,7 @@
 ||sdiapi.com/reporter/
 ||sdk-service.nsureapi.com/events
 ||sdk.51.la^$third-party
+||sdk.appsflyer.com^
 ||sdk.mrf.io/statics/marfeel-sdk.js
 ||sdrive.skoda-auto.com^
 ||sdtagging.azureedge.net^
@@ -2935,9 +2938,6 @@
 ||webgames.io/imp/
 ||webmasters.ksalsocial.online/pixel/
 ||websdk.appsflyer.com^
-||sdk.appsflyer.com^
-||onelinksmartscript.appsflyer.com^
-||impression.appsflyer.com^
 ||websdk.appsflyersdk.com^
 ||webservices.websitepros.com^
 ||webstats.thaindian.com^


### PR DESCRIPTION
Add `||onelinksmartscript.appsflyer.com^`

The appsflyer.com predecessor to `onelinksmartscript.appsflyersdk.com` (covered in #23473). `websdk.appsflyer.com` is already blocked, this covers the remaining active script hosted on the legacy domain.

Short list of sites still loading from this host:

- etoro.com, samsung.com (regional variants), fox.com (and regional variants: fox7austin.com, fox2detroit.com, etc.), taskrabbit.com, truely.com, vsco.co

Add `||impression.appsflyer.com^`

View-through attribution pixel endpoint. Fired as a `$image` request when a user is exposed to tracked content, no click required. AppsFlyer documentation can be found [here](https://support.appsflyer.com/hc/en-us/articles/210084473-Measure-view-through-engagements#set-impression-links).

Examples can be found on:

- gap.com (and all gap owned brands)
- yahoo.com, reddit.com - fired via ad networks serving AppsFlyer attributed ads, appears broadly across any publisher serving such ads

Add `||sdk.appsflyer.com^`

Mobile install attribution endpoint used by the [Windows UWP SDK](https://support.appsflyer.com/hc/en-us/articles/207032026-Windows-SDK-integration-for-developers) (AppsFlyerLib.winmd). Called on every app launch via `GetConversionDataAsync()`, transmitting app ID, dev key, and device ID to attribute the install to an ad campaign. Response is cached locally, subsequent launches return the cached value without hitting the network.

URL format: `https://sdk.appsflyer.com/install_data/v3/{appId}?devkey={devKey}&device_id={deviceId}`

Do note, `TrackEvent()` is currently blocked by an existing `||t.appsflyer.com^` rule.
