### PR TITLE
A: novodom.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2356,6 +2356,7 @@ kuchniasklep.pl##.cookie-consent-module__jYRF8G__cookies
 isystemy.pl##.cookie-div-main
 lewiatan.pl##.cookie-manage-box-wrapper
 polczat.pl##.cookie-notification
+novodom.pl##.cookie-permission-container-outer
 bezpiecznedane.gov.pl##.cookie-popup-modal
 ksiazece.pl,lech.pl,lechpils.pl,tyskie.pl,zubr.pl##.cookies--cloak
 uzdrowiskociechocinek.pl##.cookies-at


### PR DESCRIPTION
Hiding cookie notice on https://novodom.pl

Fix is in response to user reports on Brave