### PR TITLE
A: kuchniasklep.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2289,6 +2289,7 @@ pracuj.pl##.cmulq7z
 sklep.szprychy.com##.config-messages
 rozetka.pl##.consent-layout
 ercomer.pl,miodykrupiec.pl,motohid.pl,planszostrefa.pl,questsport.shop,skarbyroztocza.com##.consents
+kuchniasklep.pl##.cookie-consent-module__jYRF8G__cookies
 isystemy.pl##.cookie-div-main
 polczat.pl##.cookie-notification
 bezpiecznedane.gov.pl##.cookie-popup-modal


### PR DESCRIPTION
Hiding cookie notice on https://kuchniasklep.pl

Fix is in response to user reports on Brave