### PR TITLE
A: (NSFW) fhcontent.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -259,7 +259,7 @@ hope.study###cookie-snackbar-popup
 startermotoralternator.com###cookie-status
 chowtaifook.com###cookie-tracking-notify
 bitvavo.com###cookie-wall
-faphouse.com,faphouse.tv,faphouse1.com,faphouse2.com,fhaccess.com###cookie-wall-short
+faphouse.com,faphouse.tv,faphouse1.com,faphouse2.com,fhaccess.com,fhcontent.com###cookie-wall-short
 letsdothis.com###cookieAcceptanceModal
 511mt.net###cookieBannerHolder
 rsvp.withgoogle.com###cookieBarWrapper


### PR DESCRIPTION
Hiding cookie notice on https://fhcontent.com (NSFW)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/813