### PR TITLE
A: aegeospas.gr

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1487,6 +1487,7 @@ stigmap.gr###btm_terms
 digea.gr###ck_cookies
 eudoxus.gr###consentPlaceholder
 krikri.gr###cookSETwin
+aegeospas.gr###cookieconsentform
 dod.gr###cookies_component
 kteohellas.gr###cookiesettings-dialog
 huli.gr###cp


### PR DESCRIPTION
Hiding cookie notice on https://www.aegeospas.gr

Fix is in response to user reports on Brave