### PR TITLE
A: trustmate.io

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -956,6 +956,7 @@ fireflyz.com.my,malaysiaairlines.com##.CookiesNotificationBtmOverlaySticky
 andersenlab.com##.CookiesPolicy-module--wrapper--8pHca
 hoorayteams.com##.CookiesPopUp-module-scss-module__bkwBfG__CookiesPopUp
 movadex.com##.CookiesPopup_root__h_m4j
+trustmate.io##.Cookies_banner__A8qGR
 robertsspaceindustries.com##.CybotCookiebotDialogActive
 accounts.ucas.com,nngroup.com##.CybotEdge
 basspro.com,cabelas.com##.DisclosurePopupContainer


### PR DESCRIPTION
Hiding cookie notice on https://trustmate.io

Fix is in response to user reports on Brave