### PR TITLE
A: portal.edu.gva.es

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -616,6 +616,7 @@ toyota.com.ph###popup-slider
 chocolateminecraft.com###popup1
 moffettnathanson.com###popupDisclaimer
 growthtechnology.com###popupbanner
+portal.edu.gva.es###portaledu-policy-banner
 melaniemartinezmusic.com###pp-footer
 paperlesspost.com###pp-global-third-party-cookie-banner
 r-studio.com,r-tt.com###pp-info


### PR DESCRIPTION
Hiding cookie banner on portal.edu.gva.es

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2053