### PR TITLE
A: rigassatiksme.lv

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -272,7 +272,7 @@ dirsyncpro.org###cookie-notice-modal
 energylivenews.com###cookie-notification-mask
 broadwayinchicago.com###cookie-oven-consent-dialog
 kimkim.com###cookie-permissions-footer
-tufo.com###cookie-policy
+99percentinvisible.org,bestprice.gr,bookcabin.com,lexsynergy.com,matterport.com,meopta.com,rauch-ft.com,rigassatiksme.lv,sabric.co.za,taximaxim.ru,tufo.com,tv8.com.tr,ucla.edu###cookie-policy
 gorillas.io,simbrief.com###cookie-settings
 dotmetrics.net###cookie-snackbar-container
 hope.study###cookie-snackbar-popup


### PR DESCRIPTION
Hiding cookie notice on https://www.rigassatiksme.lv/lv

Fix is in response to user reports on Brave