### PR TITLE
A: criticalsoftware.com

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -3012,6 +3012,7 @@ cherytr.com,cine-max.sk##body .cc-nb-main-container
 facebook.com##body:not([style^="margin-bottom"]) div[data-testid="cookie-policy-banner"]
 community.nexthink.com##c-community-cookie-consent-banner
 success.trendmicro.com##c-dcx-cookie
+criticalsoftware.com##c15t-ui-bannerVisible-pYYY9
 order.maxburgers.com##consent-banner.ng-scope
 qualified.io##consent-cookie-popup
 23degrees.io##consent-toast


### PR DESCRIPTION
Hiding cookie notice on https://criticalsoftware.com/en

Fix is in response to user reports on Brave