### PR TITLE
A: aion2.plaync.com

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1938,6 +1938,8 @@ vroid.com##div[class^="GDPR__Container-"]
 ! ---------- Korean ----------
 !
 kayak.co.kr###Ag6p
+aion2.plaync.com###gCookieConfirmDimmed
+aion2.plaync.com###gCookieConfirmToast
 kotra.or.kr##.cookiePopArea
 !
 ! ---------- Latvian ----------


### PR DESCRIPTION
Hiding cookie notice on aion2.plaync.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2160