### PR TITLE
A: payjoy.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1535,6 +1535,7 @@ buying.expert##.cookie-consent-popover
 fling2night.com##.cookie-consent-root
 samsungknox.com##.cookie-consent-v3
 aronimink.org,glance.com,springbok-puzzles.com,tinyurl.com,visitukraine.today,visitworld.today##.cookie-consent-wrapper
+payjoy.com##.cookie-consetn-wrapper
 envirovent.com##.cookie-content
 weex.com##.cookie-dialog-enter-desktop
 home.cricketwireless.com##.cookie-dialog__container


### PR DESCRIPTION
Hiding cookie notice on https://www.payjoy.com/mx

Fix is in response to user reports on Brave