### PR TITLE
A: app.finom.co

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -3534,6 +3534,7 @@ iryo.eu##wc-cookies-manager
 vw.com.mx###ensNotifyBanner
 loging.mk##.showBackdrop
 loging.mk##.showConsent
+app.finom.co##.uc-cookie-consent
 sedeelectronica.sic.gov.co##[aria-label="Aviso de cookies"]
 !
 ! ---------- Catalan ----------


### PR DESCRIPTION
Hiding cookie notice on https://app.finom.co/de/signin

Fix is in response to user reports on Brave