### PR TITLE
A: finder.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1426,6 +1426,7 @@ anycubic.com##.cookie-drawer
 evoto.ai##.cookie-drawer-container
 tachyon.eco##.cookie-exp
 beautybay.com##.cookie-focus
+finder.com##.cookie-footer-bar
 amu.edu.pl##.cookie-information
 spacenighthotel.top##.cookie-locker
 answerthepublic.com##.cookie-main


### PR DESCRIPTION
Hiding cookie banner on finder.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/697