### PR TITLE
A: wart.val.town

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -2974,6 +2974,7 @@
 ||wallkit.net^*/user/event
 ||wantlive.com/pixel/
 ||warnermedia.com/api/v1/events?
+||wart.val.town^
 ||watchtower.graindata.com^
 ||wco.crownpeak.com^
 ||wds.weqs.me^


### PR DESCRIPTION
appears to be analytics, visible on https://www.val.town/auth/signup