### PR TITLE
A: newtec.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -577,6 +577,7 @@ anthonytravel.com###nb
 nba.com###nba_tos
 vsp.com###new_do_not_sell_button
 aptoide.com###news
+newtec.com###newtec-cookie-consent
 metal-shop.eu###nextcreBotDialog
 plotz.co.uk,skyremotecodes.co.uk###nfaModal
 plotz.co.uk,skyremotecodes.co.uk###nfaPopup


### PR DESCRIPTION
Hiding cookie notice on https://www.newtec.com/machines/weighing-machines

Fix is in response to user reports on Brave