### PR TITLE
A: bariinprogress.it

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1897,6 +1897,7 @@ intimerie.com##.alert-info
 bakecaincontrii.com##.alert-secondary
 vocetempo.it##.animate__animated.animate__slideInUp
 almaviva.it##.background-popup
+bariinprogress.it##.bip-on
 papersera.net##.black_overlay
 calcolostipendio.it##.bold_text
 bose.it##.bose-infoBar2016--fixedBottom


### PR DESCRIPTION
Hiding cookie notice on https://www.bariinprogress.it/project/brt-bus-rapid-transit

Fix is in response to user reports on Brave