### PR TITLE
P: blog.sport24wire.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -780,6 +780,7 @@ food52.com###jw_iframe
 variety.com###jwplayer_xH3PjHXT_plsZnDJi_div
 jigzone.com###jz
 ceoexpress.com###kalamazooDiv
+blog.sport24wire.com###kk-adblock-overlay
 msguides.com###kknbnpcv
 kohls.com###kmn-featured-carousel
 kohls.com###kmnsponsoredbrand-sponsored_top-anchor

--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -780,7 +780,7 @@ food52.com###jw_iframe
 variety.com###jwplayer_xH3PjHXT_plsZnDJi_div
 jigzone.com###jz
 ceoexpress.com###kalamazooDiv
-blog.sport24wire.com###kk-adblock-overlay
+blog.riyadahnews.com,blog.sport24wire.com###kk-adblock-overlay
 msguides.com###kknbnpcv
 kohls.com###kmn-featured-carousel
 kohls.com###kmnsponsoredbrand-sponsored_top-anchor


### PR DESCRIPTION
These sites had an anti-adblock popup. To dismiss this popup, we can simply hide it using a cosmetic filter. The site appears to work as expected after hiding the popup.

Fixes https://github.com/brave-experiments/spiking-webcompat-reports/issues/2102
Fixes https://github.com/brave-experiments/spiking-webcompat-reports/issues/2101