### PR TITLE
A: https://www.profdelo.com cookie notice

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4027,3 +4027,4 @@ tiktok.com##tiktok-cookie-banner
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt
+###cookie_3335d9b332c5d5d32068cfd2e33f8579


### PR DESCRIPTION
Fixes #22537

## Site
https://www.profdelo.com

## Issue
Cookie consent banner not hidden.

## Filter Added
###cookie_3335d9b332c5d5d32068cfd2e33f8579

## Testing
Tested on Firefox with uBlock Origin.
Banner hidden successfully. Site works normally on multiple pages tested.
Also tested in incognito mode - banner does not appear.