### PR TITLE
A: podium.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -387,7 +387,7 @@ trampaboards.com###eu_cookie_instructions
 nickfinder.com###europe_cookies_siht
 cricbuzz.com###feedback-bar
 nextjs.org,vercel.com,wetransfer.com###fides-banner-container
-cntraveller.com,nytimes.com,surveymonkey.com###fides-overlay
+cntraveller.com,nytimes.com,podium.com,surveymonkey.com###fides-overlay
 aitopics.org###fixed-footer
 toffeeweb.com###fixedFooter
 metatrader4.com###float-vertical-panel


### PR DESCRIPTION
Hiding cookie notice on https://podium.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/860