### PR TITLE
A: sompo-ri.co.jp

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2067,6 +2067,7 @@ seibuen-amusement-park.jp##.site-cookie-accept
 picrew.me##.st-Terms_Wrapper
 hitsuji-zzz.com##.tc-cookie-popup
 sponichi.co.jp##.toast-bottom-right
+sompo-ri.co.jp##.tt-cookie
 kankocho.jp##.v-snack--bottom
 keio.ac.jp##[class^="_cookieBanner_"]
 baike.baidu.com##[class^="index_cookieWrapper"]


### PR DESCRIPTION
Hiding cookie notice on https://www.sompo-ri.co.jp/2026/02/09/21823

Fix is in response to user reports on Brave