### PR TITLE
Add MDN's bottom advertisement to easylist_specific_hide

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4566,8 +4566,8 @@ scmp.com##.page-container__left-native-ad-container
 bitdegree.org##.page-coupon-landing
 iheartradio.ca##.page-footer
 carsales.com.au##.page-header
-developer.mozilla.org##.page-layout__banner
 developer.mozilla.org##mdn-placement-bottom
+developer.mozilla.org##.page-layout__banner
 realtytoday.com##.page-middle
 boxing-social.com##.page-takeover
 seeklogo.com##.pageAdsWp

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4567,6 +4567,7 @@ bitdegree.org##.page-coupon-landing
 iheartradio.ca##.page-footer
 carsales.com.au##.page-header
 developer.mozilla.org##.page-layout__banner
+developer.mozilla.org##mdn-placement-bottom
 realtytoday.com##.page-middle
 boxing-social.com##.page-takeover
 seeklogo.com##.pageAdsWp


### PR DESCRIPTION
I added a filter that removes the advertisement from the bottom of the MDN's homepage.

Without the added filter rule:
<img width="1919" height="1043" alt="image" src="https://github.com/user-attachments/assets/df944196-05dc-45c1-acbf-830e34bad1fe" />

With the added filter rule:
<img width="1920" height="1042" alt="image" src="https://github.com/user-attachments/assets/cbd9933a-60fc-4122-9949-823f4c58f27d" />
