### PR TITLE
M: fcbarcelona.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_uBO.txt
+++ b/easylist_cookie/easylist_cookie_specific_uBO.txt
@@ -2776,7 +2776,7 @@ a-spect.be,a2o-architecten.be,a2o-omgeving.be,a2o.be,abm-accountants.com,adlon.b
 a-spect.be,a2o-architecten.be,a2o-omgeving.be,a2o.be,abm-accountants.com,adlon.be,adtemptare.be,allimex.eu,antiek-albarello.com,aratina.com,atirio.be,avlwoningbouw.be,baeyens-l.be,barbecues.be,bartyde.be,bbcbb.be,browsbox.com,decoform.be,delbruyere.be,deregenboog.be,design-home.be,dewiekslag.be,dr-geeraerts-dermatologie.be,durocub.be,enib.be,eremex.be,granhold.com,gripsholm.be,groepmsi.be,hanssens.net,incadans.be,jagsonly.be,jbavicon.com,kwvanbladel.be,liswood-tache.com,marlou.be,medibe.be,microscope-shop.be,morphologicum.org,noorwegenhitravissers.be,nsi-be.com,o-f-s.eu,omerus.be,p-laser.com,royalcrown.be,rsc-slaapcomfort.com,sani-lux.net,sanik.be,scherpesteen.be,tri-active.be,tuincenterlissens.be,vaatkliniek.be,vado.be,visitatiebottelare.be,vivantia.be,vrijdagmarkt.net##body,html:style(overflow: auto !important; position: initial !important;)
 !! #didomi-host
 allocine.fr,as.com,corrieredellosport.it,fcbarcelona.com,mein-mmo.de,tuttosport.com,vecernji.hr###didomi-host
-allocine.fr,as.com,corrieredellosport.it,fcbarcelona.com,mein-mmo.de,tuttosport.com,vecernji.hr##body,html:style(overflow: visible !important; padding-right: 0 !important; overflow-y: visible !important; overflow-x: visible !important)
+allocine.fr,as.com,corrieredellosport.it,fcbarcelona.com,mein-mmo.de,tuttosport.com,vecernji.hr##body,html:style(overflow: visible !important; padding-right: 0 !important; overflow-y: visible !important; overflow-x: visible !important; position: initial !important;)
 !! Didomi noop
 elconfidencial.com,euromaster.de,gamepro.de,jofogas.hu,lavanguardia.com,melty.fr,strefabiznesu.pl##+js(set, Didomi, noopFunc)
 !! .rgpd


### PR DESCRIPTION
fcbarcelona.com on iOS was not scrollable. This is because another class was loaded on the body element which gave a position of fixed to the body. Setting this back to the initial value fixes this scroll issue.