### PR TITLE
A: novakidschool.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1970,7 +1970,7 @@ greatbigcanvas.com##.gbc-notifications
 audi.com##.gbp-overlay
 athospatsalidesmd.com,petercallandermd.com##.gdpCookie
 leapyear.io##.gdpr--modal
-brainandlife.org,thebaffler.com,wilsoncenter.org##.gdpr-alert
+brainandlife.org,novakidschool.com,thebaffler.com,wilsoncenter.org##.gdpr-alert
 principledtechnologies.com##.gdpr-check
 fast-poll.com##.gdpr-cookie-message-wrapper
 advocate.com##.gdpr-cookie-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://www.novakidschool.com/pl

Fix is in response to user reports on Brave