### PR TITLE
A: `cpstest.org`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -2637,6 +2637,7 @@ huffpost.com##.bottom-right-sticky-container
 crn.com##.bottom-section
 gamingdeputy.com##.bottom-sticky-offset
 coincodex.com##.bottom9
+cpstest.org##.bottomAdsection
 openguessr.com##.bottomFooterAds
 auto.hindustantimes.com##.bottomSticky
 softicons.com##.bottom_125_block


### PR DESCRIPTION
Hides ad banner leftover.
This pull request fixes https://github.com/easylist/easylist/issues/18289.