### PR TITLE
A: https://terminaltrove.com 

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -2326,3 +2326,4 @@ $csp=child-src 'none'; frame-src 'self' *; worker-src 'none',domain=fileone.tv|t
 $csp=child-src 'none'; frame-src *; worker-src 'none',domain=thepiratebay.org|vidoza.net
 ! Other resource abuse
 ||gyrovague.com^$domain=archive.fo|archive.is|archive.li|archive.md|archive.ph|archive.today|archive.vn|btdig.com
+||terminaltrove.com/_t/


### PR DESCRIPTION
Fixes #23951

## Site
https://terminaltrove.com

## Issue
Plausible analytics script sends tracking requests via terminaltrove.com/_t/

## Filter Added
||terminaltrove.com/_t/

## Testing
Tested on Firefox with uBlock Origin.
Request to terminaltrove.com/_t/ confirmed blocked in uBlock logger.
Site works normally after filter applied.
Also tested in incognito mode.