### PR TITLE
P: remove userway from chat widgets

### DIFF
--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -241,7 +241,6 @@ m1.com.sg##div:has(> [class^="ChatWindow"])
 ||userback.io/widget/
 ||userbot.ai^$third-party
 ||userlike-cdn-widgets.*.amazonaws.com^
-||userway.org^$third-party
 ||vergic.com^$third-party
 ||verint-cdn.com^$third-party
 ||visitor.chat^$third-party


### PR DESCRIPTION
Fixes #23294

Changes:
- Removes the broad `userway.org` third-party block from Chat Widgets; the reported service is an accessibility widget rather than a chat widget.
- Existing EasyPrivacy endpoint-specific `userway.org` event/stat filters are left untouched.

Tested:
- `./fop-mac --no-commit --check-file=fanboy-addon/fanboy_chatapps_third-party.txt`
- `npm run aglint`