### PR TITLE
A: euronews.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -351,6 +351,7 @@ discoveryeducation.com,readingplus.com###de-consent-banner
 universitysupplystore.com###demo-overlay
 filmon.com###design-switcher
 alliancefrancaise.ca###dialogbox_cookiepolicy
+euronews.com###didomi-host
 innovaphone.com###disableBackground
 claridges.com###disc-bg
 one-line.com###disclaimer-bar


### PR DESCRIPTION
## Site
https://www.euronews.com/

## Issue
Didomi cookie consent popup is not hidden on the site.

## Root cause
The cookie consent is implemented using Didomi and injected as a site-specific container (`#didomi-host`) that is not covered by existing EasyList rules.

## Fix
Added a domain-specific cosmetic filter:
`euronews.com###didomi-host`

## Technical notes
Used a site-specific cosmetic filter to precisely target the Didomi container.
A generic rule was avoided to reduce the risk of false positives on other sites.

## Testing
- Verified on homepage and multiple pages
- Confirmed via A/B testing (on/off)
- Tested in normal and private browsing modes
- Checked in another browser
- No breakage observed

## Notes
This fix is intentionally scoped to euronews.com to avoid unintended side effects on other Didomi implementations.

## Before
<img width="1146" height="739" alt="스크린샷 2026-04-21 오후 3 58 08" src="https://github.com/user-attachments/assets/ac0ce412-4bc8-4700-9877-b52b2d917456" />

## After
<img width="1146" height="738" alt="스크린샷 2026-04-21 오후 3 58 57" src="https://github.com/user-attachments/assets/93ae684b-0d9a-41bd-ab22-42e9d02412eb" />
