### PR TITLE
A: hide kamino banners

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -12851,6 +12851,7 @@
 ##[data-asg-ins]
 ##[data-block-type="ad"]
 ##[data-cl-spot-id]
+##[data-component-id="kamino"]
 ##[data-css-class="dfp-inarticle"]
 ##[data-d-ad-id]
 ##[data-desktop-ad-id]


### PR DESCRIPTION
Hides ads from [Kamino](https://www.kaminoretail.com/)'s network.

Fixes #23527