### PR TITLE
A: kunasystem.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2341,6 +2341,7 @@ rejestracja.makro.pl##.layout-mask
 onholidays.pl##.layout_cookiesRule__2QouX
 kuehlschrank.com##.legalAdvice
 albeco.com.pl##.m-cookies
+kunasystem.pl##.m-cookies-modal
 kinomoc.com##.message-alert
 nasz-gabinet.pl##.message-window
 pepper.pl##.messages


### PR DESCRIPTION
Hiding cookie notice on https://kunasystem.pl

Fix is in response to user reports on Brave