### PR TITLE
A: store.metabase.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -952,6 +952,7 @@ kyivindependent.com##.Footer_cookies__3_gEh
 debenhams.com##.FqVeA
 icodrops.com##.Ftr-Note
 tjc.co.uk##.GDPR
+store.metabase.com##[class^="GDPRCookieNotice"]
 support.meduza.io##.GDPRPanel_root__MhcjB
 atoocall.com##.GDPRPopup-module--popup--3chjm
 venngage.com##.GDPR_main__fxmFf

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -952,7 +952,6 @@ kyivindependent.com##.Footer_cookies__3_gEh
 debenhams.com##.FqVeA
 icodrops.com##.Ftr-Note
 tjc.co.uk##.GDPR
-store.metabase.com##[class^="GDPRCookieNotice"]
 support.meduza.io##.GDPRPanel_root__MhcjB
 atoocall.com##.GDPRPopup-module--popup--3chjm
 venngage.com##.GDPR_main__fxmFf
@@ -2885,6 +2884,7 @@ artist.mnetplus.world##[class^="CookieCustomBottomSheet"]
 marineserre.com##[class^="CookiePopin_"]
 bitbrain.com##[class^="CookiesManager"]
 btc-alpha.com##[class^="Cookies_container"]
+store.metabase.com##[class^="GDPRCookieNotice"]
 bookscouter.com##[class^="NoticePopupWrapper"]:has([href="/privacy"])
 app.revolut.com##[class^="Overlay__OverlayBase-sc-"]
 signin.rockstargames.com##[class^="RockstarCookiesBanner_"]


### PR DESCRIPTION
Hiding cookie notice on https://store.metabase.com/checkout

Fix is in response to user reports on Brave