### PR TITLE
A: open.online

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -713,6 +713,7 @@ scalemates.com###prv
 spiking.com###prvcypop
 ftcguardian.com###prvcypop_4
 ablefy.io###ps-cookie-banner-wrapper
+open.online###qc-cmp2-container
 migrationobservatory.ox.ac.uk###rb_cookie_popup
 rcwilley.com###rcDrawer
 totalmerchandise.co.uk###react-cookie-consent


### PR DESCRIPTION
Hiding cookie notice on https://www.open.online/2026/06/30/bastoni-indagato-prostituzione-minorile-agenzia-escort-cinisello

Fix is in response to user reports on Brave