### PR TITLE
A: comprasparaguai.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -60,7 +60,7 @@ tracemyip.org###acTOSckBar
 jemako.com###acb-wrapper
 presta-module.com###acbModal
 brulocalis.brussels###acc-bottom
-afriforum.co.za,rumbletalk.com###accept-cookies
+afriforum.co.za,comprasparaguai.com.br,rumbletalk.com###accept-cookies
 sharedinvestigator.com###accept-sip-popup-container
 global.toptoon.com###acceptCookieCon
 readawrite.com###accept_cookie_banner


### PR DESCRIPTION
Hiding cookie notice on https://comprasparaguai.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2525