### PR TITLE
A: columbiasports.co.jp

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -283,7 +283,7 @@ letsdothis.com###cookieAcceptanceModal
 511mt.net###cookieBannerHolder
 rsvp.withgoogle.com###cookieBarWrapper
 egamersworld.com###cookieBot
-e-hapi.com,feiler.jp,tomods-ap.com###cookieBox
+columbiasports.co.jp,e-hapi.com,feiler.jp,tomods-ap.com###cookieBox
 rewards.bing.com###cookieConsentContainer
 cambridgeparkandride.info###cookieConsentDialog
 investtech.com###cookieConsentDialogue


### PR DESCRIPTION
Hiding cookie notice on https://www.columbiasports.co.jp/shop/default.aspx

Fix is in response to user reports on Brave