### PR TITLE
A: kiwi.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -283,7 +283,7 @@ bulgarianproperties.com###cookie_bar_new
 1fichier.com###cookie_box
 semiconductor.samsung.com###cookie_component
 semiconductor.samsung.com###cookie_component_emea
-comscore.com,domainname.shop,givengain.com,mkchulin.cz,mzanzisolutions.co.za,uscareerinstitute.edu###cookie_consent
+comscore.com,domainname.shop,givengain.com,kiwi.com,mkchulin.cz,mzanzisolutions.co.za,uscareerinstitute.edu###cookie_consent
 khronos.org###cookie_decline
 sendgb.com###cookie_disabled
 halcyon.net,santionduty.com###cookie_info


### PR DESCRIPTION
Hiding cookie popup on kiwi.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/441