### PR TITLE
A: maciej.je

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -423,6 +423,7 @@ nextjs.org,vercel.com,wetransfer.com###fides-banner-container
 cntraveller.com,nytimes.com,surveymonkey.com###fides-overlay
 aitopics.org###fixed-footer
 toffeeweb.com###fixedFooter
+maciej.je###flexiblecookies_container
 metatrader4.com###float-vertical-panel
 deriv.com###flowappz-cookie-consent
 financesonline.com###fodp-cookies-consent


### PR DESCRIPTION
Hiding cookie notice on https://maciej.je

Fix is in response to user reports on Brave