### PR TITLE
A: kamada.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -63,6 +63,7 @@ global.toptoon.com###acceptCookieCon
 readawrite.com###accept_cookie_banner
 dallasinnovates.com,hawke.ai###acceptance
 hoverwatch.com###acceptbar
+kamada.com#cookieAlert
 manorbythelake.co.uk###acf-cookie-notice
 mega-asia.com###ad-preference-banner
 jobisjob.co.uk###adevinta_consents_cookies_universal_widget


### PR DESCRIPTION
### Site
https://www.kamada.com/

### Issue
Problems with Cookie Banner at the bottom of site access

### A technical explanation
A filter was added to selectively hide only the cookie banner on specific domains. Since it uses a domain-restricted approach, it does not affect other sites and removes only the cookie banner. 