### PR TITLE
A: rabobank.nl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2893,6 +2893,7 @@ conferience.com##div[style^="width: 380px;max-width:"]
 training.cyberark.com##doc-layout-cookie-policy-banner
 bosch-professional.com##dock-privacy-settings
 angular.dev##docs-cookie-popup
+rabobank.nl##feature-ssr-modular-cookiebanner
 fedex.com##fedex-gdpr
 fi.google.com##fi-cookie-consent
 welcome.sparxmaths.uk##footer


### PR DESCRIPTION
Hiding cookie banner on rabobank.nl

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/505