### PR TITLE
A: consent.trustarc.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -58,6 +58,7 @@
 ||consent.stuff.tv^
 ||consent.thecountrysmallholder.com^
 ||consent.thegreatoutdoorsmag.com^
+||consent.trustarc.com^
 ||consent.wegotthiscovered.com^
 ||cookie-consent.festo.com^
 ||cookie.marsus.digital^


### PR DESCRIPTION
This is a domain that is serving cookie messages to websites. I have noticed that blocking this domain on sap.com (while browsing in the UK) will clear the cookie message and allow usage of the site without accepting cookies.

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/634