### PR TITLE
A: geschmackvonasien.de

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3475,7 +3475,7 @@ lansol.de,simply-yummy.de,volcanoteide.com##.cc-grower
 !! .cb
 adammendrek.cz,airsoft.ch,iuav.it,racius.com##.cb
 !! .CA
-drago.cz,efkoart.cz,ellexgk.cz,eltasat.cz,fizishop.cz,jagrteam.cz,kawio.cz,kniharina.cz,majkl3d.cz,majkl3d.sk,marusik.cz,niwa.cz,softcotton.pl,top-dent.cz,woolife.cz##.CA
+drago.cz,efkoart.cz,ellexgk.cz,eltasat.cz,fizishop.cz,geschmackvonasien.de,jagrteam.cz,kawio.cz,kniharina.cz,majkl3d.cz,majkl3d.sk,marusik.cz,niwa.cz,softcotton.pl,top-dent.cz,woolife.cz##.CA
 !! .cookie-text
 crimetime.com,elba.sk,karakartal.com,kartelluk.com,pmkariyer.com,sarsilmaz.com,superfb.com,webaslan.com##.cookie-text
 !! .cb-overlay


### PR DESCRIPTION
Hiding cookie notice on https://www.geschmackvonasien.de/p/t-best-zitrus-yuzu-tee-1-kg

Fix is in response to user reports on Brave