### PR TITLE
A: wufoo.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -386,7 +386,7 @@ schindelhauerbikes.com###etrpop
 trampaboards.com###eu_cookie_instructions
 nickfinder.com###europe_cookies_siht
 cricbuzz.com###feedback-bar
-nextjs.org,vercel.com,wetransfer.com###fides-banner-container
+nextjs.org,vercel.com,wetransfer.com,wufoo.com###fides-banner-container
 cntraveller.com,nytimes.com,surveymonkey.com###fides-overlay
 aitopics.org###fixed-footer
 toffeeweb.com###fixedFooter


### PR DESCRIPTION
Hiding cookie banner on wufoo.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/368