### PR TITLE
A: extraportfel.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2379,6 +2379,7 @@ ercomer.pl,miodykrupiec.pl,motohid.pl,planszostrefa.pl,questsport.shop,skarbyroz
 kuchniasklep.pl##.cookie-consent-module__jYRF8G__cookies
 isystemy.pl##.cookie-div-main
 lewiatan.pl##.cookie-manage-box-wrapper
+extraportfel.pl##.cookie-manager-popup-initial-overlay
 polczat.pl##.cookie-notification
 novodom.pl##.cookie-permission-container-outer
 bezpiecznedane.gov.pl##.cookie-popup-modal


### PR DESCRIPTION
Hiding cookie notice on https://www.extraportfel.pl

Fix is in response to user reports on Brave