### PR TITLE
A: zara.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4022,3 +4022,5 @@ tiktok.com##tiktok-cookie-banner
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt
+www.zara.com##.ot-fade-in.onetrust-pc-dark-filter
+www.zara.com##.ot-sdk-container


### PR DESCRIPTION
## Site
https://www.zara.com

## Issue
The cookie consent banner appears on page load and covers the bottom of the screen.

## Analysis
The banner is rendered using OneTrust's consent components, which are not currently covered by existing EasyList Cookie rules for this domain. Specifically, the banner container and its overlay element remain visible.

## Fix
Added domain-specific cosmetic filters to target the OneTrust container and the background overlay:
```text[www.zara.com](https://www.zara.com)##.ot-sdk-container```
```text[www.zara.com](https://www.zara.com)##.ot-fade-in.onetrust-pc-dark-filter```


This ensures the cookie banner is hidden without interacting with the site's functionality.

## Testing
- Verified on Firefox and Chrome with uBlock Origin.
- Confirmed the banner is hidden on page load.
- Checked multiple pages (homepage and product pages) to ensure no site breakage.
- Verified in both normal and private browsing modes.

## Screenshot
**Before:**
<img width="2559" height="1399" alt="image" src="https://github.com/user-attachments/assets/f98d4fc0-2888-4a0c-83c0-4e699b7ff903" />

**After:**
<img width="2559" height="1397" alt="image" src="https://github.com/user-attachments/assets/157ee222-9e4a-464b-b989-b80ecca4c1c3" />