### PR TITLE
A: offi.fr

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -793,7 +793,7 @@ equilar.com,ffonts.net,whatfontis.com###sticky-popup
 firefoxosdevices.org###storage-notice
 strava.com###stravaCookieBanner
 streamify.io###streamify-gdpr
-deboulle.com###tarteaucitronAlertBig
+deboulle.com,offi.fr###tarteaucitronAlertBig
 tatsubuilder.com###tatsu-header-container
 buccellati.com,kiabi.com###tc-privacy-wrapper
 kaec.net,thelawpages.com###terms


### PR DESCRIPTION
Hiding cookie notice on https://www.offi.fr/cinema/ugc-cine-cite-la-defense-3317.html

Fix is in response to user reports on Brave