### PR TITLE
A: libram.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2429,6 +2429,7 @@ mediaexpert.pl##.layout > .wrapper
 rejestracja.makro.pl##.layout-mask
 onholidays.pl##.layout_cookiesRule__2QouX
 kuehlschrank.com##.legalAdvice
+libram.pl##.libram-cookies
 albeco.com.pl##.m-cookies
 kinomoc.com##.message-alert
 nasz-gabinet.pl##.message-window


### PR DESCRIPTION
Hiding cookie notice on https://libram.pl

Fix is in response to user reports on Brave