### PR TITLE
A: portal.nelf.gov.ng

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1783,6 +1783,7 @@ namesilo.com##.fixed-footer
 mobileshop.eu##.fixed-warning
 tomtom.com##.fixed.bottom-24
 thelatinonewsletter.org##.fixed.left-2
+portal.nelf.gov.ng##.fixed:has-text(cookies)
 developer.arm.com##.fixedPolicyBox
 bleacherreport.com##.fixedRegion
 flyone.eu##.fixed_btm_bg


### PR DESCRIPTION
Hiding cookie notice on portal.nelf.gov.ng

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2092