### PR TITLE
A: librariaonline.ro

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3318,7 +3318,7 @@ batteryequivalents.com,camara.net,culturagiapponese.it,imunify360.com,instituto-
 !! favoptic.*
 favoptic.fi,favoptic.no##.cookie_consent_alert
 !! #cookiePolicy
-absa.co.za,bdonline.co.uk,eutelsat.com,fieldsofskibbereen.ie,fullraces.com,gamesontvtoday.com,sciencelink.net,support.tresorit.com,thegrocer.co.uk,torrents.ws,wifikaernten.at,worldfishing.net###cookiePolicy
+absa.co.za,bdonline.co.uk,eutelsat.com,fieldsofskibbereen.ie,fullraces.com,gamesontvtoday.com,librariaonline.ro,sciencelink.net,support.tresorit.com,thegrocer.co.uk,torrents.ws,wifikaernten.at,worldfishing.net###cookiePolicy
 !! .custom-consent
 emerald-heizijde.be,rivo.be,upperleft.be,vooruitzicht.be##.custom-consent
 !! #CookiePolicy


### PR DESCRIPTION
Hiding cookie notice on https://www.librariaonline.ro/autori/mironescu_alexandru

Fix is in response to user reports on Brave