### PR TITLE
A: wordtune.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2441,7 +2441,7 @@ thelocalchoice.co.za##.popup-access
 dadavidson.com##.popup-container-bottom
 musee-mccord-stewart.ca##.popup-container-confidentiality
 czc.cz##.popup-content
-cbr.ru,hirsch-international.com,phys.org##.popup-cookies
+cbr.ru,hirsch-international.com,phys.org,wordtune.com##.popup-cookies
 jacksonsauction.com##.popup-dialog
 cancerresearch.org##.popup-inner
 haiermedical.com##.popup-window


### PR DESCRIPTION
Removing a cookie notice on wordtune.com. This change is in response to user reports on Brave