### PR TITLE
A: hintoai.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2884,7 +2884,7 @@ remitly.com##:has(> #cookie-consent-prompt-modal)
 santatracker.google.com##SANTA-NOTICE
 trustnet.com##USER-TYPE-POPUP
 dollarshaveclub.com##[aria-describedby="banner-description"]
-askethos.com,k2think.ai,lemonade.com##[aria-describedby="cookie-consent-description"]
+askethos.com,hintoai.com,k2think.ai,lemonade.com##[aria-describedby="cookie-consent-description"]
 ticketmaster.com##[aria-describedby="mobileMobileTOUMessage"]
 kstp.com,lucidchart.com,scribd.com##[aria-label="Cookie Consent Banner"]
 1password.com,shirtspace.com##[aria-label="Cookie Consent"]


### PR DESCRIPTION
Hiding cookie notice on https://hintoai.com/tools/video-screenshot

Fix is in response to user reports on Brave