### PR TITLE
A: mailwave.dev

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -266,6 +266,7 @@ letsdothis.com###cookieAcceptanceModal
 511mt.net###cookieBannerHolder
 rsvp.withgoogle.com###cookieBarWrapper
 egamersworld.com###cookieBot
+mailwave.dev###cookieConsent
 investtech.com###cookieConsentDialogue
 khronos.org###cookieConsentForm
 gear4music.com###cookieConsentWidgetDiv

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -63,7 +63,6 @@ global.toptoon.com###acceptCookieCon
 readawrite.com###accept_cookie_banner
 dallasinnovates.com,hawke.ai###acceptance
 hoverwatch.com###acceptbar
-kamada.com#cookieAlert
 manorbythelake.co.uk###acf-cookie-notice
 mega-asia.com###ad-preference-banner
 jobisjob.co.uk###adevinta_consents_cookies_universal_widget
@@ -237,6 +236,7 @@ team.repair###cookie-banner-ID
 velosure.co.uk###cookie-bar-template
 dnschecker.org,iplocation.io,ruedasgordas.es,sixthleafclover.com###cookie-box
 loversstores.com###cookie-check
+www.123fresh.co.il###cookie-consent
 yousign.com###cookie-consent-app
 store.azeron.eu###cookie-consent-background
 ames-surgery.com,baxtercycle.com,centralstate.bank,cumedicine.us,cyprus-childrensfund.org,dickinsonbradshaw.com,finleylaw.com,gabrielsonclinic4women.com,globalreach.com,gocivilairpatrol.com,halloumicheese.eu,hermesairports.com,heylroyster.com,iowaspecialtyhospital.com,mavroudis.com.cy,mcfarlandclinic.com,ombudsman.iowa.gov,pcbaonline.org,slots-cyprus.eu,smaluminium.com.cy,stephanis.com.cy,stredoceskykraj.cz,thewayhomedc.org,toumbas.com,welcomemagazinecy.com###cookie-consent-container
@@ -2952,6 +2952,7 @@ getgreatcareers.com##gc-accept-cookie
 globalsolaratlas.info##gsa-cookie-banner
 hathitrust.org##hathi-cookie-consent-banner
 ingwb.com##ingwb-cookiebar
+kamada.com#cookieAlert
 international.pagseguro.com##le-cookies-consent
 mythos.foundation##mf-cookies-consent
 material.io##mio-cookie-notice

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -63,6 +63,7 @@ global.toptoon.com###acceptCookieCon
 readawrite.com###accept_cookie_banner
 dallasinnovates.com,hawke.ai###acceptance
 hoverwatch.com###acceptbar
+kamada.com#cookieAlert
 manorbythelake.co.uk###acf-cookie-notice
 mega-asia.com###ad-preference-banner
 jobisjob.co.uk###adevinta_consents_cookies_universal_widget


### PR DESCRIPTION
Site
https://mailwave.dev/

Issue
Problems with Cookie Banner at the bottom of site access

A technical explanation
A domain-specific rule was implemented to hide the cookie consent banner.
By restricting the rule to a single domain, it prevents any impact on unrelated sites.