### PR TITLE
A: philharmonie.lu

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1310,7 +1310,7 @@ rapidtyping.com##.c-c
 rebirth-hannover.de##.c-callout
 index.co##.c-consent-manager
 croda.com,frontgate.com,incotec.com,york.ac.uk##.c-cookie-banner
-asm.com,bastionhotels.com,bestwesternschipholairport.com,midlands.englandhockey.co.uk##.c-cookie-bar
+asm.com,bastionhotels.com,bestwesternschipholairport.com,midlands.englandhockey.co.uk,philharmonie.lu##.c-cookie-bar
 hobbitontours.com##.c-cookie-confirm
 datagen.tech##.c-cookie-consent-background
 gic.careers##.c-cookie-notice__container


### PR DESCRIPTION
Hiding cookie notice on https://www.philharmonie.lu/fr

Fix is in response to user reports on Brave