### PR TITLE
A: fmi.co.jp

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1976,6 +1976,7 @@ studyinjapan.go.jp##.cookieConsentLayout
 his-mobile.com##.cookieagree
 kani-honke.co.jp##.cookiediag
 octoparse.jp##.cookies_cookies__dWLfO
+fmi.co.jp##.f-cookie
 tjapan.jp##.fixed_banner
 imobie.jp##.fixedbot
 museum.seiko.co.jp##.footer_disclaimer


### PR DESCRIPTION
Hiding cookie notice on https://www.fmi.co.jp/products/brand/blendtec-blendtec

Fix is in response to user reports on Brave