### PR TITLE
A: sante.fr

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -664,6 +664,7 @@ planetsurfcamps.com###ps-consent
 fromage-beaufort.com###rgpd-form
 bymycar.fr###sd-cmp
 capital.fr###sp-consentModal
+sante.fr###tarteaucitronRoot
 abc-toulouse.fr###trackingbannerpopin
 clinique-veterinaire.fr###userConsentPolicy
 terre-des-seniors.fr###valid-cookies


### PR DESCRIPTION
Hiding cookie banner on sante.fr

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/674