### PR TITLE
A: ritani.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -262,6 +262,7 @@ idp.vodafone.com,shopto.net,snodlandsurgery.org.uk###cookie-consent-wrapper
 amnesty.org###cookie-consent__modal
 autism-unlimited.org###cookie-cover
 asianlemansseries.com,bio-rad-antibodies.com###cookie-dialog
+ritani.com###cookie-info-banner
 keywordsstudios.com,uofmhealth.org###cookie-law
 cpac.ca###cookie-law-bar-holder
 ecigarettedirect.co.uk###cookie-message-slide-in


### PR DESCRIPTION
Hiding cookie notice on https://www.ritani.com/blogs/education/different-types-of-ring-finishes

Fix is in response to user reports on Brave