### PR TITLE
P: fix cookie notice breakages

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_block.txt
+++ b/easylist_cookie/easylist_cookie_specific_block.txt
@@ -187,4 +187,6 @@
 ! cookiepro.com specifics
 ||cookiepro.com^$domain=urbandictionary.com
 ! fundingchoicesmessages (consents)
+/terms-cookies-content$domain=antallaktikaexartimata.gr|autoalkatreszek24.hu|autoczescionline24.pl|autodeleshop.dk|autodielyonline24.sk|autoonderdelen24.be|autoteiledirekt.de|autovaruosadonline.ee|besteonderdelen.nl|onlinecarparts.co.uk|pecasauto24.pt|piecesauto.fr|piecesauto24.lu|recambioscoche.es|reservdelar24.se|reservedeler24.co.no|rezervesdalas24.lv|teile-direkt.at|topautoosat.fi|tuttoautoricambi.it
 ||fundingchoicesmessages.google.com^
+||grecco.com^*/jquery.cookie.js

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4025,6 +4025,8 @@ pagesix.com##.zephr-component
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
 ! Multi-national sites
+maxgaming.*###cookie_consent_dimmer
+ashild.no##.cookie-shadow
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt


### PR DESCRIPTION
Fixes #21329.
Fixes #19189.
Fixes #22122.
Fixes #20705.

Adds targeted EasyList Cookie fixes for reported breakages:

- grecco.com: block the cookie script that leaves the privacy overlay
- maxgaming.*: hide the cookie consent dimmer left behind by the blocked dialog
- ashild.no: hide the leftover cookie shadow overlay
- Wemax group sites: block the terms/cookies content request that causes frozen overlays

Tested:
- ./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_specific_block.txt
- ./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_specific_hide.txt
- npm run aglint