### PR TITLE
P: add more cookie notice filters

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3982,8 +3982,11 @@ guicheweb.com.br,mercadolibre.com###alert_cookie
 thefreedictionary.com###cmpBanner
 support.github.com###consent-banner
 www.google.*###consent-bump
+foodappeal-online.com,universe.co.il###cookie-consent-popup
 netflix.com###cookie-disclosure
 whatsapp.com###cookie-policy-banner
+kamada.com###cookieAlert
+mailwave.dev###cookieConsent
 flightaware.com###cookieDisclaimerContainer
 duplichecker.com###cookie_directive_container
 depositfiles.com,dfiles.ru###cookie_popup
@@ -3995,6 +3998,9 @@ next-episode.net###eu_cookies_disclaimer
 up-load.io###gdpr-cookie-notice
 support.arcgames.com###gdpr-wall
 hindustantimes.com###gdprpopup
+invoice4u.co.il###privacy_policy_popup
+matrefa.com###sb_privacy_policy_notice
+willi-food.co.il###scm-custom
 galerieslafayette.com,group.vig,sparkasse.at###tc-privacy-wrapper
 gryphline.com##.PolicyPrompt_policyPrompt__0Fu5L
 bild.de,welt.de##.as-oil
@@ -4004,6 +4010,7 @@ icq.com##.ca_wrap
 thebarchive.com##.cc_banner
 indiatimes.com##.consent-popup
 cross.bet##.consentModal
+yeshinvoice.co.il##.cookie
 basemark.com,sporttv.pt##.cookie-law
 enfsolar.com##.cookie-policy-banner
 allmusic.com##.cookie-policy-box
@@ -4020,8 +4027,10 @@ symbolab.com##.nl-cookiepolicy
 warn.com##.page-loader
 rp-online.de##.park-snackbar-cookies
 alabama.travel##.privacy-wrapper
+willi-food.co.il##.scm-banner
 x.com##.u12-data-protection-notice
 pagesix.com##.zephr-component
+shop.hazi-hinam.co.il##app-cookie-consent
 tumblr.com##div#cmp-app-container
 tiktok.com##tiktok-cookie-banner
 ! Multi-national sites


### PR DESCRIPTION
Fixes #23915
Fixes #23885
Fixes #23763
Fixes #23562
Fixes #23561
Fixes #23560
Fixes #23460
Fixes #23925
Fixes #23919

Changes:
- Adds domain-specific cookie notice filters for the reported sites.
- Keeps selectors scoped to the exact reported domains.

Tested:
- `./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_specific_hide.txt`
- `npm run aglint`