### PR TITLE
A: Newsletters on valnet sites

### DIFF
--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1214,7 +1214,7 @@ grid.news##.footer-daily-drop
 sneakernews.com##.footer-email-subscribe
 medicalxpress.com,paloaltonetworks.com,phys.org,techxplore.com##.footer-form
 minitool.com##.footer-join-wrapper
-androidpolice.com,backyardboss.net,carbuzz.com,cbr.com,collider.com,dualshockers.com,footballfancast.com,footballleagueworld.co.uk,gamerant.com,givemesport.com,hardcoregamer.com,hotcars.com,howtogeek.com,kunstenfestivalwatou.be,makeuseof.com,movieweb.com,pocket-lint.com,screenrant.com,simpleflying.com,thegamer.com,thesportster.com,therichest.com,thethings.com,thetravel.com,topspeed.com,xda-developers.com##.footer-newsletter
+androidpolice.com,backyardboss.net,carbuzz.com,cbr.com,collider.com,dualshockers.com,footballfancast.com,footballleagueworld.co.uk,gamerant.com,givemesport.com,hardcoregamer.com,hotcars.com,howtogeek.com,kunstenfestivalwatou.be,makeuseof.com,movieweb.com,pocket-lint.com,screenrant.com,simpleflying.com,thegamer.com,therichest.com,thesportster.com,thethings.com,thetravel.com,topspeed.com,xda-developers.com##.footer-newsletter
 letsencrypt.org##.footer-newsletter-col
 moonpalacecancun.com##.footer-newsletter__form
 butternutbakeryblog.com##.footer-optin

--- a/fanboy-addon/fanboy_newsletter_specific_hide.txt
+++ b/fanboy-addon/fanboy_newsletter_specific_hide.txt
@@ -1214,7 +1214,7 @@ grid.news##.footer-daily-drop
 sneakernews.com##.footer-email-subscribe
 medicalxpress.com,paloaltonetworks.com,phys.org,techxplore.com##.footer-form
 minitool.com##.footer-join-wrapper
-kunstenfestivalwatou.be##.footer-newsletter
+androidpolice.com,backyardboss.net,carbuzz.com,cbr.com,collider.com,dualshockers.com,footballfancast.com,footballleagueworld.co.uk,gamerant.com,givemesport.com,hardcoregamer.com,hotcars.com,howtogeek.com,kunstenfestivalwatou.be,makeuseof.com,movieweb.com,pocket-lint.com,screenrant.com,simpleflying.com,thegamer.com,thesportster.com,therichest.com,thethings.com,thetravel.com,topspeed.com,xda-developers.com##.footer-newsletter
 letsencrypt.org##.footer-newsletter-col
 moonpalacecancun.com##.footer-newsletter__form
 butternutbakeryblog.com##.footer-optin


### PR DESCRIPTION
Newsletter box in footer of various valnet-owned sites.

A generic rule for these items exists, but it gets overridden with a `@@*$generichide` on the sites added to this list.

Excluded polygon.com since no such override exists on that site.