### PR TITLE
P: hide amazon follow button leftover

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -642,6 +642,7 @@ vt.edu##.follow-virginia-tech-icons
 americansongwriter.com##.follow-widget
 srnnews.com##.followBox
 news9live.com##.followBtn
+amazon.com##.followButtonColumn
 news9live.com##.followUs_Links
 trutravels.com##.follow_us_icons
 kentonline.co.uk##.followbox


### PR DESCRIPTION
Fixes #19198

Changes:
- Hides the empty Amazon author follow button column left by Social Widgets filtering.

Tested:
- `./fop-mac --no-commit --check-file=fanboy-addon/fanboy_social_specific_hide.txt`
- `npm run aglint`