### PR TITLE
A: parcelsapp.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -191,7 +191,7 @@ nflp.com###compliance-notice
 msn.com###conditionalbanner
 imei24.com###cons
 yopmail.com###cons-pop
-mobisystems.com###consent-banner
+mobisystems.com,parcelsapp.com###consent-banner
 agoda.com###consent-banner-container
 aspose.com,chessshop.eu,theonion.com###consent-banner-main
 products.aspose.com###consent-banner-wall


### PR DESCRIPTION
Hiding cookie banner on parcelsapp.com (when browsing from the UK)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1958