### PR TITLE
A: careers.smh.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -640,6 +640,7 @@ photonfile.com###pf-ads-consent-banner
 phobs.net###phobs-cookie-consent
 get.popmenu.com,intellum.com,wi-fi.org###pi_tracking_opt_in_div
 piensasolutions.com###piensaCookieAcceptance
+careers.smh.com###pixel-consent-container
 themilitarystore.co.uk###pixelpop
 amazon.com###pldn-deep-link
 windy.com###plugin-consent


### PR DESCRIPTION
Hiding cookie notice on careers.smh.com

This is a basic cosmetic cookie notice that simply needs to be hidden.