### PR TITLE
A: nsctotal.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2536,7 +2536,7 @@ afestas.com.br##.bottom-popup-wrapper
 ecclesiae.com.br,videeditorial.com.br##.box-aceite-privacidade
 tekdistribuidor.com.br##.box-lgpd
 costanorte.com.br##.bswTsr
-diariodolitoral.com.br##.bwgr-lgpd-consent-box
+diariodolitoral.com.br,nsctotal.com.br##.bwgr-lgpd-consent-box
 enjoei.com.br##.c-cookies-banner
 grupoccr.com.br,motiva.com.br##.c-dOELgn
 kovr.com.br##.c-eupVXi


### PR DESCRIPTION
Hiding cookie notice on https://nsctotal.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2639