### PR TITLE
A: seattlepi.com, timesunion.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3725,7 +3725,7 @@ haberturk.com##.bottom-14
 !! .bottom-16
 app.erevie.pl,fikfap.com,tweetdeleter.com##.bottom-16
 !! .bottom
-joom.com,labyrinthos.co,rshb.ru,travelbags.nl##.bottom
+joom.com,labyrinthos.co,rshb.ru,seattlepi.com,timesunion.com,travelbags.nl##.bottom
 !! .py-2 (mobile inapp uses .bottom-0.fixed)
 newsbreak.com##.py-2.px-2
 !! spoke


### PR DESCRIPTION
Hiding cookie banner on seattlepi.com and timesunion.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1849
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1966