### PR TITLE
A: fixes #24510

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -940,6 +940,7 @@
 /fbevents.min.js
 /fbpix-events-
 /fbpixel.js
+/fcp/v1/i
 /fdmg-tag-manager/tags.js
 /fe_logger?
 /feature/metrics$xmlhttprequest


### PR DESCRIPTION
Blocks a currently unblocked analytics endpoint that can be found on https://www.expedia.com/, https://www.vrbo.com/, https://www.hotels.com/, and many other ExpediaGroup sites