### PR TITLE
A: silverstudiogames.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2265,6 +2265,7 @@ ctdi.eu##.mod_cookiebar_optin_medium
 iconicarcade.com##.mod_cookies_wrapper
 onlineradiobox.com##.modal--cookies
 onlineradiobox.com##.modal--cookies-backdrop
+silverstudiogames.org##.modal-cacsp-box
 hollandandbarrett.com.cy,myanimelist.net##.modal-container
 bigbeatinc.com,myanimelist.net##.modal-content
 myanimelist.net##.modal-content-overlay


### PR DESCRIPTION
Hiding cookie notice on https://www.silverstudiogames.org

Fix is in response to user reports on Brave