### PR TITLE
A: adresowo.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2194,6 +2194,8 @@ discovereurope.esn.pl##.c__cake
 prohibita.pl##.ciachbtm-wrap-container
 vod.warszawa.pl##.cjcVDw
 forumrowerowe.org##.ckg
+adresowo.pl##.cky-consent-container
+adresowo.pl##.cky-overlay
 aterima-work.pl##.cm-popup-wrapper
 pracuj.pl##.cmulq7z
 sklep.szprychy.com##.config-messages


### PR DESCRIPTION
Hiding cookie popup on adresowo.pl

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2085