### PR TITLE
P: radar.cloudflare.com/ip

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1408,7 +1408,7 @@
 ||invite.leanlab.co^
 ||invitejs.trustpilot.com^
 ||io.narrative.io/?$third-party
-||ip-check-perf.radar.cloudflare.com^
+||ip-check-perf.radar.cloudflare.com^$domain=~radar.cloudflare.com
 ||ip.lovely-app.com^
 ||ip.momentummedia.com.au^
 ||ippen.space/idat


### PR DESCRIPTION
https://radar.cloudflare.com/ip uses `ip-check-perf.radar.cloudflare.com` to get info on IPv4 address. The IPv6 version isn't blocked by easylist.