### PR TITLE
A: sedeelectronica.sic.gov.co

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3427,6 +3427,7 @@ iryo.eu##wc-cookies-manager
 vw.com.mx###ensNotifyBanner
 loging.mk##.showBackdrop
 loging.mk##.showConsent
+sedeelectronica.sic.gov.co##[aria-label="Aviso de cookies"]
 !
 ! ---------- Catalan ----------
 !


### PR DESCRIPTION
Hiding cookie notice on https://sedeelectronica.sic.gov.co

Fix is in response to user reports on Brave