### PR TITLE
A: tomods-ap.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -282,7 +282,7 @@ letsdothis.com###cookieAcceptanceModal
 511mt.net###cookieBannerHolder
 rsvp.withgoogle.com###cookieBarWrapper
 egamersworld.com###cookieBot
-e-hapi.com###cookieBox
+e-hapi.com,tomods-ap.com###cookieBox
 rewards.bing.com###cookieConsentContainer
 cambridgeparkandride.info###cookieConsentDialog
 investtech.com###cookieConsentDialogue


### PR DESCRIPTION
Hiding cookie notice on https://tomods-ap.com/shop/default.aspx

Fix is in response to user reports on Brave