### PR TITLE
A: bioenergetic.hu

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1659,6 +1659,7 @@ bonuszbrigad.hu##.newASZFLayer2
 4ig.hu##.not01-notification-container
 atlatszo.hu##.popup_window
 brendon.hu##.position-fixed
+bioenergetic.hu##.rb-cookiealert-cover-page
 orvosilexikon.hu##.region-bottom
 bestdoor.hu##.rstbox
 telekom.hu##.sze2020-container


### PR DESCRIPTION
Hiding cookie notice on https://bioenergetic.hu/konyvek/agytakaritas

Fix is in response to user reports on Brave