### PR TITLE
A: criticalsoftware.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2988,6 +2988,7 @@ crazymaplestudios.com#?#.fixed:has-text(Cookie)
 czds.icann.org##czds-cookie-notification
 daily.dev#?#.bottom-0.fixed:has-text(This site uses cookies)
 c.realme.com##div > .cookie-privacy
+criticalsoftware.com##div.c15t-ui-bannerVisible-pYYY9
 thumbnailcreator.com##div.fixed:has([href="/cookie-policy"])
 minimax.io##div.fixed:has([href="/protocol/cookie-policy"])
 my.worldmobile.io##div.fixed:has([href="https://worldmobile.io/en/cookies"])


### PR DESCRIPTION
Hiding cookie notice on https://criticalsoftware.com/en

Fix is in response to user reports on Brave