### PR TITLE
A: https://www.leboncoin.fr

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
+++ b/easyprivacy/easyprivacy_trackingservers_thirdparty.txt
@@ -504,6 +504,7 @@
 ||conductrics.com^$third-party
 ||conductrics.net^$third-party
 ||conduze.com^$third-party
+||confidence.dev^$third-party
 ||config.parsely.com^$third-party
 ||confirmational.com^$third-party
 ||connectif.cloud^$third-party


### PR DESCRIPTION
Spotify AB testing service used by other websites, https://confidence.spotify.com/. Blocking it does not appear to break leboncoin.fr website.