### PR TITLE
A: m.veloxtickets.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -644,6 +644,7 @@ apkpure.com,apkpure.net###policy-info
 eccles.utah.edu###policy-message
 fgcu.edu###policy-notification
 blaze.com###policy-regulation-popup
+m.veloxtickets.com###policyAlert
 merlion.com###policyBlockForFirstVisit
 orderofmalta.org.hk###policy_privacy
 nba.com###policy_wrapper


### PR DESCRIPTION
Hiding cookie notice on https://m.veloxtickets.com/Portal/Login

Fix is in response to user reports on Brave