### PR TITLE
A: debank.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -949,6 +949,7 @@ support.meduza.io##.GDPRPanel_root__MhcjB
 atoocall.com##.GDPRPopup-module--popup--3chjm
 venngage.com##.GDPR_main__fxmFf
 laufcycles.com##.GdprBanner_banner___hVQl
+debank.com##.GdprModal_container__o2Fpm
 airasia.com##.Gdpr__GdprParentWrapper-sc-z30mcl-0
 tunemymusic.com##.HeaderMenu_CookieAlert__ipEfK
 repost.aws##.Header_terms__3jQyq


### PR DESCRIPTION
Hiding cookie notice on https://debank.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2520