### PR TITLE
A: songsterr.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2928,6 +2928,7 @@ huntington.northwell.edu##nwhlit-gdpr-banner
 playpaxdei.com##paxdei-cookie-consent
 proactua.com##proactua-cookie-consent
 lookup.icann.org##rwc-cookie-notification
+songsterr.com##section[aria-labelledby="consent-summary-title"]
 reddit.com##shreddit-async-loader[bundlename="reddit_cookie_banner"]
 reddit.com##shreddit-cookie-banner
 remotehub.com##smp-cookies-banner


### PR DESCRIPTION
Hiding cookie message on songsterr.com (reproducible in the UK)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1804