### PR TITLE
Removing "open in maps" popup on Google Maps on iOS

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -244,6 +244,7 @@ mrporter.com##.UserTargetedNotification2
 reddit.com##.XPromoBottomBar
 duolingo.com##._15MEM
 grammarly.com##._16m8p-button
+google.com##.ml-assistive-chips [data-value="open_in_app"]
 bigbasket.com##._1dBfC
 m.economictimes.com##._2YmFf
 m.economictimes.com##._2rMIm

--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -244,7 +244,6 @@ mrporter.com##.UserTargetedNotification2
 reddit.com##.XPromoBottomBar
 duolingo.com##._15MEM
 grammarly.com##._16m8p-button
-google.com##.ml-assistive-chips [data-value="open_in_app"]
 bigbasket.com##._1dBfC
 m.economictimes.com##._2YmFf
 m.economictimes.com##._2rMIm
@@ -442,6 +441,7 @@ merckmanuals.com,msdmanuals.com##.marketing-block-wrapper
 act.hoyolab.com##.mhy-hoyolab-app-header
 inoreader.com##.mid_hero
 pixai.art##.min-h-screen > section.box-content.bg-background.border-b[style="height: 50px;"]
+google.com##.ml-assistive-chips [data-value="open_in_app"]
 google.*##.ml-promotion-container
 uinterview.com,usbair.com##.mobile-app
 kariyer.net##.mobile-app-download


### PR DESCRIPTION
On Brave iOS, it has been reported that there is an "open in maps" popup that appears on Google Maps. This change will hide this button as part of the fanboy notifications specific filter list.