### PR TITLE
A: `icao.int`

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -89,6 +89,7 @@
 ||guce.techcrunch.com/v1/consentRecord?
 ||harpercollins.co.uk/js/cookie.js
 ||hunstoncanoeclub.co.uk/media/system/js/modal.js
+||icao.int/libraries/klaro/dist/klaro-no-translations-no-css.js
 ||icgp.ie/ionic-consent/
 ||immoweb.be/250/js/thorConsent.js
 ||immozentral.com/js/stylecc


### PR DESCRIPTION

Blocks cookie popup.
Note that generic block is not possible due to https://github.com/easylist/easylist/commit/5bb9ed046ac9f1a5c4a50a081f04e9e34ad9d48a.