### PR TITLE
A: coccine-shop.eu

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -548,6 +548,7 @@ mbc.net###mbc-policy
 908devices.com,comrex.com,pbsinternational.org,pendar.com###mcb-wrap
 hand2mind.com###md-cookienotice
 allabout-japan.com###meerkat-wrap
+coccine-shop.eu###megacookieeu
 lesschwab.com,tirerack.com###meru-cc--main
 iplogger.org,psyonix.com,rocketleague.com,wts.com###message
 web.peatus.ee###messageBar


### PR DESCRIPTION
Hiding cookie notice on https://coccine-shop.eu/pl

Fix is in response to user reports on Brave