### PR TITLE
A: postmates.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -633,7 +633,7 @@ worldjournal.com###privacy-agreement
 business-humanrights.org###privacy-choices
 monitor.civicus.org###privacy-choices-banner
 gonift.com###privacy-compliance-banner
-ubereats.com###privacy-cookie-banners-root
+postmates.com,ubereats.com###privacy-cookie-banners-root
 weather.com###privacy-data-notice
 dnddiceroller.com###privacy-div
 playstation.com###privacy-header


### PR DESCRIPTION
Hiding cookie banner on postmates.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1930