### PR TITLE
A: olimpo.bet

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -149,6 +149,7 @@ ubs.com###cboxContent
 armorgames.com###cc-alert
 sdaa-france.com,yellow.place###cc-bar
 smart-home-fox.co.uk###cc-card
+olimpo.bet###cc-main
 consoleconnect.com,pccwglobal.com,sorianatural.es###cc-overlay
 aam-us.org,rodavigo.net###cc-window
 avosound.com###cc_b


### PR DESCRIPTION
Hiding cookie message on olimpo.bet

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/593