### PR TITLE
A: perthnow.com.au

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1410,6 +1410,7 @@ goodlawproject.org##.cookie-card
 allyouplay.com##.cookie-card_container
 benq.com##.cookie-component
 moneycontrol.com##.cookie-concern-wrapper
+perthnow.com.au##.cookie-consent--GDPR
 friends.figma.com##.cookie-consent-acknowledgement-conatiner
 allmyfaves.com,charlesandcolvard.com##.cookie-consent-banner
 meest-shop.com##.cookie-consent-banner_root__M9V7x


### PR DESCRIPTION
Hiding cookie message on perthnow.com.au

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/700