### PR TITLE
A: tickets.sagradafamilia.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3009,6 +3009,7 @@ crazymaplestudios.com#?#.fixed:has-text(Cookie)
 shop.orqafpv.com##csm-cookie-consent
 czds.icann.org##czds-cookie-notification
 daily.dev#?#.bottom-0.fixed:has-text(This site uses cookies)
+tickets.sagradafamilia.org##dialog.cookies__modal
 c.realme.com##div > .cookie-privacy
 thumbnailcreator.com##div.fixed:has([href="/cookie-policy"])
 minimax.io##div.fixed:has([href="/protocol/cookie-policy"])


### PR DESCRIPTION
Hiding cookie notice on https://tickets.sagradafamilia.org/es/summaryPurchase

Fix is in response to user reports on Brave