### PR TITLE
A: jeffdaviesandson.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -167,6 +167,7 @@ avosound.com###cc_b
 warwickstudentpad.co.uk###cc_cookie_banner
 skargards.com###cc_dialog
 europa.eu###cck_here
+jeffdaviesandson.com###ccm-box
 hytale.game###ccm-ui
 ammergauer-zeitgeist.de,sportarena.it,stacherhof-zillertal.at###ccmodal-container
 ovigo.tv###ccnst__main


### PR DESCRIPTION
Hiding cookie notice on https://jeffdaviesandson.com

Fix is in response to user reports on Brave