### PR TITLE
A: uni-frankfurt.de

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -477,6 +477,7 @@ glashuette-original.com###js_dataNnoticeBtns
 juno.co.uk,junodownload.com###juno-cookie-consent
 chipotle.com###ketch-consent-banner
 forbes.com###ketch-consent-overlay
+uni-frankfurt.de###klaro-cookie-notice
 carmax.com###kmx-privacy-popup
 shanebarker.com###kt-layout-id_e3c48e-e4
 brandfolder.com,katv.com,kfdm.com,komonews.com,ktul.com,wjla.com###lanyard_root


### PR DESCRIPTION
Hiding cookie popup on uni-frankfurt.de

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/466