### PR TITLE
A: fanex.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2264,6 +2264,7 @@ gliwice-ginekolog.pl,ortodoncja-brewczynska.pl###zgoda
 empikbilety.pl,goingapp.pl##.CookieBar_cookieBar__3zsIk
 paynow.pl##.Cookies-module-cookies_121T
 mednavi.pl##.CookiesNotice
+fanex.pl##.Cookies_container__Q_rPy
 bookland.com.pl##.GDPR-Popup
 policja.pl,przystanekhistoria.pl##.JSWrapper
 odrabiamy.pl##.Rodo_blur__cnKdN


### PR DESCRIPTION
Hiding cookie notice on https://fanex.pl

Fix is in response to user reports on Brave