### PR TITLE
A: block chat and RUM endpoints

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -487,6 +487,7 @@
 ||data.ublock-browser.com^
 ||data.vevor.com^
 ||data.younow.com^
+||datadoghq.com/api/v2/rum
 ||datadoghq.com/assets/dd-browser-logs-rum.js
 ||datadome.maisonsdumonde.com^
 ||datafa.st/js/script.js

--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -99,6 +99,7 @@ m1.com.sg##div:has(> [class^="ChatWindow"])
 ||chatbot.com^$third-party
 ||chatbot.pef.czu.cz^
 ||chatbotize.com^$third-party
+||chatbox.copilot.livex.ai^$third-party
 ||chatbro.com^$third-party
 ||chatdealer.jp^$third-party
 ||chatway.app^$third-party


### PR DESCRIPTION
Fixes #22844.
Fixes #20199.

Adds targeted filters for reported third-party endpoints:

- chatbox.copilot.livex.ai chat widget used on pictory.ai
- datadoghq.com/api/v2/rum Datadog RUM endpoint reported on vector.dev

Tested:
- ./fop-mac --no-commit --check-file=fanboy-addon/fanboy_chatapps_third-party.txt
- ./fop-mac --no-commit --check-file=easyprivacy/easyprivacy_specific.txt
- npm run aglint