### PR TITLE
A: block Veedmo video ads

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -117,6 +117,7 @@
 ||banners.livepartners.com^
 ||bc.coupons.com^
 ||bc.vc/js/link-converter.js
+||bc.veedmo.com^$third-party
 ||bctt.igaming-service.io^
 ||beauties-of-ukraine.com/export.js
 ||beehiiv.com^*/ad_network/
@@ -171,6 +172,7 @@
 ||cdn.statically.io/gh/ad-shield/
 ||cdn.thrad.ai^
 ||cdn.vaughnsoft.net/abvs/
+||cdn.veedmo-static.com^$third-party
 ||cdn.viously.com/js/sdk/boot.js
 ||cdn.yeahwebimobi.fun/r6.png
 ||cdn22904910.ahacdn.me^


### PR DESCRIPTION
Fixes #23883.

Blocks Veedmo third-party video ad resources reported on rynek-kolejowy.pl:

- bc.veedmo.com
- cdn.veedmo-static.com

Tested:
- ./fop-mac --no-commit --check-file=easylist/easylist_thirdparty.txt
- npm run aglint