### PR TITLE
A: asc-pro.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2172,6 +2172,7 @@ strefabiznesu.pl###cross-dialog
 federacja-konsumentow.org.pl,pewnykantor.pl###cu_bar
 redbullmobile.pl###didomiBlockNavigation
 kinonh.pl###div_ac
+asc-pro.pl###flexiblecookies_container
 elektrykasklep.pl###ftccbcmd
 idream.pl###garua_cookie_consent_popup
 grupapracuj.pl###gp_cookie_agreements


### PR DESCRIPTION
Hiding cookie notice on https://www.asc-pro.pl

Fix is in response to user reports on Brave