### PR TITLE
A: `electroboom.com`

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -494,7 +494,7 @@ budgetbytes.com,ets2.lt,miloserdov.org###custom_html-2
 blissfuldomestication.com###custom_html-22
 sonyalpharumors.com###custom_html-25
 mostlyblogging.com,tvarticles.me###custom_html-3
-godisageek.com###custom_html-4
+electroboom.com,godisageek.com###custom_html-4
 mangaread.org###custom_html-48
 comicsheatingup.net###custom_html-5
 citymagazine.si,colombiareports.com,filmschoolrejects.com,hongkongfp.com,phoneia.com,weatherboy.com###custom_html-6


### PR DESCRIPTION

Hides ad banner.
This pull request fixes https://github.com/easylist/easylist/issues/18473.