### PR TITLE
A: davines.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2671,7 +2671,7 @@ chatreplay.stream##.svelte-dx0l3i
 revanced.app##.svelte-fnvau2
 haier.com##.swiper-slide-img-txt
 taschen.com##.switch-prompt
-bp.com,us.davines.com##.syrenis-cookie-widget
+bp.com,davines.com,us.davines.com##.syrenis-cookie-widget
 amplitude-studios.com,games2gether.com##.system-notification-container
 termly.io##.t-consentPrompt
 distro.tv##.tandc-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://www.davines.com

Fix is in response to user reports on Brave