### PR TITLE
A: portfeo.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2253,6 +2253,7 @@ dowhan-nieruchomosci.pl###cookies_text
 drony.net,gadzetomania.pl,komorkomania.pl,otabletach.pl###cop
 strefabiznesu.pl###cross-dialog
 federacja-konsumentow.org.pl,pewnykantor.pl###cu_bar
+portfeo.pl###data-processing-popup
 redbullmobile.pl###didomiBlockNavigation
 kinonh.pl###div_ac
 asc-pro.pl,maciej.je###flexiblecookies_container


### PR DESCRIPTION
Hiding cookie notice on https://www.portfeo.pl

Fix is in response to user reports on Brave