### PR TITLE
A: gabals.lv

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2128,6 +2128,7 @@ ecobaltiavide.lv##.popup-filter
 aio.lv##.popup-message
 via-s.lv##.priv
 maminuklubs.lv##.set_cookie
+gabals.lv##app-modal-cookie.ng-tns-c1486710262-0
 eparaksts.lv##usps-cookie-confirmation
 !
 ! ---------- Lithuanian  ---------


### PR DESCRIPTION
Hiding cookie notice on https://gabals.lv

Fix is in response to user reports on Brave