### PR TITLE
A: chavesnamao.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2636,6 +2636,7 @@ direcaoconcursos.com.br##.sc-faada46b-0
 runrun.it##.sc-iBYQkv
 soustix.com.br##.sc-jONmMj
 brainly.com.br##.section--3Yobl
+chavesnamao.com.br##.style_Consent__cE_Gj
 trustvox.com.br##.style__Wrapper-sc-1u0uhw7-0
 pernambucanas.com.br##.styles__CookieContent-sc-16mpd2a-0
 rdstation.com##.syn-container-banner1


### PR DESCRIPTION
Hiding cookie notice on https://chavesnamao.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2563