### PR TITLE
A: motherjones.com: Social

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -927,6 +927,7 @@ inews.co.uk##.inews__footer__menus__icons
 inews.co.uk##.inews__post-share
 labiotech.eu##.inline-block.space-y-8
 mainichi.jp##.inline-list
+motherjones.com##.instagram-promo
 winnipegfreepress.com##.interactive
 bossip.com##.io-header__social-links
 thedriven.io##.is-whatsapp


### PR DESCRIPTION
Instagram promo on bottom of https://www.motherjones.com/politics/2026/08/google-lake-ontario-america-maps-rename-capitulation/