### PR TITLE
A: joyhousepublishing.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2684,6 +2684,7 @@ bonsaipartners.eu##.sqs-slide-layer-content
 fusemagazine.com##.sqs-slide-wrapper
 sparks.travel##.ss-cookie-modal-container
 openweathermap.org##.stick-footer-panel
+joyhousepublishing.com##.sticky-btm-wrapper
 hyundaicanada.com##.sticky-cookie-policy-container
 grafana.com,scoresaber.com,staterbros.com##.sticky-footer
 tc.columbia.edu##.sticky-notice-wrap


### PR DESCRIPTION
Hiding cookie notice on https://joyhousepublishing.com/gutcure2

Fix is in response to user reports on Brave