### PR TITLE
A: github.blog: Newsletter filter

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -562,7 +562,7 @@ jagranjosh.com##.NewsLetterInlineHome
 abergavennychronicle.com,tenby-today.co.uk##.NewsLetterSignUpstyled__NewsLetterSignUpWrapper-sc-aru595-0
 earth.com##.NewsSubscribeLg_main__QWMpm
 thefinancialdiet.com##.NewslBanner
-clarin.com,governing.com,govtech.com,who.com.au##.Newsletter
+clarin.com,github.blog,governing.com,govtech.com,who.com.au##.Newsletter
 cbssports.com##.Newsletter-container
 axial.acs.org##.NewsletterCTA_inner__8UZPJ
 aleteia.org##.NewsletterForm_container__CWjyJ


### PR DESCRIPTION
Hide newsletter signup on bottom of GitHub blog articles. Example: https://github.blog/changelog/2021-12-09-lists-are-now-available-as-a-public-beta/