### PR TITLE
A: kleinezeitung.at

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -595,6 +595,7 @@ meinungsstark.de##[role="dialog"]
 ran.de##cmp-banner
 cecil.de##consent-layer
 puerner.de##dialog[style="border-color:lightgray;border-width:2px;border-radius:6px;"]
+kleinezeitung.at##div#didomi-host
 lizy.be##div[class^="PopupCookies-"]
 sunrise.ch##div[class^="cookieBanner_"]
 milak.at##div[data-extension="consent_manager"]


### PR DESCRIPTION
Hiding cookie notice on https://kleinezeitung.at

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2637