### PR TITLE
A: intersocwerkvakanties.be

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1224,6 +1224,7 @@ energiewonen.nl###stOverlayB
 picnic-supermarkt.nl###switch2
 bingoal.be###tocmask
 antwoordop.nl,schulinck.nl###udtDark
+intersocwerkvakanties.be##.CookieBanner_cookiebanner__DT_Yi
 belsimpel.nl##.CookieBannerstyle__StyledContainer-sc-1kw94k2-1
 webshop.nl##.Gdpr-module__gdpr___oxQjD
 unionriver.nl,wehkamp.nl##.H_MhpZ


### PR DESCRIPTION
Hiding cookie notice on https://intersocwerkvakanties.be/nl/functies/animatie/animatie-volwassenen/wandelbegeleider

Fix is in response to user reports on Brave