### PR TITLE
A: vigi.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1523,6 +1523,7 @@ fling2night.com##.cookie-consent-root
 samsungknox.com##.cookie-consent-v3
 aronimink.org,glance.com,springbok-puzzles.com,tinyurl.com,visitukraine.today,visitworld.today##.cookie-consent-wrapper
 envirovent.com##.cookie-content
+vigi.com##.cookie-dialog
 weex.com##.cookie-dialog-enter-desktop
 home.cricketwireless.com##.cookie-dialog__container
 chargie.com##.cookie-div-block


### PR DESCRIPTION
Hiding cookie notice on https://www.vigi.com/pl

Fix is in response to user reports on Brave