### PR TITLE
R: Remove ||zeotap.com^$third-party — Zeotap is a CDP, not a tracker

### DIFF
--- a/cleaned-domains.txt
+++ b/cleaned-domains.txt
@@ -828,7 +828,6 @@ ythd.org
 ytimg.com
 zdassets.com
 zencdn.net
-zeotap.com
 zi-scripts.com
 ziffstatic.com
 ziggogratis.shop

--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -2529,7 +2529,6 @@
 ||zdtag.com^$third-party
 ||zedwhyex.com^$third-party
 ||zeerat.com^$third-party
-||zeotap.com^$third-party
 ||zesep.com^$third-party
 ||zeustechnology.com^$third-party
 ||zoomanalytics.co^$third-party


### PR DESCRIPTION
## Summary

Requesting removal of `||zeotap.com^$third-party` from `easyprivacy/easyprivacy_trackingservers_thirdparty.txt` and `zeotap.com` from `cleaned-domains.txt`.

**Zeotap is a Customer Data Platform (CDP), not a tracking company.** It is enterprise data infrastructure used by 80+ paying customers for first-party data unification, segmentation, and activation. It is not an ad tracker, pixel network, or fingerprinting service.

## What's blocked today

The `||zeotap.com^$third-party` rule blocks **all** `*.zeotap.com` subdomains in third-party context. This includes:

| Subdomain | Purpose | Legitimate? |
|---|---|---|
| `app.zeotap.com` | Primary SaaS application (customer login, dashboards, data management) | Yes — first-party product |
| `auth.zeotap.com` | SSO / OpenID Connect authentication | Yes — auth flows |
| `zeotap.com` | Corporate website | Yes |
| `spl.zeotap.com` | SDK / data collection endpoint | Debatable — this is the only subdomain that could be considered tracking-adjacent |

The rule was added in **August 2017** (commit `0ddad679`) based on a single observation of zeotap.com loading on `news18.com`. Since then, Zeotap has pivoted to a full enterprise CDP platform — it is no longer a third-party data provider or tracker.

## Impact on users

- **Enterprise customers** accessing `app.zeotap.com` through SSO redirect flows, bookmarks from internal portals, or embedded dashboards see broken pages when EasyPrivacy is enabled
- **DNS-level blocklists** (Pi-hole, NextDNS, AdGuard Home) that consume `cleaned-domains.txt` block `zeotap.com` entirely — including direct first-party access to the corporate website and product login

## Prior issues

- **#17488** (Oct 2023) — Zeotap employee reported the unconditional `||zeotap.com^` in `easylist_adservers.txt`. Removed by @ryanbr.
- **#20702** (Nov 2024) — Same unconditional rule re-appeared and was removed again by @ryanbr.

Neither issue addressed the `$third-party` variant in EasyPrivacy, which is what this PR fixes.

## Proposed alternative

If the concern is specifically about `spl.zeotap.com` (the data collection endpoint), we'd be open to a narrower rule:

```
||spl.zeotap.com^$third-party
```

This would block the SDK endpoint while allowing the SaaS application (`app.zeotap.com`), authentication (`auth.zeotap.com`), and corporate website to function normally.

## Changes

- Removed `||zeotap.com^$third-party` from `easyprivacy/easyprivacy_trackingservers_thirdparty.txt`
- Removed `zeotap.com` from `cleaned-domains.txt`

## About Zeotap

- **Website**: https://zeotap.com
- **Type**: Enterprise Customer Data Platform (CDP)
- **Customers**: 80+ enterprise brands
- **Use case**: First-party data unification, identity resolution, audience segmentation, activation
- **Not**: An ad tracker, pixel network, fingerprinting service, or third-party data broker