### PR TITLE
Hiding Cookie Notices

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -792,6 +792,7 @@ francetravail.fr,francetravail.org##pe-cookies
 boutique-box-internet.fr,fournisseur-energie.com##ppn-cookie
 ! Site Specific filters (used with $generichide)
 onvasortir.com###infocookies
+etudiant.gouv.fr###tarteaucitronAlertBig
 !
 ! ---------- Arabic ----------
 !

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2824,6 +2824,7 @@ fnkc-fmba.ru##.cookie_notification__wrap
 rzd-partner.ru##.cookie_outer_div
 bestmebelshop.ru##.cookie_warning_wrapper
 gorod48.ru##.cookiemodal
+libking.ru##.cookies
 job.mts.ru##.cookies-agreement-alert
 ok.ru##.cookies-agreement-notification
 1c-victory.ru##.cookies-block

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1459,6 +1459,7 @@ delfinakia.gr###using-cookies
 ertflix.gr##.CookiePolicyInfo__container___2ddi-
 my.heron.gr##._container_1twcf_9
 norlib.gr##.alertbanner
+harica.gr##.avada-footer-scripts
 voi-noi.gr##.bottombar
 dimotisnews.gr##.cc_obx
 welcomestores.gr##.consent-sticky-bar

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1227,6 +1227,7 @@ freo.nl##.component--freo-cookielevel
 beslist.nl##.consent--_gICP
 tvgids.nl##.consent-backdrop
 geschiedenisvanzuidholland.nl##.consent-cookiebar
+eur.nl##.consent-studio
 seat.nl##.consent-wall-overlay
 werkenbijcoolblue.nl##.cookie-bar
 werkenbijcoolblue.nl##.cookie-bar__inner

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2757,6 +2757,7 @@ mgazeta.com##._cookieBanner_1gh8s_2
 vsemayki.ru##._gTi8L8k
 2gis.ru##._n1367pl
 2gis.ru,2gis.uz##._nlniiu
+gastronom.ru##._root_24byp_2
 bankprav.ru##.a-warning
 oreluniver.ru##.accept
 uteka.ru##.accept-cookie-popover

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1911,6 +1911,7 @@ bing.com###thp_notf_div
 maruchiba.jp###tmp_wrap_info_box
 nakagawa-masashichi.jp###zigzag-test__modal-overlay:has([class^="src-components-banner-___BannerCookieConsent__wrapper"])
 narita-koi.com##.CookieConfirm
+keio.ac.jp##._cookieBanner_h867q_75
 japan.calvinklein.com##.agreeCookie
 tokyotokyo.jp##.annotation-area
 knb.ne.jp##.atention_cookie

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3561,6 +3561,7 @@ zoo-food.com###policy
 sport.ua###policy-accept
 shop.tefal.ua###root div[class^="cookieMessage-root"]
 m.censor.net###usage-notice-message
+makeup.com.ua##.CookieBanner__cookie
 i.ua##.Disclaimer
 casers.org##._2vwI89r3xy1E9vUpxC1-q
 casers.org##._3k10c1fUHhHZWUjcCu09Ve

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2629,6 +2629,7 @@ renting-tm.ro###ckn
 avertisment.ro###consentModal
 romedic.ro###cookbox
 pajurca.ro###cookiesmodal
+mersultrenurilor.infofer.ro###div-cookie-all
 mediafax.ro###ot-sdk-btn
 foxracing.ro###overlay_gdpr_autentic
 foxracing.ro###overlay_gdpr_autentic_content

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2827,6 +2827,7 @@ ok.ru##.cookies-agreement-notification
 1c-victory.ru##.cookies-block
 is1c.ru##.cookies-block-wrap
 gosapteka-mo.ru##.cookies-info__box
+getcourse.ru##.cookies-notification
 sberbank.com,sberbank.ru##.cookies-nova
 ruwiki.ru##.cookies-terms
 texet.ru##.cookies-win


### PR DESCRIPTION
Hiding cookie notices from the following sites using basic cosmetic filters:

https://etudiant.gouv.fr 

https://eur.nl 

https://gastronom.ru 

https://getcourse.ru 

https://harica.gr 

https://keio.ac.jp 

https://libking.ru 

https://makeup.com.ua 

https://mersultrenurilor.infofer.ro 
