### PR TITLE
A: gigafile.nu

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3477,6 +3477,7 @@ getcomics.org##.getco-content_2
 flickr.com##.getty-search-view
 flickr.com##.getty-widget-view
 pixabay.com##.gettyImagesContainer--7sZnR
+gigafile.nu##.gf-bottom-panel-left
 marketsfarm.com##.gfm-ad-network-ad
 law.cornell.edu##.gfs
 gg.deals##.gg-banner-full-link
@@ -4689,6 +4690,7 @@ thecoinrise.com##.pp_ad_block
 theportugalnews.com##.ppp-banner
 theportugalnews.com##.ppp-inner-banner
 oneesports.gg##.pr-sm-4
+gigafile.nu##.pr_area_sp
 hindustantimes.com##.pramotedWidget
 protrumpnews.com##.pre-announcement
 birdsandblooms.com,familyhandyman.com,rd.com,tasteofhome.com,thehealthy.com##.pre-article-ad


### PR DESCRIPTION
These ads are blocked on mobile for Adguard https://github.com/AdguardTeam/AdguardFilters/blob/2ee5d526b535730e1364e189b4d66394cceaab61/MobileFilter/sections/specific_web.txt#L2369

I am blocking them on the mobile and desktop versions with this commit