### PR TITLE
percentagecalculator.net leftover

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -1,3 +1,4 @@
+percentagecalculator.net##.pc-incontent
 advfn.com###APS_300_X_600
 advfn.com###APS_BILLBOARD
 thetvdb.com###ATF


### PR DESCRIPTION
Hides this leftover from `https://percentagecalculator.net/`
<img width="1176" height="868" alt="image" src="https://github.com/user-attachments/assets/b02f2eb8-aa6a-4953-aecc-961d21144108" />
