### PR TITLE
A: onemillionpredictions.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -247,6 +247,7 @@ autism-unlimited.org###cookie-cover
 asianlemansseries.com###cookie-dialog
 uofmhealth.org###cookie-law
 cpac.ca###cookie-law-bar-holder
+onemillionpredictions.com###cookie-law-info-bar
 ecigarettedirect.co.uk###cookie-message-slide-in
 dirsyncpro.org###cookie-notice-modal
 energylivenews.com###cookie-notification-mask


### PR DESCRIPTION
Hiding cookie popup on onemillionpredictions.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2086