### PR TITLE
A: hammerphones.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -866,7 +866,7 @@ dompe.com###warning-popup
 rehva.eu###wb-cookie-policy
 wealthfront.com###wcm-container
 waterdropfilter.com###wd-cookie-consent-popup
-artemes.org,asviva.de,datenpol.at,ees-corporation.com,evo-spirit.com,flyingbasket.com,mansuetoqueseria.com,myphone.pl###website_cookies_bar
+artemes.org,asviva.de,datenpol.at,ees-corporation.com,evo-spirit.com,flyingbasket.com,hammerphones.com,mansuetoqueseria.com,myphone.pl###website_cookies_bar
 iflicks.in###welcome
 taiwanplus.com###welcomeMsg
 weverse.io###wevConsentManager


### PR DESCRIPTION
Hiding cookie notice on https://hammerphones.com

Fix is in response to user reports on Brave