### PR TITLE
A: europa.eu

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -163,6 +163,7 @@ aam-us.org,rodavigo.net###cc-window
 avosound.com###cc_b
 warwickstudentpad.co.uk###cc_cookie_banner
 skargards.com###cc_dialog
+europa.eu###cck_here
 hytale.game###ccm-ui
 ammergauer-zeitgeist.de,sportarena.it,stacherhof-zillertal.at###ccmodal-container
 ovigo.tv###ccnst__main


### PR DESCRIPTION
Hiding cookie notice on https://europa.eu

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2510