### PR TITLE
A: hamiltonmotors.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1521,7 +1521,7 @@ tightvnc.com##.cookie-block
 n-ix.com##.cookie-block-wrapper
 betking.com##.cookie-box-container
 navigare-yachting.com##.cookie-box-popup
-goodlawproject.org,loanheadcars.co.uk##.cookie-card
+goodlawproject.org,hamiltonmotors.co.uk,loanheadcars.co.uk##.cookie-card
 allyouplay.com##.cookie-card_container
 benq.com##.cookie-component
 moneycontrol.com##.cookie-concern-wrapper


### PR DESCRIPTION
Hiding cookie notice on hamiltonmotors.co.uk.

This fix is in response to user reports on Brave