### PR TITLE
A: pwc.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -574,6 +574,7 @@ novaramedia.com###obligation-bar
 swappa.com###offcanvasCookiesConsent
 postgraduatesearch.com###ol
 estrid.com###onetrust-banner
+www.pwc.com###onetrust-consent-sdk
 openu.ac.il###openu_privacy_protection_policy_alert
 pollylingu.al###opt-form
 atlantic.money###opt-in


### PR DESCRIPTION
## Site

https://www.pwc.com/

## Issue

The OneTrust cookie consent banner remains visible and is not properly hidden by existing filter rules.

## Analysis

The banner is rendered inside the `#onetrust-consent-sdk` container, which is not currently covered by existing EasyList Cookie rules for this domain.

## Fix

Added a domain-specific cosmetic filter targeting the OneTrust consent container:
`www.pwc.com###onetrust-consent-sdk`

This approach avoids overly broad selectors and ensures that only the intended cookie banner element is affected.

## Testing

* Applied the rule via uBlock Origin "My filters" and verified its effect
* Checked multiple pages (homepage and internal pages)
* Performed A/B testing by toggling the filter on/off to confirm the rule’s impact
* Verified behavior in both normal and private browsing modes
* Confirmed consistent behavior in another browser

No site breakage observed.

## Suggestion

If similar patterns are observed across other PwC regional domains, this rule could potentially be extended or generalized to improve coverage.


## Before
<img width="1147" height="742" alt="스크린샷 2026-04-21 오후 3 53 56" src="https://github.com/user-attachments/assets/0f2a7d78-ef02-4fa2-921a-bf4a83590c19" />

## After
<img width="1149" height="742" alt="스크린샷 2026-04-21 오후 3 57 28" src="https://github.com/user-attachments/assets/8663327b-13cc-404f-8da5-d824d7485f4e" />

