### PR TITLE
A: caetanobus.pt

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4027,3 +4027,4 @@ tiktok.com##tiktok-cookie-banner
 globalblue.com##.gbnew-cookie-bar
 ! Include ubO specific
 !#include easylist_cookie_specific_uBO.txt
+caetanobus.pt##.is-open.rgc-bottom-sheet


### PR DESCRIPTION
### Site
https://caetanobus.pt/en/toyota/

### Description
The cookie consent banner on the homepage is persistent and obstructs site navigation. This change hides the banner to improve the user experience.

### Technical Details
- Filter: `caetanobus.pt##.is-open.rgc-bottom-sheet`
- Method: Used uBlock Origin's element picker to identify the banner class.

### Testing
- Checked via "My filters" to confirm the banner is successfully hidden.
- Verified in Incognito mode and standard Chrome browser that site scrolling and navigation remain fully functional.
- Confirmed no layout breakage or unintended side effects on the homepage.