### PR TITLE
A: https://2digit.io

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2341,6 +2341,7 @@ maisonstandards.com##.popin_consent
 aboardtheworld.com##.popmake
 egglifefoods.com,goodtimesoakland.com,organicawines.co.uk##.popup--cookies
 thelocalchoice.co.za##.popup-access
+2digit.io##.popup-container
 dadavidson.com##.popup-container-bottom
 musee-mccord-stewart.ca##.popup-container-confidentiality
 czc.cz##.popup-content


### PR DESCRIPTION
## Site

https://2digit.io/

## Issue

Promotional modal popups are displayed on the page and obstruct the main content.

## Fix

Added a domain-specific cosmetic filter:
`2digit.io##.popup-container`

## Testing

* Verified on homepage
* Confirmed via A/B testing (on/off)
* Tested in normal and private browsing modes
* Confirmed that all popups are removed
* No page breakage observed

## Before applying the filter
<img width="1143" height="743" alt="스크린샷 2026-04-21 오후 3 50 04" src="https://github.com/user-attachments/assets/669d297f-0227-4a6c-b278-7351297f8d67" />

## After applying the filter
<img width="1149" height="744" alt="스크린샷 2026-04-21 오후 3 50 24" src="https://github.com/user-attachments/assets/a0163ee6-4a3b-4086-958d-8e96cf168e70" />
