### PR TITLE
A: ria.com.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2486,6 +2486,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
+ria.com.pl###flexiblecookies_container
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2251,7 +2251,7 @@ strefabiznesu.pl###cross-dialog
 federacja-konsumentow.org.pl,pewnykantor.pl###cu_bar
 redbullmobile.pl###didomiBlockNavigation
 kinonh.pl###div_ac
-asc-pro.pl,maciej.je###flexiblecookies_container
+asc-pro.pl,maciej.je,ria.com.pl###flexiblecookies_container
 elektrykasklep.pl###ftccbcmd
 idream.pl###garua_cookie_consent_popup
 grupapracuj.pl###gp_cookie_agreements
@@ -2486,7 +2486,6 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-ria.com.pl###flexiblecookies_container
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]


### PR DESCRIPTION
Hiding cookie notice on https://ria.com.pl/

Fix is in response to user reports on Brave