### PR TITLE
A: mintransporte.gov.co

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3779,7 +3779,7 @@ alpha-tex.de,aromatico.de,bremer-gewuerzhandel.de,detomaso-watches.com,edampfer2
 !! .backdrop-cookie
 cambiarredo.com##.backdrop-cookie
 !! #cookies-block
-msm.co,xmasgiftsonline.nl###cookies-block
+mintransporte.gov.co,msm.co,xmasgiftsonline.nl###cookies-block
 !! .cookie-wall
 confused.com,lanzaloe.com,threadstone.eu,wembleypark.com##.cookie-wall
 !! .cookie-warning


### PR DESCRIPTION
Hiding cookie notice on https://mintransporte.gov.co/publicaciones/11445/wwwruntgovco-unico-portal-disponible-del-runt

Fix is in response to user reports on Brave