### PR TITLE
A: termsfeed.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -801,7 +801,7 @@ classicalradio.com,di.fm,jazzradio.com,radiotunes.com,rockradio.com,zenradio.com
 yourkit.com###terms-wrapper-id
 bpsa.co.uk###terms_container
 whatismymovie.com###termsandconds
-get.it.com,pensionplanpuppets.com###termsfeed-pc1-notice-banner
+get.it.com,pensionplanpuppets.com,termsfeed.com###termsfeed-pc1-notice-banner
 colorit38.com###test_alert
 bitzarium.com###textBox
 fixedbyvonnie.com###tfade


### PR DESCRIPTION
Hiding cookie notice on https://termsfeed.com

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2606