### PR TITLE
A: ale.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -4089,7 +4089,7 @@ gcds.com,make.org,oralb.ca,swapcard.com,tommy.com##.ReactModal__Overlay
 ! .ccm-root
 bszam.de,clalitsmile.co.il,glarus24.ch,jacobskaffee.shop,poppen.de,preidlhof.com##.ccm-root
 ! .acb-gdpr
-briau.com,cultureetracines.com,petitvallauris.fr,spesalia.com##.acb-gdpr
+ale.pl,briau.com,cultureetracines.com,petitvallauris.fr,spesalia.com##.acb-gdpr
 ! (formerly known as mobile.twitter.com)
 x.com###react-root > div > div > .rn-gvpnoh
 x.com##[data-reactroot] > [class] + [class]:last-child


### PR DESCRIPTION
Hiding cookie notice on https://ale.pl

Fix is in response to user reports on Brave