### PR TITLE
A: `onlineconverter.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -3044,6 +3044,8 @@ publish0x.com##.d-md-none.text-center
 arbiscan.io##.d-none.text-center.pl-lg-4.pl-xll-5
 cutyt.com,onlineocr.net,publish0x.com##.d-xl-block
 techonthenet.com##.d0230ed3
+onlineconverter.com##.d5
+onlineconverter.com##.d7
 artsy.net##.dDusYa
 yourstory.com##.dJEWSq
 fxempire.com##.dKBfBG


### PR DESCRIPTION

Hides ad placeholders.
This pull request fixes https://github.com/easylist/easylist/issues/18446.