### PR TITLE
A: rmf24.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2259,6 +2259,7 @@ asc-pro.pl,maciej.je###flexiblecookies_container
 elektrykasklep.pl###ftccbcmd
 idream.pl###garua_cookie_consent_popup
 grupapracuj.pl###gp_cookie_agreements
+rmf24.pl###gr-consent-layer-area
 zmiksowani.pl###holdon-overlay
 bauer.pl###iframePopupContainer
 skleprycerski.com###important-notice


### PR DESCRIPTION
Hiding cookie notice on https://www.rmf24.pl

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2727