### PR TITLE
A: pttavm.com

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3606,6 +3606,7 @@ hosting.com.tr##.contract-popup
 segmen.com.tr,soneksbilgisayar.com##.cookie-agreement-module
 pixad.com.tr##.cookie-manager
 hepsijet.com##.cookie-policy_cookiePolicy__9xbaz
+pttavm.com##.cookieBox__tzn27
 pinarsu.com.tr##.cookieContent
 ensonhaber.com##.cookiepolicy-banner
 e-bargello.com,pt.com.tr##.cp


### PR DESCRIPTION
Hiding cookie notice on https://pttavm.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2558