### PR TITLE
A: huaweicloud.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2288,6 +2288,7 @@ shop.pricechopper.com##.pch-cookie-policy-bar
 5thavenue.co.za##.pd-consent-backdrop
 checkraka.com##.pdpa-popup
 classic-videogames.de,ess-news.com,pv-magazine.com,radio.com.pt,radiof.gmpress.pt,radios.pt##.pea_cook_wrapper
+huaweicloud.com##.pep-global-cookies
 spainhouses.net##.persistentMessage
 nordwindairlines.ru##.personal-data
 perfectcorp.com##.pf-header-cookiestatement


### PR DESCRIPTION
Hiding cookie message on huaweicloud.com (reproducible in Belgium)

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/644