### PR TITLE
A: imax.traumpalast.de

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -97,6 +97,7 @@ laborjournal.de###cookie_popup1
 fondsprofessionell.de###cookieauth
 helaba.com###cookiebannerWrapper
 hsnstore.de###cookiebar-outer
+agoranovale.com.br,gcd.com.br,gmconline.com.br,imax.traumpalast.de###cookieconsent
 digitfoto.de###cookieds
 badoexen.de,bic-zwickau.de,blacksun2.com,butterspender.de,ceramic2000-5.de,die-aufbau.de,dtk1888.de,fantashion.de,ferienhaus-liste.de,fricke-ritschel.de,gdw-mitte.de,gelsenkirchen.de,gub-ing.de,ik-schneeberg.com,integion.de,klein-toys-shop.de,manfred-kunze.de,megabill.de,mentner-krane.de,partnerschaften-weltweit.de,r-pharm.de,simpilio.de,ternitz.at,ternitz.gv.at,tragwerk-und-statik.de,walddorfhaeslach.com,worpswede24.de,zev-energie.de###cookiehinweis
 siebenbuerger.de###cookiehinweiscontainer


### PR DESCRIPTION
Hiding cookie notice on https://imax.traumpalast.de/index.php/PID/11295.html

Fix is in response to user reports on Brave