### PR TITLE
A: wszystkoowarszawie.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2328,6 +2328,7 @@ greenmate.pl,negrasport.pl,shopii.pl,sklep-muzyczny.com.pl,srebrnystyl.pl,termok
 acom.pl,aleokulary.com,dedalus.pl,epapierosylodz.pl,lunamarket.pl,maxsklep.pl,miadora.pl,motocombo.pl,negrasport.pl,scyzoryki.net,seger.pl,zizako.pl###topInfoContainer1
 areatour.pl,dacter.pl,uni-tech.pl###topbar
 libra.com.pl###under_footer
+wszystkoowarszawie.pl###wow-cookies-layer
 greatone.pl###zamknij_cookies
 gliwice-ginekolog.pl,ortodoncja-brewczynska.pl###zgoda
 empikbilety.pl,goingapp.pl##.CookieBar_cookieBar__3zsIk


### PR DESCRIPTION
Hiding cookie notice on https://wszystkoowarszawie.pl

Fix is in response to user reports on Brave