### PR TITLE
A: https://facebook.com - block login wall

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -326,6 +326,7 @@ m.youtube.com,www.youtube.com,youtube-nocookie.com##.ytp-ce-playlist
 m.youtube.com,www.youtube.com,youtube-nocookie.com##.ytp-pause-overlay
 portableapps.com##[alt="RSS"]
 xhaccess.com,xhamster.com,xhamster.desi##[class*="cam-wgt"]
+facebook.com##div.__fb-light-mode:has(#login_popup_cta_form)
 twitter.com,x.com##div[data-testid="profileAnalyticsUpsell"]
 twitter.com,x.com##div[data-testid="verified_profile_upsell"]
 privacywall.org##div[style="top:0;right:0;position:absolute"]


### PR DESCRIPTION
Blocks an undismissable Facebook login wall:

<img width="2200" height="1420" alt="image" src="https://github.com/user-attachments/assets/0d4ddd90-d98d-43b3-8bf6-ba29b3e744f1" />

(One of the classes is named `__fb-light-mode`, but from my testing it seems like Facebook is always in light mode when logged out, so it should be fine without also adding `dark-mode`)