### PR TITLE
A: m.yelp.*

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_hide.txt
+++ b/fanboy-addon/fanboy_notifications_specific_hide.txt
@@ -618,6 +618,7 @@ x.com##header[role="banner"] > ._3oxnid3o._3f2NsD-H
 delta.com##idp-dynamic-banner
 9animetv.to##img[alt="App Download"]
 google.*##mobile-promo
+m.yelp.*##section:has([data-testid="pitch-link"])
 reddit.com##shreddit-experience-tree[active-experiences*="app_selector"]
 weatherbug.com##smart-app-banner
 fedex.com##trk-shared-smart-app-banner


### PR DESCRIPTION
This fix removes an "open in app" message which appears on m.yelp.com and many other top level domains. For example yelp.co.uk, yelp.ch, yelp.es...