### PR TITLE
A: discountelectronics.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -377,7 +377,7 @@ mobily.com.sa###data_priv_bar
 ranking.sanrio.co.jp###datasign_cmp__host
 ibm.com###dbdm--message
 pdfprof.com###dddhh
-discoveryeducation.com,readingplus.com###de-consent-banner
+discountelectronics.com,discoveryeducation.com,readingplus.com###de-consent-banner
 universitysupplystore.com###demo-overlay
 filmon.com###design-switcher
 data.europa.eu###deu-cookie-banner


### PR DESCRIPTION
Hiding cookie notice on https://discountelectronics.com/business-accounts

Fix is in response to user reports on Brave