### PR TITLE
A: htownbikes.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -876,6 +876,7 @@ weverse.io###wevConsentManagerLayer
 johnfrederick.co.uk,pestdefence.co.uk###wp-notification
 funnyordie.com###wpautoterms-bottom-fixed-container
 f1forgottendrivers.com###wpcg-box
+htownbikes.com###wpconsent-banner-holder
 acoup.blog,candidcyber.com,commonplacefacts.com,maxstock.co.il,pokespecial.com.pl,sciencebasedmedicine.org###wpconsent-root
 wpx.net###wpx-cookie-agreement
 here.com###wrapper


### PR DESCRIPTION
Hiding cookie notice on https://htownbikes.com/

Fix is in response to user reports on Brave