### PR TITLE
A: affonso.io

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -33,6 +33,7 @@
 ||adstk.io^
 ||adultium.com^
 ||advertease.store^
+||affonso.io^
 ||afrdtech.com^
 ||aftership-pixel.com^
 ||aggle.net^


### PR DESCRIPTION
Fixes #24258

Blocks affonso.io, an affiliate marketing tracking pixel that collects user data without consent on sites such as smmry.com and notepadexe.com.

Added rule:
- `||affonso.io^` — blocks affiliate tracking pixel requests from affonso.io and cdn.affonso.io

**Before:**
<img width="1456" height="829" alt="image" src="https://github.com/user-attachments/assets/521125d5-d79a-4d79-8a9b-4ad1da9d5a4f" />


**After:**
<img width="1456" height="829" alt="image" src="https://github.com/user-attachments/assets/ba3ae123-07a7-4b2a-8979-a800571cafe6" />

Tested in Firefox with uBlock Origin 1.71.0. Rule confirmed working — affonso.io requests are blocked after applying the filter.