### PR TITLE
P: https://www.qwant.com

### DIFF
--- a/easyprivacy/easyprivacy_allowlist.txt
+++ b/easyprivacy/easyprivacy_allowlist.txt
@@ -553,6 +553,7 @@
 @@||dd.blackhawknetwork.com.first-party-js.datadome.co^$domain=redeem.rewardlink.com
 @@||dd.jaycar.com.au.first-party-js.datadome.co^$script,third-party,domain=jaycar.com.au
 @@||dd.qa.moneygram.com.first-party-js.datadome.co^$script,xmlhttprequest,domain=moneygram.com
+@@||dd.qwant.com.first-party-js.datadome.co^$domain=qwant.com
 @@||dd.thetrainline.com.first-party-js.datadome.co^$domain=thetrainline.com
 @@||dd.wizzair.com.first-party-js.datadome.co^$domain=wizzair.com
 @@||dwt.soundcloud.com.first-party-js.datadome.co^$script,xmlhttprequest,domain=soundcloud.com


### PR DESCRIPTION
Search on `https://www.qwant.com/` returns HTTP 403: `dd.qwant.com`, Qwant's
DataDome anti-bot endpoint, is a CNAME, and removing the host rule in 8955f43b
did not stop it being blocked — the uncloaked request still matches the 2019
generic `||datadome.co^$third-party`. This PR adds the one exception that
reaches that match.

> **Note:** filing this as a PR rather than an issue, since #24651 and #24715
> are both closed and I would rather not reopen either.

#### The problem

This blocks the only function of the site. Search returns HTTP 403 and no
results are rendered at all, because the blocked request is DataDome's
challenge tag: it cannot load, so the challenge cannot be answered, so the
request is refused.

#### Steps to reproduce

1. Open Firefox with uBO, EasyPrivacy enabled
2. Go to `https://www.qwant.com/`.
3. Type a search term and press Enter.
4. A *"Qwant is temporarily unavailable"* message appears and no results are
   rendered. The uBO logger shows `dd.qwant.com` blocked by
   `||datadome.co^$third-party`.

<details>
<summary>Screenshot</summary>

<img width="806" height="512" alt="unavailable" src="https://github.com/user-attachments/assets/69f00209-be55-476c-a880-d2297ec01df7" />

</details>

