### PR TITLE
A: wordtune.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2437,7 +2437,7 @@ thelocalchoice.co.za##.popup-access
 dadavidson.com##.popup-container-bottom
 musee-mccord-stewart.ca##.popup-container-confidentiality
 czc.cz##.popup-content
-cbr.ru,hirsch-international.com,phys.org##.popup-cookies
+cbr.ru,hirsch-international.com,medicalxpress.com,phys.org,techxplore.com,vitalia.pl,wordtune.com##.popup-cookies
 jacksonsauction.com##.popup-dialog
 cancerresearch.org##.popup-inner
 haiermedical.com##.popup-window


### PR DESCRIPTION
Hiding cookie notice on https://www.wordtune.com

Fix is in response to user reports on Brave