### PR TITLE
P: Remove acsbapp.com to fix accessibility widget breakage

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -18,7 +18,6 @@
 ||a47b.com^
 ||a8723.com^
 ||aaxwall.com^
-||acsbapp.com^
 ||adcontroll.com^
 ||aditude.cloud^
 ||admaxium.com^


### PR DESCRIPTION
### Description
Removal request for `acsbapp.com` from `easyprivacy_trackingservers_general.txt`.

Fixes #24234

### Reason for Change
The domain `acsbapp.com` hosts the foundational scripts for the AccessWidget digital accessibility assistant. As detailed in the linked issue, the current EasyPrivacy block results in severe website breakage across thousands of production environments by entirely stripping away necessary UI accommodations (e.g., screen-reader optimization, keyboard navigation overrides, and cognitive adjustments) required by users with disabilities.

While the script dynamically adapts site elements based on user interaction to provide an accessible interface, it does not function as a third-party behavioral advertising network or cross-site tracker. The blanket block causes a critical loss of functional utility and accessibility compliance for end-users relying on assistive technology.

### Proposed Modification

In `easyprivacy/easyprivacy_trackingservers_general.txt`:

**Remove:**
```text
||acsbapp.com^