### PR TITLE
M: https://www.bing.com

### DIFF
--- a/fanboy-addon/fanboy_ai_suggestions.txt
+++ b/fanboy-addon/fanboy_ai_suggestions.txt
@@ -173,7 +173,7 @@ www.yahoo.co.jp##a.yMWCYupQNdgppL-NV6sMi._3sAlKGsIBCxTUbNi86oSjt:has(svg[aria-la
 www.yahoo.co.jp##a.ygDfdPUPK5OPiqKG4UtuU[aria-label="AIアシスタントで検索"]
 duckduckgo.com##a[class][href*="ia=chat"]
 truthsocial.com##a[href="/ai-search"]
-bing.com##a[href="/chat?FORM=hpcodx"]
+bing.com##a[href^="/chat?FORM=hpcodx"]
 duckduckgo.com##a[href^="/?ia=chat&"]
 search.brave.com##a[href^="/ask?q="]
 www.google.com##a[href^="https://ai.google/helpful-tools/?"]


### PR DESCRIPTION
Fixes the Copilot button not hiding on the Bing homepage.