### PR TITLE
A: dailykos.com

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -389,6 +389,7 @@ $third-party,xmlhttprequest,domain=mega4upload.net
 ||instagram.com/api/v1/injected_story_units/
 ||interestingengineering.com/js/recovery.js
 ||intersc.igaming-service.io^$domain=hltv.org
+||introjava.com^
 ||investing.com/jp.php
 ||iono.fm/ads/
 ||ip-secrets.com/img/nv


### PR DESCRIPTION
bottom sticky banner ad appears after the soft Admiral wall is dismissed, takes a few seconds to load.

Tested on Chrome with ABP, using EasyList & ABP Filters

appears on homepage or subpage, for example `https://www.dailykos.com/stories/2026/6/29/800062732/community/pwb-peeps-emergency-diary/`

<img width="1600" height="834" alt="dailykos" src="https://github.com/user-attachments/assets/8cbde0e0-0c2c-44b6-a786-bd8b85af6b9e" />
