### PR TITLE
A: ren-onsen.jp

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1997,6 +1997,7 @@ sansyu-pr.co.jp###privacy-panel
 medience.co.jp###sec_cookie
 bing.com###thp_notf_div
 maruchiba.jp###tmp_wrap_info_box
+ren-onsen.jp###tripla-cookie-consent
 nakagawa-masashichi.jp###zigzag-test__modal-overlay:has([class^="src-components-banner-___BannerCookieConsent__wrapper"])
 narita-koi.com##.CookieConfirm
 keio.ac.jp##._cookieBanner_h867q_75


### PR DESCRIPTION
Hiding cookie notice on https://ren-onsen.jp/sp

Fix is in response to user reports on Brave