### PR TITLE
A: pgachampionship.com

### DIFF
--- a/fanboy-addon/fanboy_newsletter_allowlist.txt
+++ b/fanboy-addon/fanboy_newsletter_allowlist.txt
@@ -3,6 +3,7 @@
 @@||e24.no/cnp-assets/components-NewsletterWidget.$~third-party
 @@||el-vidas.nl^*/phpcuong_newsletter/$script
 @@||lightboxcdn.com/vendor/$script,domain=rydercup.com
+@@||lightboxcdn.com/z9gd/$script,domain=pgachampionship.com
 @@||list-manage.com/subscribe/post-json?
 @@||lumingerie.com/min/$script,~third-party
 @@||pico.tools/load/build.js$script,domain=escapistmagazine.com


### PR DESCRIPTION
Fixing breakage on pgachampionship.com by adding lightboxcdn to the allowlist for this domain specifically.

It appears that the site does not load content without first receiving the result from a request to lightboxcdn. So, if this request is blocked, the page remains broken.