### PR TITLE
A: (NSFW) playvids.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -73,6 +73,7 @@ jobisjob.co.uk###adevinta_consents_cookies_universal_widget
 vapostore.com###adns_cookies_container
 javlibrary.com###adultwarningmask
 aecom.com###aecomCookieNotificationBar
+playvids.com###ag-cookiebar
 aprtoapy.com###agppp
 spbtv.online###agreeC
 basecamelectronics.com###agreement-alert


### PR DESCRIPTION
Hiding cookie notice on https://www.playvids.com (NSFW)

Fix is in response to user reports on Brave