### PR TITLE
A: knf.gov.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2392,6 +2392,7 @@ strefamocy.pl##.x13eucookies__backdrop
 hejto.pl##.z-1200.border-primary-main
 pzkosz.pl##.zgoda_na_przetwarzanie
 shopee.pl##.zsav9a
+knf.gov.pl##[aria-labelledby="cookie-info-title"]
 pracuj.pl##[data-test="modal-cookie-bottom-bar"]
 kurnik.pl,otoprzychodnie.pl##[style^="position: fixed; left: 0px; top: 0px;"]
 swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]


### PR DESCRIPTION
Hiding cookie notice on https://www.knf.gov.pl

Fix is in response to user reports on Brave