### PR TITLE
A: simplic.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -447,6 +447,7 @@ zylom.com###headerbar_privacy
 healio.com###healio-consent-overlay
 fitzpatrickreferrals.co.uk###hellobar
 heroesprofile.com###heroesprofile-alert
+simplic.com.br###home-page--how-it-works
 abacus.ai###homeVisitPopup
 thehustle.co###hs-banner-parent
 rewardgateway.com###hs-eu-cookie-confirmation


### PR DESCRIPTION
Hiding cookie banner on simplic.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/585