### PR TITLE
A: trinitycineasia.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3150,6 +3150,7 @@ reddit.com##shreddit-cookie-banner
 remotehub.com##smp-cookies-banner
 truecaller.com##span > .max-w-md.shadow-lg
 planner.kaboodle.co.nz##tw-privacy-preference
+trinitycineasia.com##ush-cookie-consent
 trumpf.com##ux-cookie-layer
 pacificpower.net,rockymountainpower.net##wcss-cookie-banner
 web.dev##web-snackbar


### PR DESCRIPTION
Hiding cookie notice on https://www.trinitycineasia.com/en/movie

Fix is in response to user reports on Brave