### PR TITLE
A: sharpconsumer.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2386,6 +2386,7 @@ ktomalek.pl##.ui-dialog[aria-describedby="cookies"]
 ktomalek.pl##.ui-dialog[aria-describedby="cookies"] ~ .ui-widget-overlay
 omegasoft.pl##.ui-widget-content
 optyczne.pl##.w3-modal
+sharpconsumer.pl##.webikon-cookies-bar
 zajezdniaannopol.pl##.widgets-5
 basenyogrodowe.pl,yoclub.pl##.x13eucookies
 strefamocy.pl##.x13eucookies__backdrop


### PR DESCRIPTION
Hiding cookie notice on https://www.sharpconsumer.pl

Fix is in response to user reports on Brave