### PR TITLE
P: fix fresha cookie breakage

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2946,7 +2946,6 @@ angular.dev##docs-cookie-popup
 fedex.com##fedex-gdpr
 fi.google.com##fi-cookie-consent
 welcome.sparxmaths.uk##footer
-fresha.com#?#body > div:has-text(cookies)
 getgreatcareers.com##gc-accept-cookie
 globalsolaratlas.info##gsa-cookie-banner
 hathitrust.org##hathi-cookie-consent-banner


### PR DESCRIPTION
Fixes #23953

Changes:
- Removes the broad `fresha.com#?#body > div:has-text(cookies)` filter that hides the app root and causes a blank page.
- Leaves the existing Fresha-specific banner filter in place.

Tested:
- `./fop-mac --no-commit --check-file=easylist_cookie/easylist_cookie_specific_hide.txt`
- `npm run aglint`