### PR TITLE
A: exatel.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3197,7 +3197,7 @@ analyticsmania.com,chapelle.co.uk,direct-book.com,mtis.by,museum.nl,pyszne.pl,so
 cam4.*##.EEoPD
 evertiq.*##.cc-container
 twinkl.*##.cookie-consent-popup-container
-alza.*##.cookies-info
+alza.*,exatel.pl##.cookies-info
 wildberries.*##.fixed-block__cookies
 track.amazon.*##.wfbHK2
 jumia.*##[data-pop-id="consentPopup"]


### PR DESCRIPTION
Hiding cookie notice on https://exatel.pl

Fix is in response to user reports on Brave