### PR TITLE
A: wpastra.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -795,6 +795,7 @@ equilar.com,ffonts.net,whatfontis.com###sticky-popup
 firefoxosdevices.org###storage-notice
 strava.com###stravaCookieBanner
 streamify.io###streamify-gdpr
+wpastra.com###surecookie-public-root
 deboulle.com,offi.fr###tarteaucitronAlertBig
 tatsubuilder.com###tatsu-header-container
 buccellati.com,kiabi.com###tc-privacy-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://wpastra.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2636