### PR TITLE
A: simple.ripley.com.pe

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1558,6 +1558,7 @@ freesmsgateway.com,germanospalhasitalianas.com.br,ucoin.net##.cookies-warning
 lumia.security##.cookies-wrapper-new
 n-ix.com##.cookiesBlock
 aidude.info##.cookiesConsent__wrapper
+simple.ripley.com.pe##.cookiesMessage_cookiesDisclaimer__pF8_x
 vertiv.com##.cookiesOptInBanner
 coupert.com##.cookiesPolicy_cookie_warp__76VwO
 rbth.com##.cookies__banner


### PR DESCRIPTION
Hiding cookie banner from simple.ripley.com.pe

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2237