### PR TITLE
P: mothership.sg - consolidate imu ad blocks into wildcard rule

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -362,8 +362,6 @@ ancient-origins.net###block-block-49
 insidehighered.com###block-dfptagarticle-sidebar-bottom
 insidehighered.com###block-dfptagarticle-sidebar-top
 spine-health.com###block-dfptagbottomanchorads1
-mothership.sg###block-imu1
-mothership.sg###block-imu2
 kenyans.co.ke###block-keleaderboardmenu
 romania-insider.com###block-nodepagebelowfromourpartners
 romania-insider.com###block-nodepagebelowlatespress
@@ -6459,6 +6457,7 @@ eloshapes.com##[id^="ads-"]
 bestbuy.ca,bestbuy.com##[id^="atwb-ninja-carousel"]
 beforeitsnews.com##[id^="banners_"]
 pluggedingolf.com##[id^="black-studio-tinymce-"]
+mothership.sg##[id^="block-imu"]:has(> .advertisement__container)
 shipt.com##[id^="cms-ad_banner"]
 dictionary.com##[id^="dco"]
 hola.com##[id^="div-hola-slot-"]


### PR DESCRIPTION
This PR closes #24144. 

Ads on mothership.sg are blocked at the network level, but large gray placeholders remain. The current filters use fragile sequential IDs (block-imu1, block-imu2). block-imu3 (and > 3) are thus not hidden. 

Fix: Replaced sequential rules with a single wildcard:
`mothership.sg##section[id^="block-imu"]:has(> .advertisement__container)`

This should handle all current and future block-imu units automatically. The :has() selector ensures we only target ad-specific sections, preventing accidental over-blocking.