### PR TITLE
A: getintonewcastle.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1304,7 +1304,7 @@ desiindian-brighton.co.uk,royalspiceworthing.com##.bxUGXS
 perlego.com##.bzGIHv
 shadowserver.org##.c--gdpr-message
 monopo.london##.c-AppCookies
-co-wheels.org.uk,ecologicalbuildingsystems.com,livingnorth.com,northumberlandcoast-nl.org.uk##.c-CookieConsent
+co-wheels.org.uk,ecologicalbuildingsystems.com,getintonewcastle.co.uk,livingnorth.com,northumberlandcoast-nl.org.uk##.c-CookieConsent
 audiotag.info##.c-agree
 jobs.ch,jobup.ch##.c-alert
 sunweb.co.uk##.c-backdrop


### PR DESCRIPTION
Hiding cookie notice on https://www.getintonewcastle.co.uk/offers/persia-restaurant/restaurant-week-at-persia-restaurant

Fix is in response to user reports on Brave