### PR TITLE
A: kickoff.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -206,7 +206,7 @@ store.steelcase.com###consent-skeleton
 altardstate.com,cacaushow.com.br,citizenwatch.com,helzberg.com,manyavar.com,mechanix.com,michele.com###consent-tracking
 nordvpn.com###consent-widget-container
 polymerclaylatvia.com###consent-window
-soccerladuma.co.za###consent-wrapper
+kickoff.com,soccerladuma.co.za###consent-wrapper
 akiflow.com###consentBanner-container
 krunker.io,moomoo.io###consentBlock
 oryx-embedded.com###consentBox


### PR DESCRIPTION
Hiding cookie banner on kickoff.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/832