### PR TITLE
A: pinterest.com

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -364,3 +364,7 @@ branc.jp##+js(set-cookie, inc_optin_never_see_again-popup-1, 1)
 ! Amazon Prime
 amazon.*##.fable-portal-container:has(a#cross-benefit-modal-call_to_action-btn-0[href^="https://www.amazon."][href*="/gp/video/signup?benefitId=primeaddon"])
 amazon.*##html.fable-no-scroll:style(overflow: auto !important; touch-action: auto !important;)
+! pinterest.com (signup wall on sent/shared pin pages)
+pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
+pinterest.*##div[data-test-id="bottom-right-upsell"]
+pinterest.*##body[style*="overflow: hidden"]:style(overflow: auto !important;)

--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -365,6 +365,6 @@ branc.jp##+js(set-cookie, inc_optin_never_see_again-popup-1, 1)
 amazon.*##.fable-portal-container:has(a#cross-benefit-modal-call_to_action-btn-0[href^="https://www.amazon."][href*="/gp/video/signup?benefitId=primeaddon"])
 amazon.*##html.fable-no-scroll:style(overflow: auto !important; touch-action: auto !important;)
 ! pinterest.com (signup wall on sent/shared pin pages)
-pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
-pinterest.*##div[data-test-id="bottom-right-upsell"]
+pinterest.*##div[style*="z-index: 10001"]
+pinterest.*##div[data-test-id="giftWrap"]
 pinterest.*##body[style*="overflow: hidden"]:style(overflow: auto !important;)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.pinterest.com/pin/70437488970747/sent/`

### Describe the issue

When visiting a Pinterest "sent" (shared) pin URL while not logged in, two annoyances block the page:

1. A full-screen signup wall modal (`z-index: 10001`, `position: fixed`, dark overlay) with "Join ... on Pinterest for more ideas" - blocks all content and locks body scroll via `overflow: hidden`.
2. A "You are signed out" upsell popup (`data-test-id="bottom-right-upsell"`) that appears in the bottom-right corner after scrolling.

The `#credential_picker_container` (Google one-tap) is already covered in `fanboy_annoyance_general_hide.txt`.

### Filters added to `fanboy_annoyance_specific_uBO.txt`

```
pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
pinterest.*##div[data-test-id="bottom-right-upsell"]
pinterest.*##body[style*="overflow: hidden"]:style(overflow: auto !important;)
```

### Notes

- The signup wall div uses class `Fm_EPH`, but this class is shared with the content grid (`data-test-id="grid"`). Using `.Fm_EPH` hides the page content. The `:has()` selector targets only the parent of the `aria-modal` dialog.
- Tested in Firefox 137.0 (headless via Playwright). Filters hide both popups while keeping pin content, images, and feed fully visible and scrollable.
- Redirected here from uBlockOrigin/uAssets#32523 per maintainer feedback.

### Versions

- Browser/version: Firefox 137.0
- uBlock Origin version: latest

### Settings

- Default filter lists enabled