### PR TITLE
R: saawsedge.com — video CDN false positive

### DIFF
--- a/easylist/easylist_adservers.txt
+++ b/easylist/easylist_adservers.txt
@@ -32153,7 +32153,6 @@
 ||s99s.net^
 ||sa.entireweb.com^
 ||saatydsobhrtk.space^
-||saawsedge.com^
 ||sabaismuramido.cfd^
 ||sabaothbivvy.qpon^
 ||sabatonrhamn.qpon^


### PR DESCRIPTION
This domain serves HLS video stream segments. Blocking it prevents video playback for end users. Not an ad server.