### PR TITLE
A: kujawsko-pomorskie.kas.gov.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -311,7 +311,7 @@ semiconductor.samsung.com###cookie_component_emea
 bankofcanada.ca,betsapi.com,comscore.com,domainname.shop,givengain.com,kiwi.com,mkchulin.cz,mzanzisolutions.co.za,uscareerinstitute.edu###cookie_consent
 khronos.org###cookie_decline
 sendgb.com###cookie_disabled
-halcyon.net,santionduty.com###cookie_info
+halcyon.net,kujawsko-pomorskie.kas.gov.pl,santionduty.com###cookie_info
 esa.int###cookie_loc
 search.podcastmusic.com,sourceaudio.com###cookie_manager
 groners.com###cookiebanner_bg


### PR DESCRIPTION
Hiding cookie notice on https://www.kujawsko-pomorskie.kas.gov.pl/izba-administracji-skarbowej-w-bydgoszczy

Fix is in response to user reports on Brave