### PR TITLE
A: slashdot.org

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1341,6 +1341,7 @@ sammobile.com###venatus-hybrid-banner
 nutritioninsight.com###verticlblks
 mykhel.com,oneindia.com###verticleLinks
 ghgossip.com###vi-sticky-ad
+slashdot.org###vibe-code
 investing.com###video
 forums.tomsguide.com###video_ad
 gumtree.com.au###view-item-page__leaderboard-wrapper


### PR DESCRIPTION
Hiding ad banner on slashdot.org - seen on Android

This is a first party ad that actually has no image, it is just a div on the page with an icon, text and button.