### PR TITLE
A: hide sammobile snack ad spaces

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1139,6 +1139,11 @@ orteil.dashnet.org###smallSupport
 point2homes.com###smartAsset
 apkmoddone.com###sn-Notif
 sammobile.com###snack-ad-cont
+sammobile.com###snack-incontent-1
+sammobile.com###snack-incontent-2
+sammobile.com###snack-incontent-3
+sammobile.com###snack-incontent-repeater
+sammobile.com###snack-top
 sammobile.com###snack-vod
 forums.bluemoon-mcfc.co.uk###snack_dmpu
 forums.bluemoon-mcfc.co.uk,gpfans.com###snack_ldb


### PR DESCRIPTION
Fixes #22496

Changes:
- Hides the remaining Snack top and in-content ad containers on `sammobile.com` that keep reserved blank space after ads are blocked.

Tested:
- `./fop-mac --no-commit --check-file=easylist/easylist_specific_hide.txt`
- `npm run aglint`