### PR TITLE
A: cwcars.co.uk

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1521,7 +1521,7 @@ tightvnc.com##.cookie-block
 n-ix.com##.cookie-block-wrapper
 betking.com##.cookie-box-container
 navigare-yachting.com##.cookie-box-popup
-goodlawproject.org,hamiltonmotors.co.uk,loanheadcars.co.uk##.cookie-card
+cwcars.co.uk,goodlawproject.org,hamiltonmotors.co.uk,loanheadcars.co.uk##.cookie-card
 allyouplay.com##.cookie-card_container
 benq.com##.cookie-component
 moneycontrol.com##.cookie-concern-wrapper


### PR DESCRIPTION
Hiding cookie notice on https://cwcars.co.uk/used-vehicles

Fix is in response to user reports on Brave