### PR TITLE
A: tihanyiszabadterijatekok.hu

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1690,7 +1690,7 @@ tanulommagamtanfolyam.hu##.consent-banner-root
 maxigumi.hu##.content-bottom-fullwidth
 nemzetiutdij.hu##.cookie-alert
 fressnapf.hu##.cookie-base
-azevfodrasza.hu##.cookie-consent-info
+azevfodrasza.hu,tihanyiszabadterijatekok.hu##.cookie-consent-info
 foramax.hu,mp4bolt.hu##.ct
 obi.hu##.disc-cp
 fressnapf.hu##.grey-popup-layer


### PR DESCRIPTION
Hiding cookie notice on https://tihanyiszabadterijatekok.hu

Fix is in response to user reports on Brave