### PR TITLE
A: gonet.tv

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2288,6 +2288,7 @@ aterima-work.pl##.cm-popup-wrapper
 pracuj.pl##.cmulq7z
 sklep.szprychy.com##.config-messages
 rozetka.pl##.consent-layout
+gonet.tv##.consent_form_basic
 ercomer.pl,miodykrupiec.pl,motohid.pl,planszostrefa.pl,questsport.shop,skarbyroztocza.com##.consents
 isystemy.pl##.cookie-div-main
 polczat.pl##.cookie-notification


### PR DESCRIPTION
Hiding cookie notice on https://www.gonet.tv/pl

Fix is in response to user reports on Brave