### PR TITLE
A: cdm.me

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -194,7 +194,7 @@ imei24.com###cons
 yopmail.com###cons-pop
 mobisystems.com,parcelsapp.com###consent-banner
 agoda.com###consent-banner-container
-aspose.com,chessshop.eu,theonion.com###consent-banner-main
+aspose.com,cdm.me,chessshop.eu,theonion.com###consent-banner-main
 products.aspose.com###consent-banner-wall
 fitnesssf.com###consent-click-shield
 allsaints.com,avanihotels.com,can-am.brp.com,minorhotels.com,oakshotels.com,rag-bone.com,zeffy.com###consent-dialog


### PR DESCRIPTION
Hiding cookie notice on https://cdm.me

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1419