### PR TITLE
A: europe.xpo.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -945,6 +945,7 @@ grundig.com##.CookiePolicyBanner
 lyte.com##.CookiePopUp_cookiePopUp__2mB8Q
 dailymotion.com##.CookiePopup__desktopContainer___ZCIMO
 infinitynikki.infoldgames.com##.CookieTips_cookie-tips-container___K01G
+europe.xpo.com##.CookieToast
 retn.net##.CookieWindow__Wrapper-sc-uhdlpk-0
 homehardware.ca##.Cookies
 cybervisiontech.com##.Cookies-module--cookie--2ydR3


### PR DESCRIPTION
Hiding cookie notice on https://europe.xpo.com/en

Fix is in response to user reports on Brave