### PR TITLE
A: study.richdad.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2103,6 +2103,7 @@ itv.com##.js-site-alert
 itv.com##.js-site-alert-content
 cgtn.com##.js-tools-dialog
 getaround.com##.js_cookie-consent
+study.richdad.com##.js_gdpr_flapjack_banner
 latoken.com##.jss1097
 effectivealtruism.org##.jss144
 mydirtyhobby.de##.jss177


### PR DESCRIPTION
Hiding cookie notice on https://study.richdad.com/rdpdl-sales

Fix is in response to user reports on Brave