### PR TITLE
Add return type annotation to start() function

### DIFF
--- a/FOP-nocommit.py
+++ b/FOP-nocommit.py
@@ -54,7 +54,7 @@ KNOWNOPTIONS = ("collapse", "csp", "csp=frame-src", "csp=img-src", "csp=media-sr
                 "rewrite=abp-resource:blank-html", "rewrite=abp-resource:blank-js", "rewrite=abp-resource:blank-mp3", "rewrite=abp-resource:blank-mp4", "rewrite=abp-resource:blank-text",
                 "script", "stylesheet", "subdocument", "third-party", "webrtc", "websocket", "xmlhttprequest")
 
-def start():
+def start() -> None:
     """ Print a greeting message and run FOP in the directories
     specified via the command line, or the current working directory if
     no arguments have been passed."""


### PR DESCRIPTION
### Background
The public `start()` function in `FOP-nocommit.py` lacked a return type annotation. Adding type annotations improves code readability and facilitates static type checking, aligning with modern Python best practices without altering functionality.

### Changes
- Added `-> None` return type annotation to the `start()` function definition to explicitly indicate that it returns no value.

### Verification
- The change is minimal and only affects type hints; the function's behavior remains unchanged.
- Can be verified by running the code normally or using a type checker like `mypy` to ensure no syntax or type errors are introduced.
- No external dependencies are added, maintaining compatibility.