### PR TITLE
A: dsrtashburton.org.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2004,6 +2004,7 @@ hivehome.com##.header-stacked-message
 uspatriottactical.com##.header-top-banner
 start.fyi##.headnote
 aerostar.com##.hello-bar
+dsrtashburton.org.uk##.hide-cookie-icon
 go.davidcandaux.com##.hl-cookie-consent-banner
 hmart.com##.hmartus-store-theme-1-x-cookiesModal__wrapper
 acquire.io##.home-announcement


### PR DESCRIPTION
Hiding cookie notice on https://dsrtashburton.org.uk/sarloc-a-method-for-locating-lost-climbers-and-walkers

Fix is in response to user reports on Brave