### PR TITLE
A: rkop.nl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1246,6 +1246,7 @@ eneco.nl,oxxio.nl##.c-kJrTin
 groene.nl##.c-notice
 qps.nl##.cc--window
 medischcontact.nl,muizenkwijt.nl##.cc-popup
+rkop.nl##.cc-root
 bouter.nl##.cc_root
 fiber.nl##.ccm-banner-small
 fiber.nl##.ccm-bottom-slide


### PR DESCRIPTION
Hiding cookie notice on https://rkop.nl

Fix is in response to user reports on Brave