### PR TITLE
A: ms.now: Blank spot for privacy choices

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2283,6 +2283,7 @@ petsathome.com##.onetrust
 signinapp.com##.opacity-100
 girlfriend.com##.opacity-100.translate-y-0
 torquemag.io,wpengine.com##.opt-in-modal
+ms.now##.opt-out
 tafelberg.co.za,waltons.co.za##.optin-sdk-root
 eventix.io##.ot-cookies
 cbsnews.com##.ot-fade-in


### PR DESCRIPTION
Gets rid of a blank spot in the footer where a privacy choices button is. (The link is blocked with generic rule `.ot-sdk-show-settings`, but this rule gets rid of the blank space)

Before
<img width="784" height="202" alt="image" src="https://github.com/user-attachments/assets/30f84324-dbd4-4839-858f-155c942a9bb2" />

After
<img width="750" height="236" alt="image" src="https://github.com/user-attachments/assets/3c29efa3-6532-40f0-a3d7-e87d1946a904" />
