### PR TITLE
A: lewiatan.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2290,6 +2290,7 @@ sklep.szprychy.com##.config-messages
 rozetka.pl##.consent-layout
 ercomer.pl,miodykrupiec.pl,motohid.pl,planszostrefa.pl,questsport.shop,skarbyroztocza.com##.consents
 isystemy.pl##.cookie-div-main
+lewiatan.pl##.cookie-manage-box-wrapper
 polczat.pl##.cookie-notification
 bezpiecznedane.gov.pl##.cookie-popup-modal
 ksiazece.pl,lech.pl,lechpils.pl,tyskie.pl,zubr.pl##.cookies--cloak


### PR DESCRIPTION
Hiding cookie notice on https://lewiatan.pl

Fix is in response to user reports on Brave