### PR TITLE
A: panchlebek.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2340,6 +2340,7 @@ odrabiamy.pl##.Rodo_blur__cnKdN
 motopedia.otomoto.pl##.SRaBM
 reportaz.polskieradio.pl##.TermsOfUseModal_modalWrapper__3bWPX
 talixo.pl##.TrackingInfoBox
+panchlebek.pl##.TsConsentWrapper
 przemyslprzyszlosci.gov.pl##._consent
 remedium.md##._cookie_cookies-panel__LMI9a
 genetico.pl##.abcd


### PR DESCRIPTION
Hiding cookie notice on https://www.panchlebek.pl

Fix is in response to user reports on Brave