### PR TITLE
A: avaloniaui.net

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1510,6 +1510,7 @@ avantarte.com,whitepages.com##.cookie-banner-container
 team.repair##.cookie-banner-inner
 businesscomparison.com##.cookie-banner-mask
 powerbox-systems.com##.cookie-banner-overlay
+avaloniaui.net##.cookie-banner-position
 aerofilms.cz,uxcel.com##.cookie-banner-wrap
 thewhitecompany.com##.cookie-banner__dimmer
 surferseo.com##.cookie-banner_component


### PR DESCRIPTION
Hiding cookie notice on https://avaloniaui.net

Fix is in response to user reports on Brave