### PR TITLE
M: Re-add YouTube autodub JSON filters

### DIFF
--- a/custom-lists/youtube-autodubbed.txt
+++ b/custom-lists/youtube-autodubbed.txt
@@ -7,3 +7,8 @@
 !
 youtube.com#?#yt-lockup-view-model.ytd-item-section-renderer:has-text(Auto-dubbed)
 youtube.com#?#ytd-rich-item-renderer.ytd-rich-grid-renderer.style-scope:has-text(Auto-dubbed)
+! https://github.com/easylist/easylist/issues/24473
+youtube.com##+js(json-edit, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed])
+youtube.com##+js(json-edit-fetch-response, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed], propsToMatch, /youtubei)
+youtube.com##+js(json-edit-xhr-response, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed], propsToMatch, /youtubei)
+youtube.com##+js(rpnt, script, (function serverContract(), if("object"===typeof window.ytInitialPlayerResponse){window.ytInitialPlayerResponse=JSON.parse(JSON.stringify(window.ytInitialPlayerResponse));}(function serverContract(), sedCount, 1)

--- a/custom-lists/youtube-autodubbed.txt
+++ b/custom-lists/youtube-autodubbed.txt
@@ -11,4 +11,3 @@ youtube.com#?#ytd-rich-item-renderer.ytd-rich-grid-renderer.style-scope:has-text
 youtube.com##+js(json-edit, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed])
 youtube.com##+js(json-edit-fetch-response, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed], propsToMatch, /youtubei)
 youtube.com##+js(json-edit-xhr-response, ..adaptiveFormats.*[?.audioTrack.isAutoDubbed], propsToMatch, /youtubei)
-youtube.com##+js(rpnt, script, (function serverContract(), if("object"===typeof window.ytInitialPlayerResponse){window.ytInitialPlayerResponse=JSON.parse(JSON.stringify(window.ytInitialPlayerResponse));}(function serverContract(), sedCount, 1)


### PR DESCRIPTION
Re-adds JSON filters for YouTube autodubbing. This prevents autodubbed audio tracks from playing as the default option on a video and prevents the "Audio track" menu from appearing in the video settings if all alternate tracks are autodubbed. These filters were originally created by  Originally created by paintboth1234 (https://www.reddit.com/r/uBlockOrigin/comments/1npyxsc/comment/ng4kmje/)

This filter was previously removed due to a now-resolved issue in Brave https://github.com/brave/brave-core/pull/37658 that caused ads appear on YouTube when `json-edit` was used.

Addresses #24473