### PR TITLE
A: fcbarcelona.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -348,6 +348,7 @@ discoveryeducation.com,readingplus.com###de-consent-banner
 universitysupplystore.com###demo-overlay
 filmon.com###design-switcher
 alliancefrancaise.ca###dialogbox_cookiepolicy
+fcbarcelona.com###didomi-popup
 innovaphone.com###disableBackground
 claridges.com###disc-bg
 one-line.com###disclaimer-bar


### PR DESCRIPTION
Hiding cookie popup on fcbarcelona.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1710