### PR TITLE
A: tu-darmstadt.de

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -78,6 +78,7 @@ app.taxfix.de###cookie-consent-banner-container
 spdyn.de###cookie-consent-dialog
 tec7.com###cookie-manager
 brandnooz.de###cookie-message
+tu-darmstadt.de###cookie-modal-window
 peax.ch###cookie-note-id
 shop.lashinbang.com,uni-regensburg.de###cookie-notice
 hyla-germany.de###cookie-overlay


### PR DESCRIPTION
Hiding cookie notice on https://tu-darmstadt.de

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2544