### PR TITLE
Add juneworewyjyna.com to adservers list

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -19594,6 +19594,7 @@
 ||jumvsaapqxaed.site^
 ||juncorepurgereaps.qpon^
 ||jundzeaqsodl.in^
+||juneworewyjyna.com^
 ||junior-satisfaction.com^
 ||juniorfascet.shop^
 ||juniorfirm.com^


### PR DESCRIPTION
`juneworewyjyna.com` is one of the ad servers that Xhamster uses: https://github.com/uBlockOrigin/uAssets/pull/34148#issue-5173401701

The server is already in AdGuard's Base list, but since uBO has EL enabled by default, it should be added here.