### PR TITLE
A: cozadzien.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2482,6 +2482,7 @@ hejto.pl##.z-1200.border-primary-main
 filtry-wody.pl##.zdzCookies
 pzkosz.pl##.zgoda_na_przetwarzanie
 shopee.pl##.zsav9a
+cozadzien.pl##[aria-describedby="cookie-consent-message"]
 knf.gov.pl##[aria-labelledby="cookie-info-title"]
 pracuj.pl##[data-test="modal-cookie-bottom-bar"]
 kurnik.pl,otoprzychodnie.pl##[style^="position: fixed; left: 0px; top: 0px;"]


### PR DESCRIPTION
Hiding cookie notice on https://www.cozadzien.pl

Fix is in response to user reports on Brave