### PR TITLE
M: www.google.com: Block Google Search AI Overview independent of language

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -113,7 +113,7 @@ mathrubhumi.com##.summary-wrapper
 techedt.com##.teqr-quick-read
 britannica.com##.toc-sticky-header-ai-container
 autonocion.com##.us-box-resumen
-www.google.com#?##Odp5De:has-text(/AI Overview|Übersicht mit KI/)
+www.google.com#?##Odp5De
 vercel.com##[aria-label="Ask AI"]
 meyka.com##[aria-label="Get AI Summary"]
 support.spotify.com##[data-encore-id="box"]


### PR DESCRIPTION
The current rule only blocks the AI Overview widget when the results are in English or German.
Since the rule targets the widget's ID, I removed the `:has-text(/AI Overview|Übersicht mit KI/)` check.  I can confirm that the rule now works independent of language (e.g. when the search results are in Romanian).