### PR TITLE
A: vesselfinder.com ad leftover

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1818,6 +1818,7 @@ ntvstream.cx##.ad-popup-overlay
 fanfox.net##.ad-reader
 wapt.com##.ad-rectangle
 mydramalist.com##.ad-removal-info
+vesselfinder.com##.ad-right-m
 news.ssbcrack.com##.ad-script
 nationalreview.com##.ad-skeleton
 accesswdun.com##.ad-slider-block


### PR DESCRIPTION
Fixes #23817.

Adds a site-specific cosmetic filter for an ad leftover on vesselfinder.com.

Tested:
- ./fop-mac --no-commit --check-file=easylist/easylist_specific_hide.txt
- npm run aglint

The narrower .ad-right-m selector is used instead of a broader div[class^="ad-"] selector to avoid hiding unrelated page elements.