### PR TITLE
A: matprat.no

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2153,6 +2153,7 @@ telenor.no###global-overlay-background
 nordiskporselen.com###kjeks
 eiendomsmegler1.no,sparebank1.no###opt-in
 steinhandel.no###topbar
+matprat.no##.CookiesSelectModal_modal__g__Jf
 haugesundbk.net##.GDPRcontainer
 ngi.no##.bcc-container
 dagbladet.no##.cIwTNh


### PR DESCRIPTION
Hiding cookie notice on https://www.matprat.no/oppskrifter/kos/gulrotkake-med-ostekrem

Fix is in response to user reports on Brave