### PR TITLE
A: primagames.com, destructoid.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -795,6 +795,7 @@
 ||cdn.thejournal.ie/media/hpto/$image
 ||connatix.com^$third-party,domain=~accuweather.com|~businessinsider.de|~bz-berlin.de|~cheddar.tv|~deadline.com|~elnuevoherald.com|~finanzen.net|~fitbook.de|~heraldsun.com|~hollywoodreporter.com|~huffpost.com|~lmaoden.tv|~loot.tv|~miamiherald.com|~myhomebook.de|~olhardigital.com.br|~petbook.de|~sacbee.com|~stylebook.de|~techbook.de|~travelbook.de|~welt.de
 ||delivery.vidible.tv/jsonp/
+||destructoid.com/wp-json/navy$domain=destructoid.com
 ||dywolfer.de^
 ||embed.ex.co^$third-party
 ||embed.sendtonews.com^$third-party,domain=~shmoop.com

--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -554,6 +554,7 @@
 ||presearch.com/tiles^
 ||pressablecdn.com/wp-content/uploads/Site-Skin_update.gif$domain=bikebiz.com
 ||prewarcar.com/*-banners/
+||primagames.com/wp-json/navy$domain=primagames.com
 ||prod-sponsoredads.mkt.zappos.com^
 ||product.rightmove.co.uk/featured-customer-v2.html
 ||products.gobankingrates.com^


### PR DESCRIPTION
Hiding anti-adblock on primagames.com

Admiral is using a script on primagames.com "wp-json/navy" that detects adblockers and displays an iframe on the page

These fixes work for the given pages, however, they do not follow an existing pattern. If there is a more appropriate fix, please let me know.

Another point of context: this adblocker popup was found on Brave, but when uBO lite extension was active, the popup no longer appeared.