### PR TITLE
A: radiomap.world

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -216,6 +216,7 @@ fitnesssf.com###consent-click-shield
 allsaints.com,avanihotels.com,can-am.brp.com,minorhotels.com,oakshotels.com,rag-bone.com,zeffy.com###consent-dialog
 netcraft.com###consent-form
 awesomeagents.ai,pkgs.org###consent-notice
+radiomap.world###consent-overlay
 nasdaq.com###consent-placeholder-onetrust
 audacityteam.org,tecadmin.net###consent-popup
 niwa.co.nz###consent-request


### PR DESCRIPTION
Hiding cookie notice on https://radiomap.world

Fix is in response to user reports on Brave