### PR TITLE
A: thesignalgroup.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1727,7 +1727,7 @@ unitedpets.com##.cupjma
 greats.com##.custom-onetrust-banner
 princetonreview.com##.customer-cookie-container
 tannoy.com##.cv2-wrapper
-grassfeld.com,hockeystack.com,sogni.ai##.cw-cookies
+grassfeld.com,hockeystack.com,sogni.ai,thesignalgroup.com##.cw-cookies
 careerswales.gov.wales##.cw-cookies-policy-banner
 tonies.com##.cwJWme
 eoportal.org##.cy-cookie-popup


### PR DESCRIPTION
Hiding cookie notice on https://www.thesignalgroup.com/weekly-market-monitor

Fix is in response to user reports on Brave