### PR TITLE
A: pinterest.com

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -218,6 +218,9 @@ www.yahoo.com#?#.dark\:bg-\[\#1d2228\].leading-5:has-text(See a mistake?)
 www.youtube.com##yt-video-description-youchat-section-view-model
 studio.youtube.com##ytcp-creator-chat-trigger
 www.youtube.com##ytd-talk-to-recs-flow-renderer
+www.pinterest.com##*[data-test-id="more-ideas-container"]
+www.pinterest.com##*[data-test-id="related-interests-multi-column-module"]
+www.pinterest.com##.zEVE_X.gHrR3r._xSIdT._tKaHB.ADXRXN:has(div:has(div:has-text("Related searches")))
 ! Network items
 ||askmiso.com^$third-party
 ||asus-brand-assistant.asus.com/brand-assistant.js


### PR DESCRIPTION
Blocks the "more like this" footer and the in-grid "related searches" and "related interests" boxes. 

Hidden elements:
<img width="259" height="305" alt="image" src="https://github.com/user-attachments/assets/1c3b036b-6b00-4536-87e6-aa8353f09bf8" />

<img width="535" height="487" alt="image" src="https://github.com/user-attachments/assets/ce8e36bd-d69d-4e60-b831-b48e0f13a904" />

<img width="1395" height="475" alt="image" src="https://github.com/user-attachments/assets/7570ae2c-79e2-4dc2-9403-e2452da0761e" />

