### PR TITLE
Fixing double scrollbar reddit

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -53,8 +53,7 @@ reddit.com##shreddit-async-loader[bundlename="app_selector"]
 reddit.com##shreddit-async-loader[bundlename="app_selector"]:remove()
 reddit.com##shreddit-experience-tree
 !#if env_mobile
-www.reddit.com##body,html:style(overflow: auto !important;)
-m.reddit.com##body,html:style(overflow: auto !important;)
+m.reddit.com,www.reddit.com##body,html:style(overflow: auto !important;)
 !#endif
 reddit.com##+js(prevent-addEventListener, touchmove)
 reddit.com##+js(remove-class, rpl-scroll-lock, body, stay)

--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -53,7 +53,8 @@ reddit.com##shreddit-async-loader[bundlename="app_selector"]
 reddit.com##shreddit-async-loader[bundlename="app_selector"]:remove()
 reddit.com##shreddit-experience-tree
 !#if env_mobile
-reddit.com##body,html:style(overflow: auto !important;)
+www.reddit.com##body,html:style(overflow: auto !important;)
+m.reddit.com##body,html:style(overflow: auto !important;)
 !#endif
 reddit.com##+js(prevent-addEventListener, touchmove)
 reddit.com##+js(remove-class, rpl-scroll-lock, body, stay)


### PR DESCRIPTION
Fixing a double scrollbar issue on reddit.com on Brave.

Because Brave does not compute the !#if env_mobile server side, this rule will also apply to desktop devices. This is creating a double scrollbar issue on desktop devices on brave when accessing old.reddit.com.

To fix this, I scoped the code to only apply on [www.reddit.com](http://www.reddit.com/) and m.reddit.com, so that it will not apply on old.reddit.com.