### PR TITLE
A: wowscale.com

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_general.txt
+++ b/easyprivacy/easyprivacy_trackingservers_general.txt
@@ -502,6 +502,7 @@
 ||wlt-jupiter.de^
 ||wmgroup.us^
 ||woodpeckerlog.com^
+||wowscale.com^
 ||xanalytics.vip^
 ||yardianalytics.com^
 ||yndhi.com^


### PR DESCRIPTION
`wowscale.com` and subdomains collect overzealous browsing/device information used for cross-site tracking - most likely for marketing/ads