### PR TITLE
A: purepeople.com.br

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1510,7 +1510,7 @@ chucklingcheese.co.uk##.cookie-accept-bar-v2
 syrf.org.uk##.cookie-alert-banner
 investkorea.org##.cookie-area
 pinpointproperties.com##.cookie-authority
-avantarte.com,whitepages.com##.cookie-banner-container
+avantarte.com,purepeople.com.br,whitepages.com##.cookie-banner-container
 team.repair##.cookie-banner-inner
 businesscomparison.com##.cookie-banner-mask
 powerbox-systems.com##.cookie-banner-overlay


### PR DESCRIPTION
Hiding cookie notice on https://purepeople.com.br

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2754