### PR TITLE
A: lassuranceretraitre.fr

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -664,6 +664,7 @@ planetsurfcamps.com###ps-consent
 fromage-beaufort.com###rgpd-form
 bymycar.fr###sd-cmp
 capital.fr###sp-consentModal
+lassuranceretraite.fr###tarteaucitronRoot
 abc-toulouse.fr###trackingbannerpopin
 clinique-veterinaire.fr###userConsentPolicy
 terre-des-seniors.fr###valid-cookies


### PR DESCRIPTION
Hiding cookie banner on lassuranceretraitre.fr

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/537