### PR TITLE
Add xm cookie modal

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4051,6 +4051,7 @@ x.com##.rn-gvpnoh.rn-eps6nq.rn-13qz1uu
 ! Custom Filters
 xm.com##.cdk-overlay-container:has(xm-cookie-modal-main)
 primevideo.com##.DVWebNode-conditional-site-wide-wrapper:has([data-testid="consent-reject-all-endpoint"])
+xm.com##.cdk-overlay-container:has(xm-cookie-modal-main)
 sonarhome.pl##.fixed:has(.cookies-scrollbar)
 kcrw.com##.paragraph.d-flex.align-items-center:has(We only use a few essential cookies)
 studocu.com##.undefined:has([data-test-selector="click-the-cookie-banner"])

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4049,6 +4049,7 @@ x.com##.r-13qz1uu.r-tvv088.r-d9fdf6.r-1d7fvdj.r-18u37iz.r-qo02w8.r-1m3jxhj.r-1aw
 x.com##.r-5kkj8d.r-153w4nv.r-1e4ma89.r-qq4cyc.css-175oi2r
 x.com##.rn-gvpnoh.rn-eps6nq.rn-13qz1uu
 ! Custom Filters
+xm.com##.cdk-overlay-container:has(xm-cookie-modal-main)
 primevideo.com##.DVWebNode-conditional-site-wide-wrapper:has([data-testid="consent-reject-all-endpoint"])
 sonarhome.pl##.fixed:has(.cookies-scrollbar)
 kcrw.com##.paragraph.d-flex.align-items-center:has(We only use a few essential cookies)


### PR DESCRIPTION
Steps to Reproduce (STR)

Clear all cookies/site data for xm.com.
Enable Brave Shields and load xm.com .
Attempt to click "Start Trading" or the hamburger menu.
Result: Click events are swallowed by the invisible overlay container.
Fix
Added a procedural filter targeting .cdk-overlay-container only when it contains xm-cookie-modal-main to clear the un-clickable layout layer without interfering with other potential system modals.