### PR TITLE
A: async.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1166,6 +1166,7 @@ ztedevices.com##.as-cookie
 leo.org##.as-oil
 scinapse.io##.asUhxHVGRjM9QNWMLelO5
 icelandair.com##.assets_container__3EEp3
+async.com##.async-footer-cookie-banner
 subaru.com##.at-banner-container
 landsend.com##.at-gdpr-msg
 atptour.com##.atp_cookie-message


### PR DESCRIPTION
Hiding cookie notice on https://async.com/blog/how-to-find-and-watch-spotify-video-podcasts

Fix is in response to user reports on Brave