### PR TITLE
A: https://app.trakt.tv/

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -220,6 +220,7 @@
 ||app.box.com/gen204
 ||app.gnosispay.com/relay-gp-ph/
 ||app.nicealts.com/user/referral/visit
+||app.trakt.tv/api/client-report
 ||appanalysis.banggood.com^
 ||apple-mapkit.com/mw/v1/reportAnalytics
 ||aptoide-mmp.aptoide.com^


### PR DESCRIPTION
This adds the proxied Sentry ingest endpoint added in https://github.com/trakt/trakt-web/pull/3188. Tested if it was already live by navigating to app.trakt.tv (while logged in), and saw a POST to https://app.trakt.tv/api/client-report

I also saw pageview data being sent to hal.trakt.tv, let me know if you want me to add this as well, either in this PR or in a follow-up PR.