### PR TITLE
A: stackoverflow.com: Social

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -191,7 +191,7 @@ oneindia.com###youtube_promo
 always-on.com.au###zeen_retina_image-3
 saturdayeveningpost.com##.-newsletter_social
 tennis.com##.-sharebar
-nhl.com,petri.com##.-social
+askubuntu.com,mathoverflow.net,nhl.com,petri.com,serverfault.com,stackexchange.com,stackoverflow.com,superuser.com##.-social
 ynet.co.il,ynetnews.com##.AccordionShareWrapper
 abebooks.com,americanbanker.com,koaa.com,nbcsports.com,newatlas.com,nhpr.org,pitchbook.com,refractor.io,scrippsnews.com##.ActionBar
 kpbs.org,wmar2news.com##.ActionBar-items
@@ -435,6 +435,7 @@ betanews.com##.bn-share__inner
 breitbart.com##.bnn-social-share
 bom.gov.au##.bom-social-share
 crn.com##.border-all-mid-gray-rounded
+askubuntu.com,mathoverflow.net,serverfault.com,stackexchange.com,stackoverflow.com,superuser.com##.bottom-share-links
 ofbez.com##.box-fixed-subscription
 cardiff.ac.uk##.box-services
 bangkokpost.com##.boxnav--social


### PR DESCRIPTION
Hides social buttons on unanswered questions and in site footer on Stack Overflow/Stack Exchange sites.