### PR TITLE
A: oberlo.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -367,7 +367,7 @@ dobbies.com###dobbies_cookie_widget
 uga.edu###dp-cookie-notification
 drupal.org###drupalorg-crosssite-gdpr
 duke.edu###duke-cookie-consent
-shopify.com###dux-privacy
+oberlo.com,shopify.com###dux-privacy
 dyclassroom.com###dy-cookieInfo-container
 starwest-botanicals.com###eapps-cookie
 swann-morton.com###easyNotification


### PR DESCRIPTION
Hiding cookie popup on oberlo.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/656