### PR TITLE
A: hometogo.se

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3532,6 +3532,7 @@ sodrateatern.com##.styles__CookiebarWrap-g5ab7n-0
 verktygsboden.se##.wp27nvx
 hemfrid.se##.xdmFo
 inet.se##[aria-label="Cookies"]
+hometogo.se##[data-test="cookie-consent-notification"]
 elfynd.se##[style="position: fixed; bottom: 0px; left: 0px; right: 0px;"]
 blockbuster.dk,sfanytime.com##div[class^="GlobalCookieBanner__"]
 hejalbert.se##div[class^="styles_cookiesContainer_"]


### PR DESCRIPTION
Hiding cookie notice on https://www.hometogo.se/rental/68a3c056c85f87e0d2c4831b427c7f00

Fix is in response to user reports on Brave