### PR TITLE
A: spacenews.com article gate

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_block.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_block.txt
@@ -28,6 +28,7 @@
 ||russia-insider.com/wp-content/uploads/pum/
 ||sabcnews.com^*-iabsa-
 ||sp-marketing-assets.s3.us-west-2.amazonaws.com^$domain=heraldnet.com
+||spacenews.com/wp-content/plugins/newspack-plugin/dist/content-gate-metering.js$script,domain=spacenews.com
 ||t.ly/js/sweetalert.min.js
 ||wikimedia.org/w/index.php?title=Special:BannerLoader
 ||www.glassdoor.*/static/js/gd-user-hardsell-overlay.bundle.js


### PR DESCRIPTION
Blocks the Newspack metering script on spacenews.com that replaces the article body with a "To continue reading this article:" registration gate.

Filter added to fanboy-addon/fanboy_annoyance_specific_block.txt in correct ASCII position:

||spacenews.com/wp-content/plugins/newspack-plugin/dist/content-gate-metering.js$script,domain=spacenews.com