### PR TITLE
A: wwin.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1695,6 +1695,7 @@ itv.com##.cp_dialog
 drafty.co.uk##.cpc-float
 deployhq.com##.crumbs-banner
 odds.am##.cs
+wwin.com##.cs-bottom-popup
 louisvuitton.com##.cs_banner
 audeze.com,kato-brand.com,talkingtables.co.uk,urban-planet.com##.csm-cookie-consent
 mobian.dev##.css-14g2en8


### PR DESCRIPTION
Hiding cookie notice on https://wwin.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2630