### PR TITLE
A: givesendgo.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -1273,6 +1273,7 @@ learntotradethemarket.com##.bottom-navbar
 benchmark.unigine.com##.bottom-notice
 gameleap.com##.bottom-right
 engage.eciu.eu##.bottom-sm.fixed
+givesendgo.com##.bottom-sticky-container
 cointelegraph.com##.bottom-zone
 warbyparker.com##.bottomLeft__O0HMt
 hostkey.com##.bottomMessages


### PR DESCRIPTION
Hiding cookie notice on https://www.givesendgo.com/charliekirkmonument

Fix is in response to user reports on Brave