### PR TITLE
M: deliveroo popup text update

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_uBO.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_uBO.txt
@@ -288,7 +288,7 @@ usni.org###articleCookieModal
 usni.org##+js(remove-cookie, STYXKEY_nh_count)
 usni.org##+js(remove-cookie, STYXKEY_pro_count)
 ! https://github.com/easylist/easylist/pull/24305
-deliveroo.ie#?#.ReactModalPortal > .ccl-5300654a18fccc61:has(p:has-text(Sign up to Deliveroo Plus Gold))
+deliveroo.ie#?#.ReactModalPortal > .ccl-5300654a18fccc61:has(div:has-text(Deliveroo Plus T&Cs))
 deliveroo.ie##html:style(overflow:auto !important;)
 ! accuradio.com (login nag)
 accuradio.com##.ReactModal__Overlay--after-open.ReactModal__Overlay


### PR DESCRIPTION
I noticed the campaigns are changing time to time.

Old was
<img width="1861" height="865" alt="kép" src="https://github.com/user-attachments/assets/094d418d-da44-4942-ab3b-2b0f09a16ad0" />

Now it is
<img width="836" height="876" alt="kép" src="https://github.com/user-attachments/assets/e3ba851d-8c48-4d35-8ac2-2a9780b6fbc6" />

I try to filter more general or static text now.