### PR TITLE
A: data.education.gouv.fr

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -817,6 +817,7 @@ direct-cuves.fr###coockies-modal-1
 onvasortir.com###infocookies
 etudiant.gouv.fr###tarteaucitronAlertBig
 capanimal.fr##.ch-cookie-consent
+data.education.gouv.fr##ods-manage-cookies-preferences-modal
 !
 ! ---------- Arabic ----------
 !


### PR DESCRIPTION
Hiding cookie notice on https://data.education.gouv.fr/pages/recherche-etablissement

Fix is in response to user reports on Brave