### PR TITLE
A: bloomberg.com: Social - Add on Google

### DIFF
--- a/fanboy-addon/fanboy_social_specific_hide.txt
+++ b/fanboy-addon/fanboy_social_specific_hide.txt
@@ -1905,6 +1905,7 @@ arrow.apache.org##.nav-item:has(> [href="https://www.linkedin.com/company/apache
 microsoft.com##.section-master:has(.socialfollow)
 stackify.com##.widget:has(> .social-links)
 ms.now##.wp-block-group p:has(Share this)
+bloomberg.com##div:has(> [class*="PreferUs_preferUsTextButton__"])
 rule34.xxx##li:has(> [href="https://x.com/slayerduckie"])
 diamondv.jp##main[id] > div.MuiBox-root:has(> ul > li > button.react-share__ShareButton)
 !! :has-text


### PR DESCRIPTION
"Add us on Google" button. As seen on `https://www.bloomberg.com/news/newsletters/2026-09-04/how-double-fine-escaped-the-xbox-bloodbath`