### PR TITLE
A: tfw.wales

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -116,6 +116,7 @@ aliciagame.com###block-block-6
 sfcta.org###block-cookienotice
 bsa.org###block-cookiepolicy
 gim.ac.in###block-cookies
+tfw.wales###block-cookiesui
 london-dental-implant.co.uk###block-london-cookies
 merkle.com,merkleinc.com###block-security-block
 ncaa.com###block-termsofservice


### PR DESCRIPTION
Hiding cookie notice on https://tfw.wales/places/attractions/chepstow-castle

Fix is in response to user reports on Brave