### PR TITLE
A: kids.youtube.com, tv.youtube.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1877,7 +1877,7 @@ telenor.com##.global-overlay-background
 matrixgames.com,slitherine.com##.globalAnnouncement
 starhub.com##.globalimportantmessage
 levy.co.uk,wisehosting.com##.glow-banner
-cloud.google.com##.glue-cookie-notification-bar
+cloud.google.com,kids.youtube.com,tv.youtube.com##.glue-cookie-notification-bar
 gw2mists.com##.gm-cookie-consent
 stealthex.io##.gmEwWa
 ecospaints.net##.gmt_block_screen


### PR DESCRIPTION
Hiding cookie banner on kids.youtube.com, tv.youtube.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/706
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1924