### PR TITLE
A: mimo.mi.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -909,6 +909,7 @@ humanizeai.pro##.CoockiesBanner_cookies_container__3epvo
 jksrestaurants.com##.Cookie-message
 weverse.io##.CookieAgreeView_container__qYaK3
 radioplayer.vistaradio.ca##.CookieBanner-module__wrap--1QK9t
+mimo.mi.com##.CookieBanner_banner__Dl_G3
 kaspersky.com,kaspersky.com.au##.CookieBanner_bottom__Xgcqc
 makeship.com##.CookieBar__CookieConsentWrapper-sc-1tdtgkj-0
 gobranded.com##.CookieBar_cookieBar__3qk4d


### PR DESCRIPTION
Hiding cookie notice on https://mimo.mi.com

Fix is in response to user reports on Brave