### PR TITLE
A: betao.bet.br

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,6 +2491,7 @@ sahisaudavel.com.br###wpconsent-root
 xalingo.com.br###wrng-agrmnt
 extramercado.com.br,paodeacucar.com##.Alert-sc-ubrksr-0
 shopee.com.br##.BC_VN9
+betao.bet.br##.CookieConsent-module-scss-module__TLuOPq__banner
 fiat.com.br##.CookieHolder_container__23g0s
 morana.com.br##.DykGo.sc-crzoAE
 magazineluiza.com.br##.FSeli


### PR DESCRIPTION
Hiding cookie notice on https://betao.bet.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2623