### PR TITLE
A: publitas.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1315,8 +1315,8 @@ img.ly##.cke-overlay
 ruijie.com##.cke2022fr
 stayinwales.co.uk##.ckinfo-panel
 ignitedfitness.com##.cky-consent-bar
-betplay.com.co,click2pharmacy.co.uk,delfi.ee,johnryanbydesign.co.uk,oiq.qc.ca,qcs.co.uk,scuffers.com##.cky-consent-container
-betplay.com.co,click2pharmacy.co.uk,delfi.ee,johnryanbydesign.co.uk,oiq.qc.ca,qcs.co.uk,scuffers.com##.cky-overlay
+betplay.com.co,click2pharmacy.co.uk,delfi.ee,johnryanbydesign.co.uk,oiq.qc.ca,publitas.com,qcs.co.uk,scuffers.com##.cky-consent-container
+betplay.com.co,click2pharmacy.co.uk,delfi.ee,johnryanbydesign.co.uk,oiq.qc.ca,publitas.com,qcs.co.uk,scuffers.com##.cky-overlay
 jackjones.com##.cky-overlay-custom
 clineva.com##.clineva-cookies-info
 oipc.bc.ca##.clsPopupContainer


### PR DESCRIPTION
Hiding cookie popup on publitas.com (reproducible from UK)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1441