### PR TITLE
A: bloxd.io

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -989,6 +989,7 @@ rows.com##.PnyGo
 midasbuy.com##.PopCookie_active__UWi7E
 themattresswarehouse.co.za##.PopiBanner__PopiContainer-igharm-1
 cs.money##.Popover_wrapper__feCxt
+bloxd.io##.PopupNotification
 cjbayliss.co.uk,hcdltd.com##.PopupOverall
 powercolor.com##.Privacy
 cvte.com##.Privacy-popup


### PR DESCRIPTION
Hiding cookie notice on https://bloxd.io

Fix is in response to user reports on Brave