### PR TITLE
A: Added cky-overlay class

### DIFF
--- a/easylist_cookie/easylist_cookie_general_hide.txt
+++ b/easylist_cookie/easylist_cookie_general_hide.txt
@@ -15194,6 +15194,7 @@
 ##.cky-box-bottom-left.cky-consent-container
 ##.cky-box-bottom-right.cky-consent-container
 ##.cky-classic-bottom.cky-consent-container
+##.cky-overlay
 ! autoscout24.*
 ###as24-cmp-popup
 ! fixpart.fi https://github.com/easylist/easylist/issues/17478


### PR DESCRIPTION
Added .cky-overlay blocking. This fixes overlay stuck on all websites using CookieYes.

CookieYes is one of the most popular cookie consent plugins for WordPress.
There is a general block that already blocks the consent popup showing, but the overlay stays. It makes websites using CookieYes unusable.

Adding ##.cky-overlay fixes this problem.