### PR TITLE
A: `pokevolver.com`

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -541,6 +541,7 @@
 ||plutotv.imgix.net/pauseads/$domain=pluto.tv
 ||pnn.ps/storage/images/partners/
 ||poedb.tw/image/torchlight/
+||pokevolver.com/pix/scholarships.plus.jpg
 ||pons.com/assets/javascripts/modules-min/ad-utilities_
 ||pons.com/assets/javascripts/modules-min/idm-ads_
 ||ports.co.za/banners/

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -435,6 +435,7 @@ investors.com###researchTools
 dailymaverick.co.za###ribbon-container
 fflogs.com,warcraftlogs.com###right-ad-box
 fflogs.com###right-vertical-banner
+pokevolver.com###sharedropdown
 childrenshealthdefense.org###sidebar-donate-section
 tunein.com###sidebarUpsell
 leawo.org###single_top


### PR DESCRIPTION

Blocks ad banner and hides self promotion.
This pull request fixes https://github.com/easylist/easylist/issues/18454.