### PR TITLE
Add &sst.gcsub= Google server-side tagging (SST)

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -7,6 +7,7 @@
 &hitType=pageview&
 &http_referer=$script,xmlhttprequest,domain=~biletomat.pl|~facebook.com|~jobscore.com
 &refer=http$script
+&sst.gcsub=
 &t=pageview&
 -adobe-analytics/
 -adobeDatalayer_bridge.js


### PR DESCRIPTION
Block Google server-side tagging (SST) that is hosted on various subdomains, on distinct ips (unfortunately no cname blocking is possible). So I suggest blocking based on a specific GET parameter that should probably not have much false positives.

https://developers.google.com/tag-platform/tag-manager/server-side/manual-setup-guide

Numerous websites hosts their own SST server, found at least (some parents scripts are already in blocklist on some websites and not others):
- https://gtowizard.com
- https://upway.fr
- https://www.simply.com