### PR TITLE
A: cashyo.co.il

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1611,6 +1611,7 @@ jetcamp.com##.news-letter-block
 flysfo.com##.news-letter-footer
 healthing.ca##.news-letter-form
 presstv.ir##.news-signup-container
+cashyo.co.il##.newsLetterPopup
 the-line-up.com##.newsLettetPb
 ksl.com##.newsSignup
 touristengland.com##.news_letter_box


### PR DESCRIPTION
1. Resolved Issue (#23927)

Problem: Users reported a "blank page" breakage on cashyo.co.il. The root cause was a full-screen overlay (account wall/newsletter popup) blocking the main content.

Solution: I resolved this breakage by writing a precise cosmetic filter to hide the exact popup container, restoring the normal site layout without causing false positives.

2. Technical Details of the Filter

Filter Rule: cashyo.co.il###notifications

Technical Explanation:

Domain Specificity (cashyo.co.il): Prevents the rule from breaking layouts on other websites.

Cosmetic Targeting (###notifications): Uses the standard adblock syntax (##) to target the exact ID of the overlay container found via Developer Tools.

Compliance: Ran the fop sorting script before committing to ensure correct alphabetical order, strictly following EasyList guidelines.