### PR TITLE
A: theradiatorcentre.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -3014,3 +3014,6 @@ bpstat.bportugal.pt##+js(set-cookie, bdp_use_cookies, notagree)
 ! klimahotelmilano.com
 klimahotelmilano.com###body,html:style(overflow: auto !important; position: initial !important;)
 klimahotelmilano.com##.tpl-cookie
+! theradiatorcentre.com
+theradiatorcentre.com###cpu-wrapper
+theradiatorcentre.com##body:style(overflow: auto !important)


### PR DESCRIPTION
Hiding cookie notice on theradiatorcentre.com using a cosmetic filter and a custom injected style

This is in response to a user reported cookie notice on Brave