### PR TITLE
A: akkuteile.de

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -579,7 +579,7 @@ watson.ch##.watson-cookie-footer
 mahlerundco.ch##.webzeit-cookiebanner
 hatex24.de##.widget-EyeCatcher
 rademacher.de##.widget-EyeCatcher--dropzone---preset-fixed
-servershop24.de##.widget-cookie-bar
+akkuteile.de,servershop24.de##.widget-cookie-bar
 badkeramik.de##.wpt-cc-banner
 schulze-immobilien.de##.wrap__undone
 warthunder.de##.wt-cb


### PR DESCRIPTION
Hiding cookie notice on https://www.akkuteile.de/ladegeraete/xtar/xtar-l4-intelligentes-ladegeraet-fuer-li-ion-1-5v-nimh-und-1-2v-akkus-aa-aaa_500201_3306

Fix is in response to user reports on Brave