### PR TITLE
A: bp.com 

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2656,7 +2656,7 @@ chatreplay.stream##.svelte-dx0l3i
 revanced.app##.svelte-fnvau2
 haier.com##.swiper-slide-img-txt
 taschen.com##.switch-prompt
-us.davines.com##.syrenis-cookie-widget
+bp.com,us.davines.com##.syrenis-cookie-widget
 amplitude-studios.com,games2gether.com##.system-notification-container
 termly.io##.t-consentPrompt
 distro.tv##.tandc-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://bp.com/

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2499