### PR TITLE
A: baltic.art

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -265,7 +265,7 @@ amnesty.org###cookie-consent__modal
 autism-unlimited.org###cookie-cover
 asianlemansseries.com,bio-rad-antibodies.com###cookie-dialog
 ritani.com###cookie-info-banner
-keywordsstudios.com,uofmhealth.org###cookie-law
+baltic.art,keywordsstudios.com,uofmhealth.org###cookie-law
 cpac.ca###cookie-law-bar-holder
 ecigarettedirect.co.uk###cookie-message-slide-in
 dirsyncpro.org###cookie-notice-modal


### PR DESCRIPTION
Hiding cookie notice on https://baltic.art/whats-on

Fix is in response to user reports on Brave