### PR TITLE
A: https://glassdoor.com/

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -153,6 +153,7 @@ studio.youtube.com##div.screen-banners-container.yta-screen:has(button[aria-labe
 studio.youtube.com##div.suggestion-chips-container:has(> ytcp-creator-chat-entrypoint-chips)
 bloomberg.com##div[class^="SummaryOnlyTakeaways_takeaways__"]
 google.com##div[data-rp-placement-id="gemkick-pep-icon-callout-id"]
+glassdoor.com##div[data-test=copilot-search-input]
 docs.github.com#?#.prc-ActionList-GroupHeadingWrap-pfbd9:has-text(Ask Copilot)
 docs.posit.co#?#.nav-item:has-text(Ask AI)
 duckduckgo.com#?#.chip-select_isSelected__RpaRr:has-text(Duck.ai)


### PR DESCRIPTION
Hide AI-powered search tool in header and nothing else.

<img width="851" height="236" alt="image" src="https://github.com/user-attachments/assets/e1f68700-dd28-4e7e-a195-f7aa2fde3ddf" />

## Further Considerations

This also disables *some* regular site search functionality.

Regular searching for jobs can be accomplished either with this AI search box (see screenshot below), **OR** by clicking Jobs and entering search terms in the search box that appears under the header on *that* page (https://www.glassdoor.com/Job/index.htm).

This PR does *not* break the latter search, only the one from the AI widget.

<img width="1132" height="424" alt="image" src="https://github.com/user-attachments/assets/024d7bd2-2fc1-4bfa-9069-61da7d1d6a72" />
