### PR TITLE
A: index-education.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -810,7 +810,7 @@ strava.com###stravaCookieBanner
 streamify.io###streamify-gdpr
 wpastra.com###surecookie-public-root
 saladfingersstore.com###sw-cookie-consent-widget
-deboulle.com,offi.fr###tarteaucitronAlertBig
+deboulle.com,index-education.com,offi.fr###tarteaucitronAlertBig
 tatsubuilder.com###tatsu-header-container
 buccellati.com,kiabi.com###tc-privacy-wrapper
 kaec.net,thelawpages.com###terms


### PR DESCRIPTION
Hiding cookie notice on https://www.index-education.com/fr/declaration-accessibilite-enej.php

Fix is in response to user reports on Brave