### PR TITLE
A: fix ad leftovers

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -853,3 +853,4 @@ testpages.eyeo.com*js/test-script-regex
 testpages.eyeo.com*js/test-script.js
 ! ABP for Safari on iOS
 ||ads.google.com^$xmlhttprequest,domain=ynet.co.il
+||resource.innovamarketinsights360.com/fif/banners/$domain=foodingredientsfirst.com

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -8332,11 +8332,13 @@ bing.com##div[class="ins_exp vsp"]
 ! bing.com##li.b_ans[data-partnertag][role="presentation"]
 bing.com##li[data-idx]:has(#mm-ebad)
 ! kayak
+foodingredientsfirst.com###midarticlebannerimage
 checkfelix.com,kayak.*,swoodoo.com###resultWrapper > div > div > [role="button"][tabindex="0"] > .yuAt-pres-rounded
 checkfelix.com,kayak.*,swoodoo.com##.Dp1L
 checkfelix.com,kayak.*,swoodoo.com##.EvBR
 checkfelix.com,kayak.*,swoodoo.com##.IZSg-mod-banner
 checkfelix.com,kayak.*,swoodoo.com##.J8jg:has(.J8jg-provider-ad-badge)
+foodingredientsfirst.com##.UpdateGaBanner
 checkfelix.com,kayak.*,swoodoo.com##.YnaR
 checkfelix.com,kayak.*,swoodoo.com##.ev1_-results-list > div > div > div > div.G-5c[role="tab"][tabindex="0"] > .yuAt-pres-rounded
 checkfelix.com,kayak.*,swoodoo.com##.ev1_-results-list > div > div > div > div[data-resultid$="-sponsored"]
@@ -8344,6 +8346,8 @@ checkfelix.com,kayak.*,swoodoo.com##.nqHv-pres-three:has(div.nqHv-logo-ad-wrappe
 checkfelix.com,kayak.*,swoodoo.com##.resultsList > div > div > div > div.G-5c[role="tab"][tabindex="0"] > .yuAt-pres-rounded
 checkfelix.com,kayak.*,swoodoo.com##.resultsList > div > div > div > div[data-resultid$="-sponsored"]
 checkfelix.com,kayak.*,swoodoo.com##.zZcm-pres-three
+nytimes.com##[id*="story-ad-"]
+foodingredientsfirst.com##[src^="https://resource.innovamarketinsights360.com/fif/banners/"]
 checkfelix.com,kayak.*,swoodoo.com##div.PzK0-pres-default
 checkfelix.com,kayak.*,swoodoo.com##div.YTRJ[role="button"][tabindex="0"] > .yuAt-pres-rounded
 checkfelix.com,kayak.*,swoodoo.com##div[class$="-adWrapper"]
@@ -8351,3 +8355,5 @@ checkfelix.com,kayak.*,swoodoo.com##div[class*="-ad-card"]
 checkfelix.com,kayak.*,swoodoo.com##div[class*="-adInner"]
 checkfelix.com,kayak.*,swoodoo.com##div[data-resultid]:has(a.IZSg-adlink)
 checkfelix.com,kayak.*,swoodoo.com##div[id^="inline-"]
+pockettactics.com##iframe[title*="affiliate"]
+pockettactics.com##nav a[rel*="sponsored"]


### PR DESCRIPTION
Fixes #23821.
Fixes #22516.
Fixes #19075.

Adds site-specific filters for reported ad leftovers and affiliate/sponsored placements:

- pockettactics.com: sponsored nav link and affiliate iframe
- nytimes.com: story ad placeholders
- foodingredientsfirst.com: banner image placements and scoped banner request blocking

Tested:
- ./fop-mac --no-commit --check-file=easylist/easylist_specific_hide.txt
- ./fop-mac --no-commit --check-file=easylist/easylist_specific_block.txt
- npm run aglint