### PR TITLE
A: partspc.pl

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -2297,6 +2297,7 @@ lovekrakow.pl###new-policy
 cefarm24.pl,e-zikoapteka.pl,gwp.pl,paramedyk24.pl,tanie-leczenie.pl###notice_bar
 sii.org.pl###notifycookie
 a2mobile.pl###oreos-popup
+partspc.pl###partspc-google-consent
 bdb.com.pl###plansza
 krosnocity.pl###polcia
 omcar.pl###policy


### PR DESCRIPTION
Hiding cookie notice on https://partspc.pl

Fix is in response to user reports on Brave