### PR TITLE
A: leclerc.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2270,6 +2270,7 @@ flatart.pl###kekse
 e-podroznik.pl###klaro-cookies-modal
 berdsen.pl###kqs-box-tlo
 berdsen.pl###kqs-tlo
+leclerc.pl###lmk_cookiebaner_container
 borelioza.vegie.pl###menubar
 tupowstalapolska.pl###menusDiv
 almapress.com.pl,twojliquid.pl###message


### PR DESCRIPTION
Hiding cookie notice on https://leclerc.pl

Fix is in response to user reports on Brave