### PR TITLE
A: www.analyticsmania.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -6220,6 +6220,7 @@ greatist.com,healthline.com,medicalnewstoday.com,psychcentral.com##[data-empty]
 badgerandblade.com,ginx.tv##[data-ez-ph-id]
 reddit.com##[data-faceplate-tracking-context*="\"promoted\":true"]
 news.sky.com##[data-format="leaderboard"]
+www.analyticsmania.com##[data-formkit-toggle]
 euromaidanpress.com##[data-fuse="header"]
 cooljugator.com##[data-fuse]
 cumbriacrack.com,euromaidanpress.com##[data-hbwrap]
@@ -7222,6 +7223,7 @@ groupon.com##figure[data-clickurl^="https://api.groupon.com/sponsored/"]
 imgburn.com##font[face="Arial"][size="1"]
 realitytvworld.com##font[size="1"][color="gray"]
 dailydot.com##footer
+www.analyticsmania.com##form[action$="/subscriptions"]
 law.com,topcultured.com##h3
 kazwire.com##h3.tracking-widest
 drive.com.au##hr


### PR DESCRIPTION
Fixes #24175

Hides newsletter subscription forms on www.analyticsmania.com that appear multiple times throughout blog articles. The forms were not being blocked despite using the EasyList Newsletter Notices filter, which prompted the issue report.

Added rules:
- `www.analyticsmania.com##form[action$="/subscriptions"]` — hides the newsletter subscription form
- `www.analyticsmania.com##[data-formkit-toggle]` — hides the FormKit-based toggle element

**Before:**
<img width="1456" height="836" alt="image" src="https://github.com/user-attachments/assets/c5ecf708-f4cd-4012-8899-d187167c05cc" />

**After:**
<img width="2914" height="1674" alt="image" src="https://github.com/user-attachments/assets/30fe8a32-0262-4b39-86aa-67d058350fda" />



Tested in Firefox with uBlock Origin 1.71.0. Both rules confirmed working — newsletter banners are hidden after applying the filters.