### PR TITLE
Hiding cookie notices

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2728,7 +2728,7 @@ sport-express.net###se-cookie-popup
 thepublic.info###silktide-wrapper
 softline.ru###stripe_permission_use_cookie
 dobrodel.mosreg.ru###toast-container
-keysight-technologies.ru###uni-notification
+keysight-technologies.ru,world-devices.ru###uni-notification
 incom.ru###use_cookies_message-block
 nord-news.ru###ym-cookie-notification
 bcs.ru##.Cbh_c

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -195,6 +195,7 @@ komediateatteri.fi###rehtiConsentMainWrapper
 gourmetbugs.ch###rgpd-ask-popin
 rwth-aachen.de###rwth-cb
 gfoe-conference.de###sb-container
+thepublic.info,trepedia.de,trepedia.fr,trepedia.nl###silktide-wrapper
 felbermayr.cc###siwa-cookiebar-banner
 sightseeing-kontor.de###sk-info
 servicebund.de###social-opt-in

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3519,7 +3519,7 @@ saltur.com.tr##.cerezkullanimi
 haberler.com##.cmp-reopen
 bettilt496.com##.consent-modal
 hosting.com.tr##.contract-popup
-soneksbilgisayar.com##.cookie-agreement-module
+segmen.com.tr,soneksbilgisayar.com##.cookie-agreement-module
 hepsijet.com##.cookie-policy_cookiePolicy__9xbaz
 pinarsu.com.tr##.cookieContent
 ensonhaber.com##.cookiepolicy-banner

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3510,7 +3510,7 @@ natro.com###readed_contract_row
 tatgida.com###topbar-hide
 oz.av.tr##.Legal
 apigo.com.tr##.ant-notification
-ikonambalaj.com.tr,teknoparkizmir.com.tr##.bottom-center
+ikonambalaj.com.tr##.bottom-center
 aydinyeniufuk.com.tr,balikesirartihaber.com,denizli20haber.com,eldedemokrasi.com,haberimizvar.net,hedefgazetesi.com.tr,isdunyasindakadin.com,kocaelisabah.com,mhrs.gov.tr,seffafbelediyecilik.com,yenigolcuk.com##.cerez
 tebilon.com##.cerezNotification
 akkushop-turkiye.com.tr##.cerezPopupUyari

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1159,7 +1159,7 @@ vlaanderen.be###calibr8-cookie-compliance
 autentiek.nl###ciWrapper
 blog.andwork.com###ckm
 cdh.be###comp-jkmod7cm
-denhaagfm.nl,gld.nl,l1.nl,l1nieuws.nl,nieuwsplein33.nl,omroepwest.nl,omroepzeeland.nl,omropfryslan.nl,oost.nl,rtvdrenthe.nl,rtvnoord.nl,rtvutrecht.nl###consent-plugin
+denhaagfm.nl,gld.nl,l1.nl,l1nieuws.nl,nieuwsplein33.nl,omroepwest.nl,omroepzeeland.nl,omropfryslan.nl,oost.nl,rijnmond.nl,rtvdrenthe.nl,rtvnoord.nl,rtvutrecht.nl###consent-plugin
 targetsupport.nl###consentModal
 wijzeringeldzaken.nl###consentbar
 finambank.ru,wijnhaven.nl###cookie-consent-popup

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2673,7 +2673,7 @@ clinic3.ru###agreedBanner
 gazeta-n1.ru###bdModalCookie
 ecolipetsk.ru###bg_popup
 bankinform.ru###bisCookieCompliance
-hh.ru###bottom-cookies-policy-informer
+hh.ru,zarplata.ru###bottom-cookies-policy-informer
 earth-chronicles.ru,vip-tv.online###bottomInfoBar
 yvid.ru###cbb
 mamba.ru###closeCookieBanner

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2688,7 +2688,7 @@ violity.com###cookieConsentPopup
 zia.aero###cookieDisclaimer
 aeroflot.ru###cookieInfo
 abok.ru###cookieNotice
-itweek.ru###cookie_notification
+itweek.ru,rvdtut.ru###cookie_notification
 vladimir-city.ru###cookie_pp
 so-ups.ru###cookieagreement
 vtb.ru###cookies-box

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3509,7 +3509,7 @@ natro.com###readed_contract_row
 tatgida.com###topbar-hide
 oz.av.tr##.Legal
 apigo.com.tr##.ant-notification
-ikonambalaj.com.tr##.bottom-center
+ikonambalaj.com.tr,teknoparkizmir.com.tr##.bottom-center
 aydinyeniufuk.com.tr,balikesirartihaber.com,denizli20haber.com,eldedemokrasi.com,haberimizvar.net,hedefgazetesi.com.tr,isdunyasindakadin.com,kocaelisabah.com,mhrs.gov.tr,seffafbelediyecilik.com,yenigolcuk.com##.cerez
 tebilon.com##.cerezNotification
 akkushop-turkiye.com.tr##.cerezPopupUyari

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3716,7 +3716,7 @@ bka.de,cieplodlakrakowa.pl,compitoinclasse.org,irroba.com.br,kancelariamzm.pl,kp
 !! .privacy
 bodohavn.no,brieffreund-gesucht.de,directours.com,edzl.lv,emezeta.com,engagelab.com,homey.com.tr,hstock.org,inforoom.com.ua,naegele.it,one.ua,rbc.ua,vikingtemizlik.com.tr##.privacy
 !! .privacy-policy
-alfred.com,amino.dk,gigaom.com,gq.com.au,henrilloyd.com,hesapkurdu.com,hvylya.net,hyser.com.ua,mail.meta.ua,mta.tv,oldmail.meta.ua,paymaster.ru,politeka.net,tupras.com.tr,ukrainci.com.ua,ukrainianwall.com,vocativ.com,znaj.ua,zumba.com##.privacy-policy
+alfred.com,amino.dk,gigaom.com,gq.com.au,henrilloyd.com,hesapkurdu.com,hvylya.net,hyser.com.ua,mail.meta.ua,mta.tv,oldmail.meta.ua,paymaster.ru,politeka.net,taximaster.ru,tupras.com.tr,ukrainci.com.ua,ukrainianwall.com,vocativ.com,znaj.ua,zumba.com##.privacy-policy
 !! #privacy-policy
 104.ua,atlanticsuperstore.ca,bostools.nl,nofrills.ca,planetfitness.com,realcanadiansuperstore.ca,wccaviation.com###privacy-policy
 !! cdk-overlay-container

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -673,7 +673,7 @@ foundryvtt.com###privacy-policy-prompt
 fa-mag.com###privacy-policy-sticky
 advmusic.com,kidmah.co.il,utas.edu.au###privacy-popup
 supermicro.com###privacy-popup-agree
-toomics.com###privacy-popup-msg
+toomics.com,toomics.in###privacy-popup-msg
 amazon.jobs###privacy-preferences-banner
 telegraph.co.uk###privacy-settings-prompt
 dolarhoje.com###privacy-warning

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3335,7 +3335,7 @@ luna.amazon.co.uk,luna.amazon.de###cookie_consent_dialog
 !! sandberg
 sandberg.es,sandberg.fr,sandberg.world###privalert-container
 !! .fixed-bottom
-atproperties.com,autotrader.com,cofense.com,coingecko.com,disponivel.com,disponivel.net,dogruhaber.com.tr,equisys.com,excellent-hemd.de,farmers.com,fordblueadvantage.com,g2g.com,gateway.one,getmailbird.com,hausgold.de,ilkha.com,innn.it,jsonquerytool.com,lacsc.be,lobaevarms.com,modoko.com.tr,muze.gen.tr,parklot.pl,plantnet.org,remove.bg,shroomers.app,skokka.com,speisebaron.de,susicka.cz,tjsc.jus.br,unscreen.com,wallpaperdirect.com##.fixed-bottom
+atproperties.com,autotrader.com,cofense.com,coingecko.com,disponivel.com,disponivel.net,dogruhaber.com.tr,equisys.com,excellent-hemd.de,farmers.com,fordblueadvantage.com,g2g.com,gateway.one,getmailbird.com,hausgold.de,ilkha.com,innn.it,jsonquerytool.com,lacsc.be,lobaevarms.com,modoko.com.tr,muze.gen.tr,parklot.pl,plantnet.org,remove.bg,sariyersoz.com.tr,shroomers.app,skokka.com,speisebaron.de,susicka.cz,tjsc.jus.br,turkiyekatilimsigorta.com.tr,unscreen.com,wallpaperdirect.com##.fixed-bottom
 !! .navbar-fixed-bottom
 biblio.co.uk,comfortclick.com,discountoffice.nl,nowemiasteczko.pl,ornox.fr,polimarky.pl##.navbar-fixed-bottom
 !! .banner

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1770,7 +1770,7 @@ cervelo.com##.eSJQoN
 aiease.ai##.ea-cookies-accept
 i-subdigital.com##.eb-1
 i-sub.co.uk##.eb-shd1
-cherryred.co.uk,military1st.com##.ec-gtm-cookie-directive
+adamscc.nl,cherryred.co.uk,diegomarin.com,fiftiesstore.com,houseofsound.ch,mildot.es,military1st.co.uk,military1st.com,military1st.eu,punanaamio.fi,retro-audio.nl,rubber4roofs.co.uk,sportmix.pl,store.kapetanis.com,uvex.com.pl##.ec-gtm-cookie-directive
 midasbuy.com##.eea-pop
 carvago.com##.ees0v8i1
 tech.eu##.efilli-layout-legacy

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3433,7 +3433,7 @@ arkone.co.uk,bristonhorseshoes.co.uk,norfolkmead.co.uk###cookiedialogmini
 !! #wr-c
 ahprofi.cz,akros.cz,aspshop.cz,fiskars-shop.cz,mpmshop.eu,rafoshop.cz,relaxin.cz,yatun.cz###wr-c
 !! .gdpr
-app.gleek.io,atarim.gov.il,aviationweek.com,centar-tehnike.hr,globalrescue.com,metallica.com,namal.co.il,partnerboost.com,phonemore.com,schmackarys.com,srilankan.com,sydsvenskan.se,tomba.io,umkc.edu,venngage.com##.gdpr
+app.gleek.io,atarim.gov.il,aviationweek.com,centar-tehnike.hr,globalrescue.com,metallica.com,namal.co.il,partnerboost.com,phonemore.com,schmackarys.com,srilankan.com,sydsvenskan.se,taa-ankara.org.tr,tomba.io,umkc.edu,venngage.com##.gdpr
 !! .gdpr-wrapper
 adressa.no,ezviz.com,hikvision.com,ria.com##.gdpr-wrapper
 !! #GDPR

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3621,7 +3621,7 @@ alfombrashamid.es,autovilardell.com,blancmarine.com,carmenvazquez.es,fadenkreuz-
 !! .cookiewall
 achemosgrupe.lt,brockhoff.nl,cibit.nl,dbkeukens.nl,dutchweek.nl,hurenbijwooove.nl,kroftman.com,vinkvink.nl,woontank.nl##.cookiewall
 !! .modal--cookie
-pkprintprof.ru,themodernhouse.com,wildberries.by##.modal--cookie
+pkprintprof.ru,themodernhouse.com,wildberries.by,znaet.petrovich.ru##.modal--cookie
 !! _modal_outer_
 marathonphotos.live,witbee.com##div[id*="_modal_outer_"]
 !! #rgpd


### PR DESCRIPTION
Hiding cookie notices from the following sites using basic cosmetic filters:

https://taximaster.ru 

https://teknoparkizmir.com.tr 

https://toomics.in 

https://trepedia.de

https://trepedia.fr

https://trepedia.nl 

https://world-devices.ru 

https://zarplata.ru 

https://znaet.petrovich.ru 

https://rijnmond.nl 

https://rvdtut.ru 

https://rvdtut.ru 

https://sariyersoz.com.tr

https://turkiyekatilimsigorta.com.tr 

https://segmen.com.tr 

https://sportmix.pl

https://uvex.com.pl 

https://taa-ankara.org.tr 
