### PR TITLE
A: apteekkini.fi

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -1422,6 +1422,7 @@ ifolor.fi##.dialogBanner--align-bottom
 aatos.app##.eiabyj
 sporthammer.fi##.first-page-of-accept-cookies
 verkkokauppa.com##.gDFWtL
+apteekkini.fi##.gbase-consent-dialog-no-titlebar
 esri.fi##.gnav_notification-popup
 asiakaspalvelu.verkkokauppa.com##.hc-cookie-notification
 bittimittari.fi,kyberturvallisuuskeskus.fi,saavutettavuusvaatimukset.fi,traficom.fi##.hds-cc__target


### PR DESCRIPTION
Hiding cookie notice on https://www.apteekkini.fi/Korvat-nenae-ja-kuorsaus/Nenaen-kostutus

Fix is in response to user reports on Brave