### PR TITLE
P: `en.pronouns.page`

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -704,6 +704,7 @@
 ||foodcouture.net/public_html/ra/script.php
 ||forgood.co.za/api/tracking/
 ||formula1.com/api/track
+||fornovn.fo/api/sentry/tunnel
 ||fortune.com/comscore-json/
 ||foursquare.com/v2/private/logactions
 ||foxsports.com.au/akam/
@@ -1355,6 +1356,12 @@
 ||prod-events.nykaa.com^
 ||progressive.com/Log/
 ||promos.investing.com/*/digibox.gif?
+||pronom.it/api/sentry/tunnel
+||pronombr.es/api/sentry/tunnel
+||pronomejo.net/api/sentry/tunnel
+||pronomen.net/api/sentry/tunnel
+||pronoms.fr/api/sentry/tunnel
+||pronouns.page/api/sentry/tunnel
 ||prop.astonvillanews.co.uk^
 ||proporn.com/ajax/log/
 ||proxima.midjourney.com^
@@ -2130,6 +2137,7 @@
 ||z.cdp-dev.cnn.com^
 ||z737.thestar.com^
 ||za.qeeq.com^
+||zaimki.pl/api/sentry/tunnel
 ||zalando-lounge.*/api/tracking/
 ||zalando-prive.*/api/tracking/
 ||zappos.com/err.cgi?

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1670,7 +1670,8 @@ rsc.org##.returntotop
 hodinky-365.com##.roll-to-top
 rti.org.tw##.scorll-top
 artx.at##.scroll--top-wrapper
-magazine.medlineplus.gov,pronouns.page##.scroll-btn
+magazine.medlineplus.gov##.scroll-btn
+fornovn.fo,pronom.it,pronombr.es,pronomejo.net,pronomen.net,pronoms.fr,pronouns.page,zaimki.pl##.scroll-btn[style]
 timesofmalta.com##.scroll-notification-container
 esslinger-zeitung.de##.scroll-to
 50languages.com,advgazeta.ru,boredpanda.com,btgpactual.com,centroculturalfcsn.org.br,cnevpost.com,developer-tech.com,gulftoday.ae,hsn.com,ingolstadt-today.de,intercabos.com.br,iol.co.za,labouroutlook.org,leadingrestaurants.co.uk,lessknownfacts.com,malighting.com,nostalgica.cl,ons.org.br,origo.hu,pandasecurity.com,pbteen.com,peoplematters.in,ptinews.com,radiondadurto.org,saalbach-hinterglemm.nl,sasol.com,westcordhotels.com,westcordhotels.de,westcordhotels.nl##.scroll-to-top


### PR DESCRIPTION
Unhides translation button and blocks sentry endpoint.
This pull request fixes https://github.com/easylist/easylist/issues/18247.