### PR TITLE
A: nyctourism.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -861,6 +861,7 @@ push.org##.CookieComponent__CookieContainer-sc-thf5lr-0
 bstage.in##.CookieConfirm_container__7A6dW
 tsi.com##.CookieConsent > .o-container
 tunemymusic.com##.CookieConsent-module-scss-module__piaogq__CookieAlert
+nyctourism.com##.CookieConsentBanner_cookieContent__ueLwu
 rebrandly.com##.CookieConsent__container
 elitesingles.com##.CookieConsent_cookie-consent__nuLuI
 russellandbromley.co.uk##.CookieControl


### PR DESCRIPTION
Using a simple cosmetic filter to hide the cookie notice on nyctourism.com