### PR TITLE
A: usatoday.com ad/survey sidebar

### DIFF
--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1445,6 +1445,8 @@ youtube.com##.ytd-primetime-promo-renderer
 youtube.com##ytd-brand-video-singleton-renderer
 ! usatoday, close icon
 ##.gnt_ar_xb
+! usatoday, ad/survey sidebar
+usatoday.com##main .gnt_rr
 ! instgram.com hovercards
 instagram.com##.HoverCard
 ! medium.com blogs

--- a/fanboy-addon/fanboy_annoyance_specific_hide.txt
+++ b/fanboy-addon/fanboy_annoyance_specific_hide.txt
@@ -1444,7 +1444,7 @@ dhgate.com##.promo-pack-mask
 youtube.com##.ytd-primetime-promo-renderer
 youtube.com##ytd-brand-video-singleton-renderer
 ! usatoday, close icon
-##.gnt_ar_xb
+usatoday.com##.gnt_ar_xb
 ! usatoday, ad/survey sidebar
 usatoday.com##main .gnt_rr
 ! instgram.com hovercards


### PR DESCRIPTION
Two commits in this PR:

- **A: https://www.usatoday.com/story/news/nation/2026/09/07/court-constitution-right-clean-water/91649488007/**

	On [usatoday article pages](https://www.usatoday.com/story/news/nation/2026/09/07/court-constitution-right-clean-water/91649488007/) there is a sidebar which has ads (currently blocked) and a survey request:
	
	<img width="1477" height="1032" alt="Screenshot 2026-09-07 at 2 23 56 PM" src="https://github.com/user-attachments/assets/8876ee07-efaf-4d4a-afe9-69b8afbb533a" />
	
	This filter blocks that sidebar completely:
	
	<img width="1434" height="1015" alt="Screenshot 2026-09-07 at 2 24 30 PM" src="https://github.com/user-attachments/assets/0d7839ee-ff4f-4270-87c0-397c29719cc0" />

- **M: add url selector to usatoday close icon filter**
   Adjacent url selector in the `fanboy-addon/fanboy_annoyance_specific_hide.txt` file doesn't have a URL selector, making it run on all websites. This change adds one.
