### PR TITLE
A: twinkl.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1416,6 +1416,7 @@ meest-shop.com##.cookie-consent-banner_root__M9V7x
 aerolopa.com##.cookie-consent-modern
 developers.turing.com##.cookie-consent-overlay
 buying.expert##.cookie-consent-popover
+twinkl.co.uk##.cookie-consent-popup-container
 fling2night.com##.cookie-consent-root
 samsungknox.com##.cookie-consent-v3
 springbok-puzzles.com,tinyurl.com,visitworld.today##.cookie-consent-wrapper


### PR DESCRIPTION
Hiding cookie popup on twinkl.co.uk

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/699