### PR TITLE
Sap.com cookie notice

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -58,6 +58,7 @@
 ||consent.stuff.tv^
 ||consent.thecountrysmallholder.com^
 ||consent.thegreatoutdoorsmag.com^
+||consent.trustarc.com^
 ||consent.wegotthiscovered.com^
 ||cookie-consent.festo.com^
 ||cookie.marsus.digital^

--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -58,7 +58,6 @@
 ||consent.stuff.tv^
 ||consent.thecountrysmallholder.com^
 ||consent.thegreatoutdoorsmag.com^
-||consent.trustarc.com^
 ||consent.wegotthiscovered.com^
 ||cookie-consent.festo.com^
 ||cookie.marsus.digital^

--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -56,7 +56,7 @@
 ||consent.prointernet.com^
 ||consent.standardadmin.org^
 ||consent.trustarc.com/get?name=$subdocument,domain=avantiwestcoast.co.uk|oracle.com
-||consent.trustarc.com^$domain=authy.com|nejm.org|pedialyte.com|twilio.com
+||consent.trustarc.com^$domain=authy.com|nejm.org|pedialyte.com|sap.com|twilio.com
 ||consent.truste.com^$third-party
 ||consentag.eu^$third-party
 ||consentframework.com^$third-party


### PR DESCRIPTION
Related to this PR: https://github.com/easylist/easylist/pull/23856

However, this change now only applies to sap.com, to avoid breakage on other sites.