### PR TITLE
A: 2game.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -754,7 +754,6 @@ arcade1up.com,infinitygametable.com###shopify-section-cookies_consent
 pipingrock.com###shopify-section-custom-cookie-consent
 ankerwork.com,elginusa.com,manlymanco.com,recongearusa.com,seedbarn.com,techmarkit.co.za###shopify-section-fixed-message
 koifootwear.com###shopify-section-popup
-2game.com###shopify-section-sections--29761304428869__jv_cookies_banner_aawKqH
 itinstock.com###shopui-cookie-popup-container
 edealinfo.com###showFTCMessage
 edealinfo.com###showFTCMessage-back

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -753,6 +753,7 @@ arcade1up.com,infinitygametable.com###shopify-section-cookies_consent
 pipingrock.com###shopify-section-custom-cookie-consent
 ankerwork.com,elginusa.com,manlymanco.com,recongearusa.com,seedbarn.com,techmarkit.co.za###shopify-section-fixed-message
 koifootwear.com###shopify-section-popup
+2game.com###shopify-section-sections--29761304428869__jv_cookies_banner_aawKqH
 itinstock.com###shopui-cookie-popup-container
 edealinfo.com###showFTCMessage
 edealinfo.com###showFTCMessage-back

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -753,6 +753,7 @@ arcade1up.com,infinitygametable.com###shopify-section-cookies_consent
 pipingrock.com###shopify-section-custom-cookie-consent
 ankerwork.com,elginusa.com,manlymanco.com,recongearusa.com,seedbarn.com,techmarkit.co.za###shopify-section-fixed-message
 koifootwear.com###shopify-section-popup
+2game.com###jvCookiePopup
 itinstock.com###shopui-cookie-popup-container
 edealinfo.com###showFTCMessage
 edealinfo.com###showFTCMessage-back

--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -517,6 +517,7 @@ gainesvillecoins.com###jsGDRP
 glashuette-original.com###js_dataNnoticeBackdrop
 glashuette-original.com###js_dataNnoticeBtns
 juno.co.uk###juno-cookie-consent
+2game.com###jvCookiePopup
 chipotle.com###ketch-consent-banner
 forbes.com###ketch-consent-overlay
 carmax.com###kmx-privacy-popup
@@ -753,7 +754,6 @@ arcade1up.com,infinitygametable.com###shopify-section-cookies_consent
 pipingrock.com###shopify-section-custom-cookie-consent
 ankerwork.com,elginusa.com,manlymanco.com,recongearusa.com,seedbarn.com,techmarkit.co.za###shopify-section-fixed-message
 koifootwear.com###shopify-section-popup
-2game.com###jvCookiePopup
 itinstock.com###shopui-cookie-popup-container
 edealinfo.com###showFTCMessage
 edealinfo.com###showFTCMessage-back


### PR DESCRIPTION
Hiding cookie notice on https://www.2game.com/pl-pl/products/palworld-steam-key

Fix is in response to user reports on Brave