### PR TITLE
A: super.buycom.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2449,6 +2449,7 @@ webprojekt.biz##.ppc
 kp.pl##.privacyModal
 hejto.pl##.py-4.px-6.items-center
 rankomat.pl##.rank-cookie-bar
+super.buycom.pl##.realCookies
 prk24.pl##.rk-cookie-overlay
 alloc.pl,bagpolska.pl,dzieciwnature.pl,ecowater.md,ecowater.sk,ecowatersystems.cz,genesis.pl,mikolaj.org.pl,pkf.org.pl,teologiapolityczna.pl,yourcityguides.com##.rodopolicy
 scanner.com.pl##.rstboxes


### PR DESCRIPTION
Hiding cookie notice on https://super.buycom.pl

Fix is in response to user reports on Brave