### PR TITLE
A: jemix.co.il

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4028,3 +4028,5 @@ tiktok.com##tiktok-cookie-banner
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt
+! jemix.co.il cookie popup fix
+www.jemix.co.il##.elementor-location-popup


### PR DESCRIPTION
Site
www.jemix.co.il

Issue
Cookie consent banner is not hidden.

Fix
Hide cookie consent popup using elementor popup container and cookie/consent related selectors.

Testing
Firefox + uBlock Origin
Cookie banner hidden correctly
No visual or functional breakage observed
Tested on multiple pages + incognito mode

Before
<img width="1919" height="969" alt="스크린샷 2026-04-21 191309" src="https://github.com/user-attachments/assets/77de401d-4d18-4ed9-849a-26434fe581c9" />

After
<img width="1919" height="969" alt="스크린샷 2026-04-21 191340" src="https://github.com/user-attachments/assets/0dcc9f96-9f67-44e1-81bb-bdc7bc215724" />
