### PR TITLE
A: otvarta.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2139,6 +2139,7 @@ cigarro.pl###cb-cookie
 gov.pl###cb2-banner
 are.waw.pl###cc_popup
 televio.pl###ccnst__main
+otvarta.pl###cct-banner
 webd.pl###cffc
 almamarket.pl,kozy.pl###claw
 pobieralnia.org###close


### PR DESCRIPTION
Hiding cookie notice on https://otvarta.pl

Fix is in response to user reports on Brave