### PR TITLE
Remove non.li third-party filter from EasyPrivacy

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -308,7 +308,6 @@
 ||mmtro.com^$third-party
 ||netquattro.com/stats/
 ||netvigie.com^$third-party
-||non.li^$third-party
 ||pa-cd.com^$third-party
 ||phywi.org^$third-party
 ||pingclock.net^$third-party


### PR DESCRIPTION
## Summary

Remove the broad `||non.li^$third-party` rule from EasyPrivacy.

## Context

This follows the same false-positive cleanup that was accepted in Liste FR:

- PR: https://github.com/easylist/listefr/pull/294
- Maintainer commit: https://github.com/easylist/listefr/commit/4389c23e83fe2bc628c4e11af40f9e6264338e06

The EasyPrivacy rule appears to come from the 2023 BFMTV report where `l.bfmtv.com` was observed as an alias for `non.li`:

- Original PR: https://github.com/easylist/easylist/pull/15312
- Follow-up issue: https://github.com/easylist/easylist/issues/15960

The current EasyPrivacy rule should be removed because the current Nonli SDK behavior does not match this domain-level tracker classification.

The SDK / analytics tag behavior is documented here:

https://www.nonli.com/en/faq/nonli-sdk-analytics-tag-q-a

That document explains the current production behavior:

- the analytics tag is served from a subdomain of the publisher client's main domain;
- traffic analysis happens on Nonli servers anonymously;
- the tag drops no cookie in the visitor's browser and reads no cookie either;
- no individual visitor journey is reconstructed;
- collected data is anonymized and never consolidated across different domains;
- each brand gets its own isolated editorial measurement;
- the SDK is focused on article traffic analysis and social-publishing decisions, not advertising targeting or user retargeting.

This means the `non.li` domain-level EasyPrivacy rule no longer has a technical reason to exist for the current Nonli service.

The broad rule also creates false positives outside the SDK context. `non.li` is used for legitimate publisher shortlink / redirect infrastructure, so blocking or classifying the whole domain causes downstream products that consume EasyPrivacy-derived domain rules to flag normal publisher links before they even reach the website.

Examples of affected legitimate uses include:

- publisher shortlink / redirect domains such as `l.numerama.com`, which resolve to Nonli redirect infrastructure;
- direct Nonli short links used to redirect readers to publisher content;
- publisher infrastructure where the short URL identifies a public content item, not a person.

The shortener behavior is documented here:

https://www.nonli.com/en/shortener-data-protection

That document explains the current production behavior of Nonli short links:

- a short-link redirect is a plain HTTP redirect;
- the response sets no cookie and serves no script, pixel, or executable content;
- no local storage, fingerprinting, visitor identifier, recipient identifier, session identifier, or user identifier is used;
- the shortener has set no cookie at all since January 22, 2025, so older observations no longer reflect the current service;
- click data is limited to aggregated editorial counters on behalf of the publisher;
- no advertising targeting, profiling, personalized advertising, or individual profile building is performed by Nonli or on its behalf.

Because of that, this EasyPrivacy rule is not an accurate representation of the current service. It also breaks products that flatten ABP-style rules into DNS/app-level tracker lists, where `$third-party` and path context may no longer protect normal publisher SDK or shortlink usage.

With the current production behavior, we do not see a technical reason for keeping `non.li` in EasyPrivacy.

## Verification

- Removed only `||non.li^$third-party` from `easyprivacy/easyprivacy_trackingservers_international.txt`
- Ran `git diff --check`
- Verified there are no remaining `non.li` rules under `easyprivacy/`
