### PR TITLE
A: vagaro.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1837,6 +1837,7 @@ keyboard.cool##.gdpr-nag
 ecwid.com,liberties.eu##.gdpr-window
 terro.com,woodstreambrands.ca##.gdpr-wrap
 curacao.com##.gdprConsent
+vagaro.com##.gdprCookies-banner
 doteasy.com,mochahost.com##.gdprTheme
 chillychiles.com,shop.animalbiome.com##.gdpr__holder
 mitac.com##.gdpr_block


### PR DESCRIPTION
Hiding cookie banner on vagaro.com

Fixed https://github.com/brave-experiments/cookiecrumbler-issues/issues/752