### PR TITLE
A: https://share4max.com/iframe/mJdAPgyiwoKU9

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -636,6 +636,7 @@ $third-party,xmlhttprequest,domain=mega4upload.net
 ||service-ad-image-ga-weighted.prd.pluto.tv^
 ||sfgate.com/juiceExport/production/sfgate.com/loadAds.js
 ||sgtreport.com/wp-content/uploads/*Banner
+||share4max.com/ads/$script
 ||sharecast.ws/cum.js
 ||sharecast.ws/fufu.js
 ||shieldload.neoseeker.com^


### PR DESCRIPTION
## What

Adds `||share4max.com/ads/$script` to `easylist/easylist_specific_block.txt`.

## Where found

`share4max.com` is a video embed host used by anime streaming aggregators (e.g. `https://ww3.okanime.xyz/episode/one-piece-episode-1164`, which loads `https://share4max.com/iframe/mJdAPgyiwoKU9` as its player).

## What it blocks

The player's page payload ships an ad manifest that injects two first-party popunder scripts from the `/ads/` path:

- `//share4max.com/ads/smartlink11.js`
- `//share4max.com/ads/popads/share4max.com.js`

These are the scripts that trigger the `window.open` popunders (to rotating third-party destinations such as `bonuscaf.com`, `omg10.com`, `cdn4ads.com`). Blocking the `/ads/` script path stops them at source.

## Reproduce

1. Default uBO lists enabled.
2. Load `https://share4max.com/iframe/mJdAPgyiwoKU9`.
3. Without the filter, the two `/ads/` scripts load and a click opens a popunder. With it, both scripts are blocked and the player still loads and plays.

## Note

Complementary to the `share4max.com` popup-rule addition in #24312: that rule catches the popunder window; this one prevents the popunder/ad scripts from loading in the first place. Verified the `/ads/` block does not affect the `share4max.com/iframe/` player.
