### PR TITLE
P: fix abcya cookie notice space

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -36,6 +36,7 @@ funnelcockpit.com,graziellawicki.com##+js(rc, gdpr-cookie-notice-center-loaded, 
 rassenlijst.info,werkenbijiciparisxl.nl,werkenbijkruidvat.be,werkenbijtrekpleister.nl##+js(rc, is-active-cookiebar, , stay)
 5asec.pt,tui.dk,tui.fi,tui.no,tui.se##+js(rc, no-scroll, body, stay)
 agvillagecamarguais.com,allokebab-pau.fr,artech-sellerie.com,az-renovation.fr,biomeo-environnement.com,cambridge-centre.fr,campingdusoleil.com,cotedecor.com,croco-kid.com,cuisin-studio.com,desrayaud-paysagistes.com,dj4events.fr,equisud.com,esthetique-meyerbeer.com,etre-visible.local.fr,gabriel-godard.com,helenevue.com,hotel-aigoual.com,hotel-la-chaumiere.com,hotel-restaurant-pau.com,institut-bio-naturel-nice.fr,joyella.com,kinechartreuse.com,ledauphinhotel.com,leman-instruments.com,les-anges-gardiens.fr,lesjardinsinterieurs.com,motoclubernee.com,nature-et-bois.fr,restaurant-la-badiane.fr,saintjoursexpertmaritime.com,saubusse-thermes.com,systelia.fr##+js(rc, unreadable-display, , stay)
+abcya.com##.root.fixed-padding.cookie:remove-class(cookie)
 juken-mikata.net##body:remove-class(has-cookie-consent)
 ! set-cookie
 foodker.hu,laptophardware.hu,milestone66.hu,paplanvilag.hu,reformsziget.hu##+js(set, cookie_alert_overlay, noopFunc)


### PR DESCRIPTION
Fixes #23899

Changes:
- Removes the `cookie` class from the fixed root container on `abcya.com` after the cookie banner is handled, clearing the leftover blank header space.

Tested:
- `./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_specific_uBO.txt`
- `npm run aglint`