### PR TITLE
A: `viennapte.pl`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -176,6 +176,7 @@ newindianexpress.com###ckgre
 nch.com.au,nchsoftware.com###ckndiv
 bghotelite.com###clb_wr
 familytreenow.com###clym-widget-discrete
+viennapte.pl###cm-overlay
 cmegroup.com###cmePermissionQuestion
 polygon.technology###cmp
 c3ny.org,means-of-production.com###cnb


### PR DESCRIPTION
Hides cookie banner.
This pull request fixes https://github.com/easylist/easylist/issues/18274.