### PR TITLE
A: Hide YouTube anti-adblock enforcement popup + cover youtube-nocookie ad_break

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -766,6 +766,7 @@
 ||yimg.com/rq/darla/$domain=yahoo.com
 ||ynet.co.il/gpt/
 ||youswear.com/ads/
+||youtube-nocookie.com/youtubei/v1/player/ad_break
 ||youtube.com/pagead/
 ||youtube.com/youtubei/v1/player/ad_break
 ||zillastream.com/api/spots/

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1256,6 +1256,10 @@ music.youtube.com#?#tp-yt-paper-dialog.ytmusic-popup-container:has-text(/We’re
 www.youtube.com##tp-yt-paper-dialog.ytd-popup-container:has(> .ytd-popup-container > #options[class$="survey-renderer"])
 www.youtube.com#?#.YtdTalkToRecsFlowRendererHost:has-text(What hobbies are you interested in developing?)
 www.youtube.com#?#tp-yt-paper-dialog.ytd-popup-container:has-text(/How do you feel|Which of the following|following Premium|Get background play|Choose all that apply|Become a member of this channel|Free trial|How are your|How interested|Live TV|Wish videos|better TV|cable box|cable reimagined|hidden fees|of YouTube TV|on YouTube TV|unlimited DVR|with YouTube TV|without the ads|try this feature|Terms apply|View live scores|YouTube experience/)
+! YT anti-adblock enforcement
+www.youtube.com##tp-yt-paper-dialog:has(ytd-enforcement-message-view-model)
+www.youtube.com##ytd-enforcement-message-view-model
+www.youtube.com##ytd-popup-container:has(ytd-enforcement-message-view-model)
 ! https://github.com/easylist/easylist/issues/22334 YT suggestion div
 www.youtube.com#?#.YtdTalkToRecsFlowRendererHost:has-text(/Ask for videos|What do you like|Help us improve/)
 ! Login popups


### PR DESCRIPTION
The "Ad blockers violate YouTube's Terms of Service" popup currently isn't covered. uAssets handles it via scriptlets, but for engines that load EasyList without uAssets the popup shows.

`ytd-enforcement-message-view-model` mounts inside either `tp-yt-paper-dialog` or `ytd-popup-container` depending on the session. Hiding only the bare element leaves an empty wrapper covering the page, so all three are needed:

    ! YT anti-adblock enforcement
    www.youtube.com##tp-yt-paper-dialog:has(ytd-enforcement-message-view-model)
    www.youtube.com##ytd-enforcement-message-view-model
    www.youtube.com##ytd-popup-container:has(ytd-enforcement-message-view-model)

Also mirroring `||youtube.com/youtubei/v1/player/ad_break` for `youtube-nocookie.com`. Embedded players using the privacy-enhanced iframe currently slip through.