### PR TITLE
A: add tracking endpoint filters

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -922,6 +922,7 @@
 ||intent.pcworld.idg.com.au^
 ||intent.techadvisor.com^
 ||internal-analytics.odoo.com^
+||internal-api.prolific.com/api/v1/statistics/
 ||internetslang.com/jass/
 ||intg.snapchat.com^
 ||intuit.com/static/scripts/cookie-sync/cookiesync-pixel.js
@@ -1078,6 +1079,8 @@
 ||mcc-tags.cisco.com^
 ||mcdonalds.com/tags/js/*/mparticle.js
 ||mcdonalds.com/webevents/
+||mcl.io^
+||mcl.spur.us^
 ||mcs-ie.tiktokw.eu^
 ||mcs-va-useast2a.tiktokv.com^
 ||mcs-va.tiktokv.com^
@@ -1936,6 +1939,8 @@
 ||twitter.com/1.1/attribution
 ||twitter.com/1.1/jot
 ||twitter.com/9/measurement/
+||twitter.com/i/api/1.1/graphql/error_log.json
+||twitter.com/i/api/1.1/graphql/user_flow.json
 ||twitter.com/i/api/1.1/jot
 ||twitter.com/i/csp_report?
 ||twitter.com/i/jot
@@ -2089,6 +2094,8 @@
 ||x.com/1.1/attribution
 ||x.com/1.1/jot
 ||x.com/9/measurement/
+||x.com/i/api/1.1/graphql/error_log.json
+||x.com/i/api/1.1/graphql/user_flow.json
 ||x.com/i/api/1.1/jot
 ||x.com/i/csp_report
 ||x.com/i/jot


### PR DESCRIPTION
Fixes #23842.
Fixes #23521.
Fixes #21077.

Adds EasyPrivacy filters for reported telemetry and fingerprinting endpoints:

- Spur/mcl telemetry domains
- X/Twitter renamed user_flow and error_log analytics endpoints
- Prolific fingerprinting statistics endpoint

Tested:
- ./fop-mac --no-commit --check-file=easyprivacy/easyprivacy_specific.txt
- npm run aglint