### PR TITLE
P: allow cashyo cookie script

### DIFF
--- a/easylist_cookie/easylist_cookie_allowlist.txt
+++ b/easylist_cookie/easylist_cookie_allowlist.txt
@@ -334,6 +334,7 @@
 @@||bstatic.com/libs/privacy-consent/*/cookie-banner.min.js$script,domain=booking.com
 @@||caib.es/webgoib/o/goib-theme/js/klaro-config.js$~third-party
 @@||candidat.pole-emploi.fr^*/modules/jquery-eu-cookie-law-popup.js$script
+@@||cashyo.co.il/js/CookieJar.js$script,~third-party
 @@||cdn.orangeclickmedia.com/tech/$script,domain=flash.gr
 @@||cdn.rp.pl/cmp/cmp.min.js
 @@||cdn.transcend.io/cm/$script,domain=outlier.org|pluralsight.com|visible.com


### PR DESCRIPTION
Fixes #23927

Changes:
- Adds a first-party allowlist for `cashyo.co.il/js/CookieJar.js` to prevent the EasyList Cookie `/cookiejar.js` rule from blanking the page.

Tested:
- `./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_allowlist.txt`
- `npm run aglint`