### PR TITLE
A: nameslink.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -580,6 +580,7 @@ extreme.com,mtn.co.za###my-welcome-message
 rockstarcoders.com###myAlert
 aueb.gr,bott-workplace.co.uk,interface.com,kon-boot.com,southerntravelsindia.com,telegram.im###myModal
 blog.n8n.io###n8n-consent-modal
+nameslink.com###nameslink-cookie-consent-root
 spandidos-publications.com###navbar
 anthonytravel.com###nb
 nba.com###nba_tos


### PR DESCRIPTION
Hiding cookie notice on https://nameslink.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2763