### PR TITLE
A: register-welfare.mof.go.th

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3658,6 +3658,7 @@ soeco.se##react-cookies-popup
 !
 komchadluek.net###accept-cookie-footer
 posttoday.com###box-policy
+register-welfare.mof.go.th###consent-section
 nipa.co.th###cookie-con-head
 bloggang.com###forcookie
 settrade.com###pdpa-policy


### PR DESCRIPTION
Hiding cookie notice on https://register-welfare.mof.go.th

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2747