### PR TITLE
A: myphone.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -865,7 +865,7 @@ dompe.com###warning-popup
 rehva.eu###wb-cookie-policy
 wealthfront.com###wcm-container
 waterdropfilter.com###wd-cookie-consent-popup
-artemes.org,datenpol.at,ees-corporation.com,evo-spirit.com,flyingbasket.com,mansuetoqueseria.com###website_cookies_bar
+artemes.org,datenpol.at,ees-corporation.com,evo-spirit.com,flyingbasket.com,mansuetoqueseria.com,myphone.pl###website_cookies_bar
 iflicks.in###welcome
 taiwanplus.com###welcomeMsg
 weverse.io###wevConsentManager


### PR DESCRIPTION
Hiding cookie notice on https://myphone.pl

Fix is in response to user reports on Brave