### PR TITLE
P: https://www.bkmkitap.com/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -1175,7 +1175,6 @@
 ||app.kulgacdn.com/js/script.js
 ||apps.ihlasdigitalassets.com/stats
 ||c.keltis.com^
-||collector.wawlabs.com^
 ||core.dehapi.com/ip.php
 ||daioncdn.net/events?
 ||eticaret.pro/pixel/
@@ -1190,6 +1189,7 @@
 ||track.livasoft.com.tr^
 ||tracker.adcluster.com.tr^
 ||traffic.wdc.center^
+||wa.wawlabs.com^
 ||web.tv/analytics/
 ! Ukranian
 ||informers.sinoptik.ua^


### PR DESCRIPTION
The domain `collector.wawlabs.com` is currently blocked by EasyPrivacy.
However, this domain is not a general analytics/tracking script. It belongs to Wawlabs, an AI-powered search and product discovery service used by several Turkish online stores (e.g. homend.com.tr, bkmkitap.com, ayakkabidunyasi.com.tr, and others).

The actual analytics and event tracking for Wawlabs is handled by `wa.wawlabs.com`.

Blocking `collector.wawlabs.com` breaks the search feature on affected sites. For example:

On bkmkitap.com, searching for “kalemlik” returns no results (even though the product exists).
The same issue occurs on ayakkabidunyasi.com.tr and other sites using Wawlabs AI search.

When the collector.wawlabs.com rule is disabled, search works normally again.
Request:
Please remove `||collector.wawlabs.com^` from EasyPrivacy and (if appropriate) add `||wa.wawlabs.com^` instead, since wa.wawlabs.com is the domain actually used for analytics/event collection.

---

Steps to reproduce:

Go to https://www.bkmkitap.com/
Type “kalemlik” into the search bar
Press Enter

<details><summary>Screenshot</summary>

<img width="1366" height="724" alt="bk" src="https://github.com/user-attachments/assets/e0853ec3-44df-4326-832b-38a2c9e04857" />


</details>