### PR TITLE
A: brandirectory.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1165,6 +1165,7 @@ surron.com,user1st.com##.ant-drawer
 globalhome.solarmanpv.com##.ant-modal-root
 billhop.com,findmcserver.com,newtextdocument.com##.ant-notification
 cryptoquant.com##.ant-row-center
+brandirectory.com##.app-cookie-banner--banner
 similarweb.com##.app-cookies-notification
 leo.org##.app-footer-content
 2captcha.com##.app-level-notifications


### PR DESCRIPTION
Hiding cookie notice on https://brandirectory.com

Fix is in response to user reports on Brave