### PR TITLE
A: skapamer.se

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3476,6 +3476,7 @@ kulturbolaget.se##.c-messages
 swestat.se##.c-w
 inet.se##.c1hsuii6
 eidar.se##.cc-page
+skapamer.se##.ccConsentHolder
 liberalerna.se##.ccnt-app
 buyersclub.se##.component\:cookie-consent-dialog
 jak.se##.consent-backdrop


### PR DESCRIPTION
Hiding cookie notice on https://www.skapamer.se/band-dekorband

Fix is in response to user reports on Brave