### PR TITLE
P: https://www.suwen.com.tr/

### DIFF
--- a/fanboy-addon/fanboy_chatapps_third-party.txt
+++ b/fanboy-addon/fanboy_chatapps_third-party.txt
@@ -198,7 +198,6 @@ vectara.com##react-chatbot
 ||onwebchat.com^$third-party
 ||pageview.activengage.com^
 ||paradox.ai^$third-party
-||personaclick.com^$third-party
 ||phenompeople.com/txm-bot/prod/prod.js
 ||phplivesupport.com^$third-party
 ||podium.com^$third-party


### PR DESCRIPTION
This is an e-commerce personalization and marketing automation tool rather than a chat app. Keeping personaclick.com in this filter causes extensive breakages on numerous major shopping sites, leading to massive false positives. Please see the specific breakdown below.

---

suwen.com.tr

The search function is completely broken; clicking on the search input box yields no response.

<details><summary>Screenshot</summary>

<img width="1365" height="215" alt="suwen" src="https://github.com/user-attachments/assets/c6421e75-8946-45a1-8aea-93f8673903f4" />


</details>

---

bellamaison.com

The search functionality is partially broken.

Most product sliders on the homepage are completely blocked.

Product recommendation widgets at the bottom of product pages, such as "Bunu alanlar bunu da aldı" (Customers Also Bought) , fail to load.

Affected page: https://www.bellamaison.com/oud-serenity-oda-koku-seti-p8681790173680

<details><summary>Screenshot</summary>

<img width="1351" height="1857" alt="bella" src="https://github.com/user-attachments/assets/9fe38215-ca95-4ce2-8f7c-3b9b33510d9f" />


</details>

---

enplus.com.tr

The story widget on the homepage is blocked.

<details><summary>Screenshot</summary>

<img width="1321" height="589" alt="enplus1" src="https://github.com/user-attachments/assets/4f691db5-258f-47ba-8458-b3ed8853ed05" />


</details>

The "Beğenebileceğiniz Ürünler" (You May Also Like) and "Birlikte Alınan Ürünler" (Frequently Bought Together) widgets at the bottom of product pages are blocked.

Affected page: https://www.enplus.com.tr/ziipa-rio-pizza-kesici-21265

<details><summary>Screenshot</summary>

<img width="1352" height="768" alt="image" src="https://github.com/user-attachments/assets/bada7271-8881-43dc-8ea3-559141427724" />


</details>

---

koctas.com.tr

Homepage widgets like "Çok Satan Ürünler" (Bestsellers) are blocked.

<details><summary>Screenshot</summary>

<img width="1203" height="768" alt="koc1" src="https://github.com/user-attachments/assets/be22f680-a72c-4738-9a0c-6a43557f5756" />


</details>

The "Benzer Ürünler" (Similar Products) widget at the bottom of product pages is blocked.

Affected page: https://www.koctas.com.tr/bestway-buyuk-havuz-57270/p/2000030182

<details><summary>Screenshot</summary>

<img width="1244" height="768" alt="koc2" src="https://github.com/user-attachments/assets/ac6cb492-12e2-4cd4-9190-1818f201ad95" />


</details>

---

victoriassecret.com.tr

The search functionality is partially broken.

Campaign and promotional banners showcasing deals on the homepage are blocked.

<details><summary>Screenshot</summary>

<img width="1344" height="2808" alt="victoria" src="https://github.com/user-attachments/assets/3e67938a-726d-4662-a5c9-3e71c5587c5a" />


</details>

---

englishhome.com

The main campaign banner at the very top of the website is blocked.

<details><summary>Screenshot</summary>

<img width="1350" height="403" alt="eng1" src="https://github.com/user-attachments/assets/27054141-53da-4163-a542-e5ab5cf4cffc" />


</details>

The "Birlikte Alınabilecek Ürünler" (Frequently Bought Together) widget at the bottom of the page is blocked.

<details><summary>Screenshot</summary>

<img width="1232" height="698" alt="eng2" src="https://github.com/user-attachments/assets/ba86458b-0085-4bc0-bcd8-e3169fdbe4f8" />


</details>

Affected page: https://www.englishhome.com/diagonal-pamuk-el-havlusu-30x40-cm-gri-30671
