### PR TITLE
A: worldcoinindex.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1861,6 +1861,7 @@ airproducts.co.uk##.eu-dp
 componentsearchengine.com##.eu-message
 hotelesmares.com,niedersteinhof.it,skinmc.net##.eu-popup
 prospan.com.au##.eu-privacy
+worldcoinindex.com##.eupopup
 bahrain.bh,cognizantee.tekstac.com,xbox-store-checker.com##.eupopup-container
 kromgaming.com##.eupouY
 investors.adtran.com##.evergreen-consent-banner


### PR DESCRIPTION
Hiding cookie notice on https://www.worldcoinindex.com

Fix is in response to user reports on Brave