### PR TITLE
A: autokrs.cz

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3304,7 +3304,7 @@ flexispot.co.uk,flexispot.de,flexispot.es,flexispot.it,flexispot.nl,flexispot.pl
 !! .swal2-container
 kyounoryouri.jp,outage.report##.swal2-container
 !! .cc-container
-comfeel.cz,drpalani.com,easygujaratityping.com,fibt.com,joberty.com,majordentalclinics.com,parkovaniplzen.cz,pidentists.com,studentbostader.se,viciunaigroup.eu,westlaimplants.com##.cc-container
+autokrs.cz,comfeel.cz,drpalani.com,easygujaratityping.com,fibt.com,joberty.com,majordentalclinics.com,parkovaniplzen.cz,pidentists.com,studentbostader.se,viciunaigroup.eu,westlaimplants.com##.cc-container
 !! #cc-container
 busterplugholes.com.sg,charleslandaudentistry.co.uk,weptech.de###cc-container
 !! .modal-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://www.autokrs.cz

Fix is in response to user reports on Brave