### PR TITLE
A: redecanais.ph

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -5570,6 +5570,7 @@ timesofmalta.com##.sw-Top
 saltwire.com##.sw-banner
 securityweek.com##.sw-bulletin
 securityweek.com##.sw-home-ads
+redecanais.ph##.swal2-backdrop-show:has(#vipAccessBtn)
 swimswam.com##.swimswam-acf
 khmertimeskh.com##.swiper-container-horizontal
 khmertimeskh.com##.swiper-wrapper


### PR DESCRIPTION
This page has an anti-adblock popup that appears, prompting the user to turn off their adblocker. This rule will allow us to hide that popup and continue to use the page without disabling adblock.

Fixes https://github.com/brave/adblock-lists/issues/2878