### PR TITLE
M: narrow getterms cookie filter

### DIFF
--- a/easylist_cookie/easylist_cookie_thirdparty.txt
+++ b/easylist_cookie/easylist_cookie_thirdparty.txt
@@ -142,7 +142,8 @@
 ||geolocation.onetrust.com^$third-party
 ||getcomplied.com^$third-party
 ||getsitecontrol.com^$third-party
-||getterms.io^$third-party
+||getterms.io/cookie-consent/embed/^$third-party
+||gettermscmp.com/cookie-consent/embed/^$third-party
 ||goadopt.io^$third-party
 ||grvmedia.com^$third-party
 ||hs-banner.com^$third-party


### PR DESCRIPTION
Fixes #23531.

Narrows the existing third-party getterms.io cookie filter to the cookie consent embed path and adds the newer gettermscmp.com embed host.

This keeps the cookie banner blocking behavior targeted while avoiding a domain-wide third-party block for unrelated getterms.io embeds.

Tested:
- ./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_thirdparty.txt
- npm run aglint