### PR TITLE
A: https://www.similarweb.com/

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -14,6 +14,8 @@ huckberry.com##.modal-content
 huckberry.com##body,html:style(height: auto !important; overflow: auto !important)
 ! semrush.com
 semrush.com##+js(set-session-storage-item, sem30_popup_shown, 1)
+! similarweb.com (usage limit/signup wall) https://github.com/uBlockOrigin/uAssets/issues/29112
+similarweb.com##+js(cookie-remover, sgID)
 ! https://github.com/uBlockOrigin/uAssets/issues/22927 (forced login)
 clarin.com##+js(nostif, _waitingAuth0Counter)
 ! bestrecipes.com.au (forced login)


### PR DESCRIPTION
## A: https://www.similarweb.com/

**File:** `fanboy-addon/fanboy_annoyance_specific_uBO.txt`

**Filter added:**
```
! similarweb.com (usage limit/signup wall) https://github.com/uBlockOrigin/uAssets/issues/29112
similarweb.com##+js(cookie-remover, sgID)
```

### What it fixes
After a few page views, similarweb.com shows a full-page modal (`div.wa-limit-modal`, `position:fixed; z-index:1402`) reading "Create an account to continue using Similarweb", and the server stops returning data ("No Data to Display"). It is a usage meter keyed on the `sgID` cookie.

### Why a scriptlet and not a cosmetic hide
The content is server-gated, not merely covered. Hiding `.wa-limit-modal` leaves an empty "No Data to Display" page. Wiping the `sgID` meter cookie makes each load count as a first visit, so the wall never fires and the full ranking renders.

### Testing (headless Firefox / Playwright)
- Fresh visit: no wall, full ranking (52 rows). `sgID` cookie set.
- After 5 visits with the cookie kept: wall appears, ranking drops to ~2 rows.
- With `sgID` removed on every load: no wall, full 52-row ranking restored. Reproduced on the Top Websites Ranking page.

### Notes
- Placed in the existing "forced login / signup wall" cluster, next to the sibling `! semrush.com` entry; same `cookie-remover` mechanism already used for `zippia.com` and the howtogeek network in this file.
- Tracking issue: https://github.com/uBlockOrigin/uAssets/issues/29112 (closed by a uAssets maintainer with the label "fixable by Easylist / Adguard lists").
- Sorted with FOP; no other lines changed.
