### PR TITLE
Hiding cookie notices with .realCookies selector

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,7 +2491,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-benugo.pl,buycom.pl##div.realCookies
+benugo.pl,buycom.pl,essystemk.pl##div.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,7 +2491,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-benugo.pl##div.realCookies
+benugo.pl,buycom.pl##div.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,7 +2491,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-benugo.pl,buycom.pl,essystemk.pl##div.realCookies
+benugo.pl,buycom.pl,essystemk.pl,lako.pl##div.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,6 +2491,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
+benugo.pl##div.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2491,7 +2491,7 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-benugo.pl,buycom.pl,essystemk.pl,lako.pl##div.realCookies
+benugo.pl,buycom.pl,essystemk.pl,lako.pl##.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]

--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2453,6 +2453,7 @@ webprojekt.biz##.ppc
 kp.pl##.privacyModal
 hejto.pl##.py-4.px-6.items-center
 rankomat.pl##.rank-cookie-bar
+benugo.pl,buycom.pl,essystemk.pl,lako.pl##.realCookies
 prk24.pl##.rk-cookie-overlay
 alloc.pl,bagpolska.pl,dzieciwnature.pl,ecowater.md,ecowater.sk,ecowatersystems.cz,genesis.pl,mikolaj.org.pl,pkf.org.pl,teologiapolityczna.pl,yourcityguides.com##.rodopolicy
 scanner.com.pl##.rstboxes
@@ -2491,7 +2492,6 @@ swiat-agd.com.pl##[style^="top:0;left:0;right:0;"]
 info-car.pl##app-accept-cookies
 pirolam.pl##body > div[style*="100%"]
 ingbank.pl##cookie-policy
-benugo.pl,buycom.pl,essystemk.pl,lako.pl##.realCookies
 elektrotechnikautomatyk.pl##div[class^="GDPRCookieInfo_"]
 magentatv.pl##div[class^="styles__HeaderInfoBar"]
 siepomaga.pl##div[data-testid="cookies-banner"]


### PR DESCRIPTION
The following is a list of Polish sites that have a cookie notice that can be hidden by adding their domains to the .realCookies selector.

 benugo.pl 

buycom.pl 

essystemk.pl 

lako.pl 

lako.pl 
