### PR TITLE
A: mazda-autohaus-schnickers-geldern.de

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -3014,3 +3014,6 @@ bpstat.bportugal.pt##+js(set-cookie, bdp_use_cookies, notagree)
 ! klimahotelmilano.com
 klimahotelmilano.com###body,html:style(overflow: auto !important; position: initial !important;)
 klimahotelmilano.com##.tpl-cookie
+! mazda-autohaus-schnickers-geldern.de
+mazda-autohaus-schnickers-geldern.de##body:style(overflow-y: visible !important;)
+mazda-autohaus-schnickers-geldern.de##.ReactModalPortal:has(#cookie-banner)


### PR DESCRIPTION
Hiding cookie notice on mazda-autohaus-schnickers-geldern.de.

This is in response to a user reported cookie notice on Brave.