### PR TITLE
A: sciencebasedmedicine.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -851,7 +851,7 @@ weverse.io###wevConsentManagerLayer
 johnfrederick.co.uk,pestdefence.co.uk###wp-notification
 funnyordie.com###wpautoterms-bottom-fixed-container
 f1forgottendrivers.com###wpcg-box
-acoup.blog,candidcyber.com###wpconsent-root
+acoup.blog,candidcyber.com,sciencebasedmedicine.org###wpconsent-root
 wpx.net###wpx-cookie-agreement
 here.com###wrapper
 groners.com###wrapper_cookiebanner


### PR DESCRIPTION
Hiding cookie notice on sciencebasedmedicine.org with a basic cosmetic filter