### PR TITLE
M: https://github.blog/open-source/git/highlights-from-git-2-55/

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -56,7 +56,7 @@ trip.com##.A9zea:has([aria-label*="Hi! TripGenie"])
 ndtv.com,ndtv.in##.ASum_wr
 search.yahoo.co.jp##.AiAssistant
 search.yahoo.co.jp##.AnswerAiNavigation
-github.blog##.Button[href="https://github.com/features/copilot"]
+github.blog##.Button[href^="https://github.com/features/copilot"]
 coinmarketcap.com##.FloatingAiChat_floatingAiChatContainer__YJK16
 search.yahoo.co.jp##.Unit__naturalText
 sciencedirect.com##._pendo-guide-walkthrough_


### PR DESCRIPTION
Fixes an AI Annoyance on the GitHub Blog Website.

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/45ddf004-c6a6-4aa2-bc46-4760542cc929" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6b7c031c-1744-438c-9821-c6d1ea592af5" />
