### PR TITLE
A: worldtabletennis.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3469,7 +3469,7 @@ ferienbon.de,hfm-stb.de,hoffmann-medien.com###Consent
 !! #cc-wrapper
 flanco.ro,ip-adress.com###cc-wrapper
 !! .cc_dialog
-it-notes.dragas.net,krautgartner-bus.at,lehmanns.de,solas.ie,valencia.es##.cc_dialog
+it-notes.dragas.net,krautgartner-bus.at,lehmanns.de,solas.ie,valencia.es,worldtabletennis.com##.cc_dialog
 !! .cc-grower
 lansol.de,simply-yummy.de,volcanoteide.com##.cc-grower
 !! .cb


### PR DESCRIPTION
Hiding cookie notice on https://www.worldtabletennis.com/home

Fix is in response to user reports on Brave