### PR TITLE
A: capgemini.talentnet.community

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -315,6 +315,7 @@ halcyon.net,kas.gov.pl,santionduty.com###cookie_info
 esa.int###cookie_loc
 search.podcastmusic.com,sourceaudio.com###cookie_manager
 groners.com###cookiebanner_bg
+capgemini.talentnet.community###cookieconsent
 meetings.smartrecoveryglobal.org###cookieconsentmodal
 cvedetails.com###cookieconsentwarningcontainer
 spf-record.com###cookieguidelineRoot


### PR DESCRIPTION
Hiding cookie notice on https://capgemini.talentnet.community

Fix is in response to user reports on Brave