### PR TITLE
A: rewards.bing.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -282,6 +282,7 @@ letsdothis.com###cookieAcceptanceModal
 rsvp.withgoogle.com###cookieBarWrapper
 egamersworld.com###cookieBot
 e-hapi.com###cookieBox
+rewards.bing.com###cookieConsentContainer
 cambridgeparkandride.info###cookieConsentDialog
 investtech.com###cookieConsentDialogue
 khronos.org###cookieConsentForm


### PR DESCRIPTION
Hiding cookie notice on https://rewards.bing.com/dashboard

Fix is in response to user reports on Brave