### PR TITLE
A: tecconcursos.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2494,6 +2494,7 @@ gauchazh.clicrbs.com.br###privacy-tools-banner
 unesp.br###pu-analytics-consent-bar
 webmotors.com.br###root > .sc-bdVaJa
 rtp.pt###rtpgeralcookiecontent
+tecconcursos.com.br###tec-cookie-banner
 porque.com.br###termos_analytics
 unisanta.br###unisanta-cookie-mensagem
 imashop.com.br,toqueacampainha.com.br###vtex-lgpd-cookie


### PR DESCRIPTION
Hiding cookie notice on https://tecconcursos.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2649