### PR TITLE
A: oponykozak.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2082,7 +2082,7 @@ newsnow.co.uk##.js-alerts-container
 gaijin.net##.js-cb-policy
 curiocity.com,littlepotatoes.com##.js-consent-box
 nordarun.com##.js-consent-management
-cdek.shopping,mangaplanet.com,sourcesecurity.com##.js-cookie-consent
+cdek.shopping,mangaplanet.com,oponykozak.pl,sourcesecurity.com##.js-cookie-consent
 osprey.com##.js-cookie-consent-popup__bg
 pharming.com##.js-cookiebar-container
 ibinder.com##.js-cookiebot


### PR DESCRIPTION
Hiding cookie notice on https://oponykozak.pl

Fix is in response to user reports on Brave