### PR TITLE
A: nubia.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1163,7 +1163,7 @@ annualreviews.org##.ar-news-footer
 argaam.com##.argaam-policy
 kingscross.co.uk##.argent_consent
 linkedin.com##.artdeco-global-alert
-ztedevices.com##.as-cookie
+nubia.com,ztedevices.com##.as-cookie
 leo.org##.as-oil
 scinapse.io##.asUhxHVGRjM9QNWMLelO5
 icelandair.com##.assets_container__3EEp3


### PR DESCRIPTION
Hiding cookie notice on https://www.nubia.com/en

Fix is in response to user reports on Brave