### PR TITLE
A: cbsnews.com: Google source

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -534,6 +534,7 @@ financemagnates.com##.contact-widget__sticky
 u.today##.contacts-social
 dailymail.co.uk##.container-3zJLP
 el-observador.com##.content-social
+cbsnews.com##.content__google
 christian.org.uk##.content__sharing
 carnegieendowment.org##.controls
 homecookingadventure.com##.cookbook-instagram


### PR DESCRIPTION
Remove extra whitespace from "Add to google as source" button
Example: `https://www.cbsnews.com/live-updates/iran-war-us-trump-netanyahu-israel-lebanon-hezbollah/`