### PR TITLE
A: trabajo.org

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2745,6 +2745,7 @@ tovatt.com##.tovatt-gdprpopup
 talentplug.com##.tp-popin-cookies
 thepodcasthost.com##.tph-cookie-notice
 thomsonreuters.com##.tr-DismissibleBanner
+trabajo.org##.trabajo-consent
 mrd.com##.track-banner
 nyit.edu##.tracking
 fabasoft.com##.tracking-alert


### PR DESCRIPTION
Hiding cookie notice on https://trabajo.org

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2700