### PR TITLE
A: servershop24.de

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -577,6 +577,7 @@ watson.ch##.watson-cookie-footer
 mahlerundco.ch##.webzeit-cookiebanner
 hatex24.de##.widget-EyeCatcher
 rademacher.de##.widget-EyeCatcher--dropzone---preset-fixed
+servershop24.de##.widget-cookie-bar
 badkeramik.de##.wpt-cc-banner
 schulze-immobilien.de##.wrap__undone
 warthunder.de##.wt-cb


### PR DESCRIPTION
Hiding cookie notice on https://www.servershop24.de

Fix is in response to user reports on Brave