### PR TITLE
M: http://getadblock.com/ & http://adblockplus.org/

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -302,6 +302,7 @@
 @@||ps.w.org/wp-slimstat/$domain=wordpress.org
 @@||pub.pixels.ai/prebid_standard.js$script,domain=standard.co.uk
 @@||public.fbot.me/events/$domain=casper.com
+@@||public.profitwell.com^$domain=adblockplus.org|getadblock.com
 @@||px-cdn.net/api/v2/collector/ocaptcha$xmlhttprequest
 @@||qm.redbullracing.com/gtm.js$~third-party
 @@||qm.wrc.com/gtm.js$~third-party


### PR DESCRIPTION
Hello,

on account pages of AdBlock & ABP, a user is unable to cancel their subscription if subscribed to EasyPrivacy. 
Page unresponsive when the user clicks the 'cancel' CTA

e.g. `https://myaccount.adblockplus.org/?lang=en_US&av=4.37.1&ref=desktop-options`
(this behaviour is reproducible for a logged in Premium user)

<img width="1364" height="1024" alt="Screenshot 2026-05-01 at 1 36 04 PM" src="https://github.com/user-attachments/assets/875aec01-cd06-4391-8569-c9e91c30fc50" />

https://github.com/user-attachments/assets/428ac511-f78d-41ef-861c-7c9354f4cbbc

