### PR TITLE
A: nextbase.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2265,7 +2265,7 @@ businessoffashion.com##.navbar-notification
 freeimages.com##.navbar-qards
 bloomberg.com##.navi-terms-of-service
 orkney.com,shetland.org##.nb-cookie-consent-modal
-nextbase.com##.nb-cookies-container
+nextbase.co.uk,nextbase.com##.nb-cookies-container
 userbenchmark.com##.nb-parent
 wik-walsoe.com##.ncm-ready
 ncts.ie##.nctoverlay


### PR DESCRIPTION
Hiding cookie notice on https://nextbase.co.uk/dash-cams

Fix is in response to user reports on Brave