### PR TITLE
M: Add sol.no to .share-icons-bottom allowlist

### DIFF
--- a/fanboy-addon/fanboy_social_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_social_allowlist_general_hide.txt
@@ -71,7 +71,7 @@ bitly.com,knivesout.jp#@#.share-btn
 search.brave.com#@#.share-button-wrapper
 ida2at.com#@#.share-holder
 app.degoo.com#@#.share-icon-container
-dagbladet.no,seher.no#@#.share-icons-bottom
+dagbladet.no,seher.no,sol.no#@#.share-icons-bottom
 pornhub.com#@#.share-link-container
 baidu.com,findagrave.com,locataire.dossierfacile.logement.gouv.fr#@#.share-list
 deezer.com#@#.share-message


### PR DESCRIPTION
Resolving the following issue: https://github.com/easylist/easylist/issues/24154

Summary                                                                                                       
                                                                                                                
  sol.no/studio/ experiences a page layout breakage when Fanboy's Social Blocking List is enabled. The
  .share-icons-bottom element is a structural layout container on this site, not a social sharing widget, and   
  its removal collapses the page.
                                                                                                                
  Root cause                                                

  The generic rule in fanboy_social_general_hide.txt:                                                           
  ##.share-icons-bottom
  matches the class name and hides the element globally. dagbladet.no and seher.no (which share the same        
  CMS/template) were already allowlisted in fanboy_social_allowlist_general_hide.txt, but sol.no was missing
  from that entry.                                                                                              
   
  Fix                                                                                                           
                                                            
  Extended the existing allowlist rule from:                                                                    
  dagbladet.no,seher.no#@#.share-icons-bottom
  to:                                                                                                           
  dagbladet.no,seher.no,sol.no#@#.share-icons-bottom                                                            
                                                    
  Domain order follows ASCII ascending sort convention. The fix is minimal and consistent with how the same     
  issue was already resolved for the sibling sites.                                                             
   
  Affected URLs                                                                                                 
  - https://sol.no/studio/   