### PR TITLE
A: order.maxburgers.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3000,6 +3000,7 @@ cherytr.com,cine-max.sk##body .cc-nb-main-container
 facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]
 community.nexthink.com##c-community-cookie-consent-banner
 success.trendmicro.com##c-dcx-cookie
+order.maxburgers.com##consent-banner.ng-scope
 qualified.io##consent-cookie-popup
 23degrees.io##consent-toast
 axis.com,orbis.com##cookie-consent


### PR DESCRIPTION
Hiding cookie notice on https://order.maxburgers.com/pl/pl-pl

Fix is in response to user reports on Brave