### PR TITLE
A: dahuasecurity.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1898,6 +1898,7 @@ cioapplicationseurope.com,doubleviking.com,fallentitans.com,peakd.com##.footer
 subzero-wolf.com##.footer-announcement
 thesynergydentalpartners.com##.footer-bar
 publicmobile.ca##.footer-consent-main
+dahuasecurity.com##.footer-cookies-box
 clausporto.com##.footer-fixed-bar
 liberal-international.org##.footer-message
 swipe.io##.footer-notice


### PR DESCRIPTION
Hiding cookie notice on https://www.dahuasecurity.com/uk/products/network-products/network-cameras/wizmind-7-series/ir-series/ipc-hdbw71242e1-z-x

Fix is in response to user reports on Brave