### PR TITLE
A: fahrgastfernsehen.city

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -240,6 +240,7 @@ a-hausverwaltungen.de,ec-planegg-geisenbrunn.de,fdp-mh.de,hausmeister-service-au
 centrotherm.de##.H_s
 aqualip.de##.HrSys-Gips-iBoxDivOverlay
 jaguar.at,landrover.at##.Modal
+fahrgastfernsehen.city##.MuiPaper-root:has([href="/datenschutz"])
 landrover.de##.NotificationBar
 toppreise.ch##.Plugin_WeUseCookies
 snowfall-beads.de##.PopupOnTopScreen


### PR DESCRIPTION
Hiding cookie notice on fahrgastfernsehen.city.

This fix is in response to cookie notices on Brave