### PR TITLE
P: atypon literatum

### DIFF
--- a/fanboy-addon/fanboy_annoyance_allowlist_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_allowlist_general_hide.txt
@@ -13,5 +13,4 @@ skadden.com#@#.back-to-top:not(body):not(html)
 realme.com#@#.btn-back-to-top
 skadden.com#@#.js-back-to-top
 midori-japan.co.jp#@#.js-scroll-top:not(html):not(body)
-sagepub.com#@#.scrollToTop
 skadden.com#@#a[href="#back-to-top"]

--- a/fanboy-addon/fanboy_annoyance_general_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_general_hide.txt
@@ -693,7 +693,7 @@ dashboard.razorpay.com#@##credential_picker_container
 ##.scroll-up-button-wrapper
 ##.scroll-up-cta
 ##.scroll2top
-##.scrollToTop
+##.scrollToTop:not(.dropdown-content-wrapper)
 ##.scrollToTopBtn
 ##.scrollToTopButton
 ##.scrollToTopLink


### PR DESCRIPTION
Fixes Literatum, a PDF viewer embedded on many academic sites.

There was previously an exception from the blocking rule just for sagepub.com, but the same reader is used by many journals across different domains, and this fix applies to all of them.

Before:

<img width="690" height="270" alt="image" src="https://github.com/user-attachments/assets/96be8108-0189-453f-8660-edee879e8226" />

After:

<img width="684" height="536" alt="image" src="https://github.com/user-attachments/assets/d975ca11-3c5e-40b0-b0d0-9cb4ccd740d8" />
