### PR TITLE
P: https://xlivesex.com/ (nsfw, fixes #20654)

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -45243,7 +45243,6 @@
 ||xliirdr.com^
 ||xliohleaxabmf.website^
 ||xlirdr.com^
-||xlivesex.com^
 ||xlivrdr.com^
 ||xliwryycvgfh.com^
 ||xljcwduwcepkm.site^


### PR DESCRIPTION
Fixes #20654

Removes the `||xlivesex.com^` filter from `easylist_adservers.txt`. As reported in the issue, the site does not display advertisements, and the blanket domain block breaks access for users of AdBlock/ABP-based extensions that apply network filters from EasyList.

The filter was added in 1e5d554bc490e0fa590e230c278a0bf7c6276302 (Jan 2024) as part of a larger batch addition.