### PR TITLE
R: sacdnssedge.com — video CDN false positive

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -32170,7 +32170,6 @@
 ||sacaesmootrendoun.cyou^
 ||sacbttgnxaklv.store^
 ||saccliyoungdiduce.cyou^
-||sacdnssedge.com^
 ||sachemfrenalanukit.cyou^
 ||sachemsifint.cfd^
 ||sachetsmicella.cyou^


### PR DESCRIPTION
This domain serves HLS video stream segments. Blocking it prevents video playback for end users. Not an ad server.