### PR TITLE
A: graff.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1186,6 +1186,7 @@ alivecolors.com##.awarning
 amundi.com##.awf-eu-cookie-compliance
 airwallex.com##.awx-privcbanner-root
 welcometothejungle.com##.axeptio_mount
+graff.com##.b-consent-tracking
 hush-uk.com##.b-header-message
 makingyourmoneysimple.com,rimowa.com##.b-modal
 bitrefill.com##.b-vsrR8W


### PR DESCRIPTION
Hiding cookie notice on https://www.graff.com/us-en/home

Fix is in response to user reports on Brave