### PR TITLE
A: daihachisushi.at

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -276,6 +276,7 @@ slewo.com##.banner_ack
 kontist.com,refurbed.de##.bg-opacity-50
 fembio.org,natur.com##.bg-wg-modal
 inreifen.de##.bgDim
+daihachisushi.at##.bit-cookiewall
 hausschuh.com,hausschuhexperte.de##.blackBody
 blm.de##.blm-consent-modal__wrapper
 nijlen.be##.block-messages


### PR DESCRIPTION
Hiding cookie notice on https://daihachisushi.at

Fix is in response to user reports on Brave