### PR TITLE
M: reddit.com - fixing scroll issue

### DIFF
--- a/fanboy-addon/fanboy_notifications_specific_uBO.txt
+++ b/fanboy-addon/fanboy_notifications_specific_uBO.txt
@@ -53,7 +53,7 @@ reddit.com##shreddit-async-loader[bundlename="app_selector"]
 reddit.com##shreddit-async-loader[bundlename="app_selector"]:remove()
 reddit.com##shreddit-experience-tree
 !#if env_mobile
-m.reddit.com,www.reddit.com##body,html:style(overflow: auto !important;)
+m.reddit.com,www.reddit.com##body:style(overflow: auto !important;)
 !#endif
 reddit.com##+js(prevent-addEventListener, touchmove)
 reddit.com##+js(remove-class, rpl-scroll-lock, body, stay)


### PR DESCRIPTION
There is a scroll issue on reddit.com for iOS devices. This issue is caused by the html element having an overflow:auto style applied.

I have tested with the following rules:

m.reddit.com,www.reddit.com#@#body,html:style(overflow: auto !important;)
m.reddit.com,www.reddit.com##body:style(overflow: auto !important;)

This uses an exception rule to remove the current filter and then another rule to apply the style to only the body element. After applying these rules, the issue is resolved on my iOS device.

Fixes: https://github.com/brave-experiments/spiking-webcompat-reports/issues/2018