### PR TITLE
A: mail.aol.com

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -7949,6 +7949,7 @@ linuxcommandlibrary.com##[href^="/"]:has([src*=".webp"])
 alibaba.com##[id^="sse-fluent-wending"]:has(.creative-ad-tag)
 kayak.com##[role="button"]:has([class*="ad-marking"])
 staples.com##[role="complementary"] #observer-id-temp:has(> #SKU_FeaturedProductCarousel)
+mail.aol.com##[role="presentation"]:has(> div[data-ad-row-id])
 kayak.com##[role="tab"]:has([class*="sponsored"])
 pixiv.net##[span="1"]:has(> div > div > div[style="display: block; width: 100%; height: 434px;"])
 unknowncheats.me##[style*="justify-content"]:has([rel^="sponsored"]) + [style]


### PR DESCRIPTION
AOL inbox shows an ad item at the top of mailbox

Using ABP 4.43.0 on Chrome Version 151.0.7922.76
Filter lists: EasyList + ABP Filters
can reproduce ad with Canada geo

<img width="1496" height="875" alt="Screenshot 2026-08-11 at 9 02 48 AM" src="https://github.com/user-attachments/assets/48581745-2ac1-4083-98ed-9d57b9fdc2d2" />
