### PR TITLE
P: narrow getdrip tracking rules

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -900,7 +900,6 @@
 ||getblueshift.com^$third-party
 ||getclicky.com^$third-party
 ||getconversion.net^$third-party
-||getdrip.com^$third-party
 ||getfreebl.com^$third-party
 ||getinsights.io^$third-party
 ||getlasso.co^$third-party
@@ -2136,6 +2135,7 @@
 ||sysomos.com^$third-party
 ||t-analytics.com^$third-party
 ||tadpull.com^$third-party
+||tag.getdrip.com^$third-party
 ||tag4arm.com^$third-party
 ||tagcommander.com^$third-party
 ||tagdatax.com^$third-party

--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -102,7 +102,6 @@
 ||gatherup.com^$third-party
 ||georiot.com^$third-party
 ||getbeamer.com^$third-party
-||getdrip.com^$third-party
 ||getfivestars.com^$third-party
 ||getglue.com^$third-party
 ||getkudos.me^$third-party
@@ -298,6 +297,7 @@
 ||swiftypecdn.com^$third-party,domain=~swiftype.com
 ||synapsys.us^$third-party
 ||systeme.io^$third-party
+||tag.getdrip.com^$third-party
 ||tapcdn.com/mosaic/tap_button.js
 ||teamautofollow.com/modules/mod_jtwitter/
 ||techbeat.com/wp-content/custom-php/$third-party


### PR DESCRIPTION
Fixes #22102

Changes:
- Narrows broad `getdrip.com` third-party rules to `tag.getdrip.com`, keeping the tracking subdomain blocked while avoiding the application domain false positive.

Tested:
- `./fop-mac --no-commit --check-file=fanboy-addon/fanboy_annoyance_thirdparty.txt`
- `./fop-mac --no-commit --check-file=easyprivacy/easyprivacy_trackingservers_thirdparty.txt`
- `npm run aglint`