### PR TITLE
A: fertisuisse.ch

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1617,7 +1617,7 @@ atlanticahotels.com##.cookieagreement
 iqtree.github.io##.cookiealert
 hs-bremen.de,worldbook.com##.cookiebanner
 plitch.com##.cookiebar-overlay
-spotlight.cn##.cookiebox
+fertisuisse.ch,spotlight.cn##.cookiebox
 paymentcloudinc.com##.cookiebtn
 etias.com,s-iq.co##.cookieconsent
 bairdwarner.com##.cookieinfo


### PR DESCRIPTION
Hiding cookie notice on https://www.fertisuisse.ch/en

Fix is in response to user reports on Brave