### PR TITLE
A: trendoby.net

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1211,6 +1211,7 @@ enen.eu##.basel-cookies-popup
 prestamarketing.com##.basicLightbox
 batchgeo.com##.batchgeo-cookie-notice
 bbc.com##.bbc-bmxm2b
+trendoby.net##.bcb3a172
 band.us##.bcm_bandCookieModuleWrap
 opentip.kaspersky.com##.bd80ac
 pushkin.institute##.beono-flashmessage


### PR DESCRIPTION
Hiding cookie notice on https://trendoby.net

Fix is in response to user reports on Brave