### PR TITLE
A: app.myexpattaxes.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2748,6 +2748,7 @@ trustnet.com##USER-TYPE-POPUP
 dollarshaveclub.com##[aria-describedby="banner-description"]
 lemonade.com##[aria-describedby="cookie-consent-description"]
 ticketmaster.com##[aria-describedby="mobileMobileTOUMessage"]
+app.myexpattaxes.com##[aria-label="Cookie Banner"]
 kstp.com,scribd.com##[aria-label="Cookie Consent Banner"]
 1password.com,shirtspace.com##[aria-label="Cookie Consent"]
 dictionary.cambridge.org##[aria-label="Cookie banner"]


### PR DESCRIPTION
Using a simple cosmetic filter to hide the cookie notice on app.myexpattaxes.com 

This is a user reported cookie notice on the Brave browser