### PR TITLE
A: `metrotvnews.com`

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -539,6 +539,7 @@
 ||tvid.in/log/
 ! Indonesian
 ||beacon.coofis.com^
+||mediagroupnetwork.com/js/ua.js
 ||mediaquark.com/tracker.js
 ||oval.id/tracker/
 ||parsley.detik.com^


### PR DESCRIPTION
Blocks fingerprinting script.
A test page can be accessed at `https://www.metrotvnews.com/read/NgxCalaA-bahasa-indonesia-resmi-digunakan-dalam-publikasi-vatican-news`.
You need to scroll down until the article text loads in order to reproduce the issue.