### PR TITLE
A: fresha.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2825,6 +2825,7 @@ duelz.com##app-tiny-alert
 thomasnet.com##aside[data-sentry-component="CookieBanner"]
 essential.gg##banner-content
 cherytr.com,cine-max.sk##body .cc-nb-main-container
+fresha.com##body > div:has-text(cookies)
 facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]
 community.nexthink.com##c-community-cookie-consent-banner
 success.trendmicro.com##c-dcx-cookie


### PR DESCRIPTION
Hiding cookie notice on fresha.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2015