### PR TITLE
A: New Webloc/Penlink tracking servers

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -506,3 +506,22 @@
 ||rsras.cdn-fileserver.com^
 ||sra-px.cdn-fileserver.com^
 ||youseasky.com^
+! Webloc/Penlink infrastructure https://citizenlab.ca/research/analysis-of-penlinks-ad-based-geolocation-surveillance-tech/
+||cobwebsapp.com^
+||cwtapp.com^
+||cwsystem.com^
+||13.63.16.113^
+||139.0.5.194^
+||15.161.209.206^
+||15.161.210.71^
+||177.107.47.51^
+||182.23.55.125^
+||195.228.126.190^
+||20.187.80.77^
+||4.185.223.22^
+||4.233.111.135^
+||41.215.20.45^
+||52.253.117.211^
+||62.201.208.195^
+||78.11.103.139^
+! End of Webloc/Penlink infra


### PR DESCRIPTION
Citizen Lab found tracking servers for "Webloc" owned by Penlink, a geolocation surveillance company. This commit includes all known servers associated with the company.

Original report: https://citizenlab.ca/research/analysis-of-penlinks-ad-based-geolocation-surveillance-tech/