### PR TITLE
Hiding cookie notices

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -200,6 +200,7 @@ sightseeing-kontor.de###sk-info
 servicebund.de###social-opt-in
 mydealz.de,preisjaeger.at###softMessages-list
 soldesign.de###solbox
+freenet.de###sp_message_container_1426925
 jetztlive.com###splash-consent
 urteile-gesetze.de###stickyFooter
 soeren-hentzschel.at###storage-notice

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2522,6 +2522,7 @@ bauerexpress.com.br##.jss57
 idok.madeira.gov.pt##.jss68
 justica.gov.pt##.justica-cookie_bar
 magazineluiza.com.br##.kUgSEx
+f12.bet.br##.left-4
 queropassagem.com.br##.lgdp
 agroolhar.com.br,classicline.com.br,cobasi.com.br,freitasbastos.com.br,institutophi.org.br,licitanet.com.br,miess.com.br,mprs.mp.br,olharconceito.com.br,olhardireto.com.br,olharjuridico.com.br,opoder.com.br,saber.com.br,unesc.br##.lgpd
 girolando.com.br##.lgpd-aceite

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2761,6 +2761,7 @@ mgazeta.com##._cookieBanner_1gh8s_2
 vsemayki.ru##._gTi8L8k
 2gis.ru##._n1367pl
 2gis.ru,2gis.uz##._nlniiu
+gastronom.ru##._root_24byp_2
 bankprav.ru##.a-warning
 oreluniver.ru##.accept
 uteka.ru##.accept-cookie-popover

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1104,6 +1104,7 @@ el-klinikken.dk###c-l-widget
 cristalclubcph.com,turtlespeed.dk,vhi.dk###consentUI
 csgo.mtsl.dk###cookie-accepter
 autohjornet.com###cookiesAcceptWrapper
+danskespil.dk###ensModalWrapper
 bild-online.dk###fixedDiv2
 bygningskultur2015.dk,udlodningsmidler.dk###lbmodal
 udlodningsmidler.dk###lbmodal-overlay

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2459,6 +2459,7 @@ afestas.com.br##.bottom-popup-wrapper
 ecclesiae.com.br,videeditorial.com.br##.box-aceite-privacidade
 tekdistribuidor.com.br##.box-lgpd
 costanorte.com.br##.bswTsr
+diariodolitoral.com.br##.bwgr-lgpd-consent-box
 enjoei.com.br##.c-cookies-banner
 grupoccr.com.br,motiva.com.br##.c-dOELgn
 kovr.com.br##.c-eupVXi

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -201,6 +201,7 @@ servicebund.de###social-opt-in
 mydealz.de,preisjaeger.at###softMessages-list
 soldesign.de###solbox
 freenet.de###sp_message_container_1426925
+freundin.de###sp_message_container_1477762
 jetztlive.com###splash-consent
 urteile-gesetze.de###stickyFooter
 soeren-hentzschel.at###storage-notice

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2111,6 +2111,7 @@ dowhan-nieruchomosci.pl###cookies_text
 drony.net,gadzetomania.pl,komorkomania.pl,otabletach.pl###cop
 strefabiznesu.pl###cross-dialog
 federacja-konsumentow.org.pl,pewnykantor.pl###cu_bar
+dziennikzachodni.pl,gloswielkopolski.pl###didomi-host
 redbullmobile.pl###didomiBlockNavigation
 kinonh.pl###div_ac
 elektrykasklep.pl###ftccbcmd

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2114,7 +2114,6 @@ dowhan-nieruchomosci.pl###cookies_text
 drony.net,gadzetomania.pl,komorkomania.pl,otabletach.pl###cop
 strefabiznesu.pl###cross-dialog
 federacja-konsumentow.org.pl,pewnykantor.pl###cu_bar
-dziennikzachodni.pl,gloswielkopolski.pl###didomi-host
 redbullmobile.pl###didomiBlockNavigation
 kinonh.pl###div_ac
 elektrykasklep.pl###ftccbcmd

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1227,6 +1227,7 @@ freo.nl##.component--freo-cookielevel
 beslist.nl##.consent--_gICP
 tvgids.nl##.consent-backdrop
 geschiedenisvanzuidholland.nl##.consent-cookiebar
+eur.nl##.consent-studio
 seat.nl##.consent-wall-overlay
 werkenbijcoolblue.nl##.cookie-bar
 werkenbijcoolblue.nl##.cookie-bar__inner

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2947,6 +2947,7 @@ sberbank.ru##.style_cookieContainer__YEzG_
 zr.ru##.styled__CookieDisclaimerContainer-sc-43a78382-7
 cloud.ru##.styles-module-scss-module__7mbI1G__cookie_policy
 ingrad.ru##.styles-module__cookiesWarning--2mfHC
+culture.ru##.styles_CookieNotify__p_Rn1
 auchan.ru##.styles_acceptCookieAlert__7Tijv
 lada.ru##.styles_container__1obM5
 cloud.ru##.styles_cookiePolicy__VPjHs

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3083,6 +3083,7 @@ easistent.com###cookie_popup
 otpbanka.si###cookiepopupholder
 otpbanka.si###cookiepopupoverlay
 emporium.si###grayOut
+ekipa.svet24.si###potisni_popup
 zps.si###preload_over
 xxxlesnina.si##._1zBP5ruymc38ND7B
 hse-invest.si##.cc-cookiesmessage

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -200,8 +200,6 @@ sightseeing-kontor.de###sk-info
 servicebund.de###social-opt-in
 mydealz.de,preisjaeger.at###softMessages-list
 soldesign.de###solbox
-freenet.de###sp_message_container_1426925
-freundin.de###sp_message_container_1477762
 jetztlive.com###splash-consent
 urteile-gesetze.de###stickyFooter
 soeren-hentzschel.at###storage-notice

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2523,7 +2523,6 @@ bauerexpress.com.br##.jss57
 idok.madeira.gov.pt##.jss68
 justica.gov.pt##.justica-cookie_bar
 magazineluiza.com.br##.kUgSEx
-f12.bet.br##.left-4
 queropassagem.com.br##.lgdp
 agroolhar.com.br,classicline.com.br,cobasi.com.br,freitasbastos.com.br,institutophi.org.br,licitanet.com.br,miess.com.br,mprs.mp.br,olharconceito.com.br,olhardireto.com.br,olharjuridico.com.br,opoder.com.br,saber.com.br,unesc.br##.lgpd
 girolando.com.br##.lgpd-aceite

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3087,7 +3087,6 @@ easistent.com###cookie_popup
 otpbanka.si###cookiepopupholder
 otpbanka.si###cookiepopupoverlay
 emporium.si###grayOut
-ekipa.svet24.si###potisni_popup
 zps.si###preload_over
 xxxlesnina.si##._1zBP5ruymc38ND7B
 hse-invest.si##.cc-cookiesmessage


### PR DESCRIPTION
Hiding cookie notices on the following international sites using basic cosmetic filters:

https://culture.ru 

https://danskespil.dk 

https://diariodolitoral.com.br 

https://eur.nl 

https://gastronom.ru 
