### PR TITLE
A: rpmrestaurants.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -328,7 +328,7 @@ forcesfamiliesjobs.co.uk,linuxcareers.com,lumijobs.com###cookienotice_notice
 europa-plc.com,oustudentsshop.com###cookieplate
 connscameras.ie###cookiepref
 cryptwerk.com,hoteldaweb.com.br###cookies-accept
-monamigabi.com###cookies-choices-panel
+monamigabi.com,rpmrestaurants.com###cookies-choices-panel
 accolade.eu###cookies-component
 yufap.com###cookies-content
 currentcircular.com,elaoffcial.com###cookies-iki


### PR DESCRIPTION
Hiding cookie notice on https://www.rpmrestaurants.com/rpm-italian-chicago

Fix is in response to user reports on Brave