### PR TITLE
A: amcharts.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -92,6 +92,7 @@ heli-one.com###alertmessagewrp
 dagbladet.no,elbil24.no,kk.no,seher.no,sol.no###am-branding
 auroramap.org###am-cookie-banner
 mightywatches.com###am-cookie-bar
+amcharts.com###amcharts-utils-consent
 adcoffee.io###analytics-id
 buckle.com###analytics-prompt
 ao.com###aoMessageHolder


### PR DESCRIPTION
Hiding the cookie notice on amcharts.com using a basic cosmetic filter.