### PR TITLE
A: zulacasino.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3059,7 +3059,7 @@ agados.cz,concert.ua,delfortgroup.com,githubstatus.com,goldaglida.co.il,morfix.c
 !! .cookie-consent-popup
 015.co.il,almaviva.it,cos.com,expireddomains.com,gcli.li,hm.com##.cookie-consent-popup
 !! #cookie-consent-popup
-bagina.co.il,finam.ru,halalit.co.il,pccenter.co.il,rsm.co.il,shop-now14.co.il###cookie-consent-popup
+bagina.co.il,finam.ru,halalit.co.il,pccenter.co.il,rsm.co.il,shop-now14.co.il,zulacasino.com###cookie-consent-popup
 !! .cookiebar
 ammeraalbeltech.com,asst-lecco.it,community.dyson.com,community.jamf.com,mahle-aftermarket.com,mega-monheim.de,nautadutilh.com,purejingles.com,sigmanet.lv,trtcocuk.net.tr,um.edu.mt##.cookiebar
 !! #cliSettingsPopup


### PR DESCRIPTION
Hiding cookie popup on zulacasino.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/549